### PR TITLE
Fix Chrome deps: direct shared lib install

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,16 +149,16 @@ jobs:
 
       - name: Install Chrome and system dependencies
         run: |
-          # Install all Chrome/Chromium system dependencies in one shot
+          # Install Chrome via Puppeteer
+          npx puppeteer browsers install chrome
+          # Install all required shared libraries for headless Chrome
           sudo apt-get update -qq
-          sudo apt-get install -yqq --no-install-recommends chromium-browser || \
           sudo apt-get install -yqq --no-install-recommends \
             libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
             libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 \
             libgbm1 libpango-1.0-0 libcairo2 libasound2 libxshmfence1 \
-            libxfixes3 libx11-xcb1 libxext6 libxi6 libxtst6 \
-            fonts-liberation xdg-utils
-          npx puppeteer browsers install chrome
+            libxfixes3 libx11-xcb1 libxext6 libxi6 libxtst6 libxcursor1 \
+            fonts-liberation
 
       - name: Run E2E API tests
         env:


### PR DESCRIPTION
Skip chromium-browser snap stub, install shared libraries directly including libxfixes3.