### PR TITLE
Normalize target URLs to https:// in pentest and stress test workflows

### DIFF
--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -12,15 +12,21 @@ concurrency:
   group: pentest
   cancel-in-progress: true
 
+env:
+  _RAW_TARGET: ${{ vars.PENTEST_TARGET }}
+
 jobs:
   security-headers:
     name: Security headers
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
-    env:
-      TARGET: ${{ vars.PENTEST_TARGET }}
     steps:
+      - name: Normalize target URL
+        run: |
+          T="${_RAW_TARGET#http://}" && T="https://${T#https://}"
+          echo "TARGET=$T" >> "$GITHUB_ENV"
+          echo "Target: $T"
       - name: Check required security headers
         run: |
           headers=$(curl -s -I "$TARGET/" 2>&1)
@@ -59,9 +65,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
-    env:
-      TARGET: ${{ vars.PENTEST_TARGET }}
     steps:
+      - name: Normalize target URL
+        run: |
+          T="${_RAW_TARGET#http://}" && T="https://${T#https://}"
+          echo "TARGET=$T" >> "$GITHUB_ENV"
+          echo "Target: $T"
       - name: Verify TLS 1.3 and reject old protocols
         run: |
           failed=0
@@ -126,9 +135,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
-    env:
-      TARGET: ${{ vars.PENTEST_TARGET }}
     steps:
+      - name: Normalize target URL
+        run: |
+          T="${_RAW_TARGET#http://}" && T="https://${T#https://}"
+          echo "TARGET=$T" >> "$GITHUB_ENV"
+          echo "Target: $T"
       - name: Verify API endpoints require authentication
         run: |
           failed=0
@@ -177,9 +189,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
-    env:
-      TARGET: ${{ vars.PENTEST_TARGET }}
     steps:
+      - name: Normalize target URL
+        run: |
+          T="${_RAW_TARGET#http://}" && T="https://${T#https://}"
+          echo "TARGET=$T" >> "$GITHUB_ENV"
+          echo "Target: $T"
       - name: Check for sensitive file exposure
         run: |
           failed=0
@@ -216,9 +231,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
-    env:
-      TARGET: ${{ vars.PENTEST_TARGET }}
     steps:
+      - name: Normalize target URL
+        run: |
+          T="${_RAW_TARGET#http://}" && T="https://${T#https://}"
+          echo "TARGET=$T" >> "$GITHUB_ENV"
+          echo "Target: $T"
       - name: Host header injection
         run: |
           failed=0
@@ -278,9 +296,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
-    env:
-      TARGET: ${{ vars.PENTEST_TARGET }}
     steps:
+      - name: Normalize target URL
+        run: |
+          T="${_RAW_TARGET#http://}" && T="https://${T#https://}"
+          echo "TARGET=$T" >> "$GITHUB_ENV"
+          echo "Target: $T"
       - name: Verify TRACE is disabled
         run: |
           code=$(curl -s -o /dev/null -w "%{http_code}" -X TRACE "$TARGET/")

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Resolve target and smoke test
         id: target
         run: |
-          BASE="${{ vars.E2E_BASE_URL }}"
+          RAW="${{ vars.E2E_BASE_URL }}"
+          RAW="${RAW#http://}" && BASE="https://${RAW#https://}"
           echo "base_url=$BASE" >> "$GITHUB_OUTPUT"
           echo "Target: $BASE"
 


### PR DESCRIPTION
## Summary
- Pentest and stress test workflows fail when environment variables (`PENTEST_TARGET`, `E2E_BASE_URL`) don't include the `https://` scheme
- Adds URL normalization step to each job that strips any existing scheme and prepends `https://`
- Fixes auth gate returning 301 (HTTP redirect) instead of expected 302/401/403
- Fixes TLS checks failing because curl defaulted to HTTP

## Test plan
- [ ] CI passes
- [ ] Manually trigger pentest workflow and verify all jobs pass
- [ ] Manually trigger stress test workflow and verify setup job resolves target