### PR TITLE
Install Chrome system deps for E2E UI tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -147,6 +147,15 @@ jobs:
         run: npm ci
         working-directory: web-ui
 
+      - name: Install Chrome system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yqq --no-install-recommends \
+            libnss3 libnspr4 libatk1.0-0t64 libatk-bridge2.0-0t64 \
+            libcups2t64 libdrm2 libxkbcommon0 libxcomposite1 \
+            libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 \
+            libcairo2 libasound2t64 libxshmfence1
+
       - name: Install Puppeteer Chrome
         run: npx puppeteer browsers install chrome
 


### PR DESCRIPTION
## Summary
- Install Chrome shared library dependencies (libnss3, libnspr4, etc.) before Puppeteer browser install
- Fixes `libnspr4.so: cannot open shared object file` error on ubuntu-latest

## Context
E2E API tests pass (26/26). UI tests failed because Chrome couldn't launch — missing system libraries.