### PR TITLE
Fix scorecard: use ubuntu-latest directly

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scorecard:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       security-events: write


### PR DESCRIPTION
## Summary
- Scorecard webapp rejects results when `runs-on` uses dynamic expressions
- Change to literal `ubuntu-latest` as required by OSSF

## Test plan
- [x] Scorecard workflow runs successfully and publishes results