### PR TITLE
fix: security and correctness fixes from codebase review

### DIFF
--- a/src/lib/access-policy.ts
+++ b/src/lib/access-policy.ts
@@ -75,6 +75,7 @@ export async function syncAccessPolicy(
     const groupsRes = await cfApiCB.execute(() =>
       fetch(`${CF_API_BASE}/accounts/${accountId}/access/groups`, {
         headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(10_000),
       })
     );
     const groupsData = await groupsRes.json() as CfAccessGroupsResponse;
@@ -96,6 +97,7 @@ export async function syncAccessPolicy(
               name: groupName,
               include: groupUsers.map((email) => ({ email: { email } })),
             }),
+            signal: AbortSignal.timeout(10_000),
           })
         );
 
@@ -133,6 +135,7 @@ export async function syncAccessPolicy(
   const appsRes = await cfApiCB.execute(() =>
     fetch(`${CF_API_BASE}/accounts/${accountId}/access/apps`, {
       headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(10_000),
     })
   );
   const appsData = await appsRes.json() as CfAccessAppsResponse;
@@ -152,7 +155,7 @@ export async function syncAccessPolicy(
     const policiesRes = await cfApiCB.execute(() =>
       fetch(
         `${CF_API_BASE}/accounts/${accountId}/access/apps/${app.id}/policies`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(10_000) }
       )
     );
     const policiesData = await policiesRes.json() as CfAccessPoliciesResponse;
@@ -180,6 +183,7 @@ export async function syncAccessPolicy(
             include,
             exclude: policy.exclude || [],
           }),
+          signal: AbortSignal.timeout(10_000),
         }
       )
     );

--- a/src/lib/user-cleanup.ts
+++ b/src/lib/user-cleanup.ts
@@ -7,7 +7,7 @@
  */
 import type { Env, Session } from '../types';
 import { getBucketName } from './access';
-import { getSessionPrefix, listAllKvKeys, getPresetsKey, getPreferencesKey } from './kv-keys';
+import { getSessionPrefix, listAllKvKeys, getPresetsKey, getPreferencesKey, getLlmKeysKey } from './kv-keys';
 import { getContainerId } from './container-helpers';
 import { getContainer } from '@cloudflare/containers';
 import { createR2Client, emptyR2Bucket } from './r2-client';
@@ -67,6 +67,7 @@ export async function cleanupUserData(email: string, env: Env): Promise<CleanupR
     env.KV.delete(`storage-stats:${bucketName}`),
     env.KV.delete(getPresetsKey(bucketName)),
     env.KV.delete(getPreferencesKey(bucketName)),
+    env.KV.delete(getLlmKeysKey(bucketName)),
   ]);
 
   // --- Read R2 token data ONCE before cleanup (used by Block C and D) ---

--- a/src/routes/setup/access.ts
+++ b/src/routes/setup/access.ts
@@ -129,6 +129,13 @@ async function listAccessApps(token: string, accountId: string): Promise<AccessA
   return data.result;
 }
 
+function isAlreadyExistsError(errors: Array<{ message?: string }> | undefined): boolean {
+  return errors?.some((e) =>
+    e.message?.toLowerCase().includes('already exists')
+    || e.message?.toLowerCase().includes('duplicate')
+  ) ?? false;
+}
+
 async function upsertAccessApp(
   token: string,
   accountId: string,
@@ -165,11 +172,7 @@ async function upsertAccessApp(
 
   const data = await parseCfResponse<AccessAppResult>(response);
   if (!data.success || !data.result?.id) {
-    const alreadyExistsError = data.errors?.some((e) =>
-      e.message?.toLowerCase().includes('already exists')
-      || e.message?.toLowerCase().includes('duplicate')
-    );
-    if (alreadyExistsError && !existingAppId) {
+    if (isAlreadyExistsError(data.errors) && !existingAppId) {
       logger.warn('Access app already exists but was not found in initial lookup, retrying list', { appDomain });
       const retriedApps = await listAccessApps(token, accountId);
       const existingByDomain = retriedApps.find((app) => app.domain === appDomain);
@@ -208,13 +211,6 @@ async function listAccessGroups(token: string, accountId: string): Promise<Acces
     throw new Error(`Failed to list Access groups: ${data.errors?.map(e => e.message).join(', ') ?? 'unknown'}`);
   }
   return data.result;
-}
-
-function isAlreadyExistsError(errors: Array<{ message?: string }> | undefined): boolean {
-  return errors?.some((e) =>
-    e.message?.toLowerCase().includes('already exists')
-    || e.message?.toLowerCase().includes('duplicate')
-  ) ?? false;
 }
 
 async function upsertAccessGroup(

--- a/src/routes/setup/index.ts
+++ b/src/routes/setup/index.ts
@@ -140,8 +140,12 @@ app.post('/configure', async (c) => {
         handleSetSecrets(token, accountId, r2AccessKeyId, r2SecretAccessKey, c.req.url, steps, workerName)
       );
 
+      // Normalize and deduplicate emails before any KV operations
+      const normalizedAllowed = [...new Set(allowedUsers.map(e => e.trim().toLowerCase()))];
+      const normalizedAdmins = [...new Set(adminUsers.map(e => e.trim().toLowerCase()))];
+
       // Remove stale users not in the new allowedUsers list (full cleanup)
-      const allowedSet = new Set(allowedUsers);
+      const allowedSet = new Set(normalizedAllowed);
       const existingUserKeys = await listAllKvKeys(c.env.KV, 'user:');
       const staleEmails = existingUserKeys
         .filter(key => !allowedSet.has(emailFromKvKey(key.name)))
@@ -157,8 +161,8 @@ app.post('/configure', async (c) => {
       }
 
       // Store users in KV with role
-      const adminSet = new Set(adminUsers);
-      const userWrites = allowedUsers.map(email => {
+      const adminSet = new Set(normalizedAdmins);
+      const userWrites = normalizedAllowed.map(email => {
         const role = adminSet.has(email) ? 'admin' : 'user';
         return c.env.KV.put(
           `user:${email}`,


### PR DESCRIPTION
## Summary
- **CF-001** (CRITICAL): Delete orphaned LLM API keys (`llm-keys:{bucket}`) during user cleanup — previously leaked on user deletion
- **CF-010** (HIGH): Normalize and deduplicate emails at setup before constructing KV keys — prevents case-mismatch with `resolveUserFromKV` lookups
- **CF-015** (HIGH): Add `AbortSignal.timeout(10s)` to all 5 CF API fetch calls in `access-policy.ts` — prevents indefinite hangs on CF API outage
- **CF-027** (HIGH): Replace inline duplicate of `isAlreadyExistsError()` with the extracted helper in `setup/access.ts`

## Test plan
- [ ] CI passes (existing tests cover auth and setup flows)
- [ ] Verify user deletion cleans up LLM keys KV entry
- [ ] Verify mixed-case emails in setup resolve correctly
- [ ] Verify Access policy sync times out after 10s on CF API failure