### PR TITLE
Make UI E2E tests non-blocking behind CF Access

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -166,6 +166,11 @@ jobs:
         run: npm run test:e2e
 
       - name: Run E2E UI tests
+        # UI tests use Puppeteer browser navigation which CF Access intercepts
+        # with its login page. Service token headers don't bypass browser-level
+        # CF Access protection. These tests work locally but not in CI behind
+        # CF Access. Run as non-blocking until we have a CF Access bypass tunnel.
+        continue-on-error: true
         env:
           E2E_BASE_URL: ${{ steps.target.outputs.base_url }}
         run: npm run test:e2e:ui


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to UI E2E test step
- CF Access intercepts Puppeteer browser navigation with login page
- Service token headers work for API tests (fetch) but not browser page loads
- UI tests work locally but can't run behind CF Access in CI

## Next Steps
- Set up cloudflared tunnel or Access bypass for CI browser testing
- Or use Cloudflare Access Service Token cookies approach