### PR TITLE
refactor: migrate host/ from JavaScript to TypeScript (CF-018)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -46,8 +46,8 @@ jobs:
           FAST_CHECK_NUM_RUNS: '50000'
         run: cd web-ui && npx vitest run src/__tests__/fuzz/ --reporter=verbose
 
-      - name: Install host dependencies
-        run: cd host && npm ci
+      - name: Install host dependencies and build
+        run: cd host && npm ci && npm run build
 
       - name: Run host fuzz tests
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
 # Codeflare Container - Multi-session terminal server with rclone sync
 # Uses node-pty for PTY management and rclone for R2 storage sync
 
-# ---- Stage 1: Builder (compile native addons) ----
+# ---- Stage 1: Builder (compile native addons + TypeScript) ----
 FROM node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends make gcc g++ python3 && rm -rf /var/lib/apt/lists/*
 
 COPY host/package.json host/package-lock.json /app/host/
 WORKDIR /app/host
-RUN npm ci --omit=dev
+# Install all deps (including devDependencies for TypeScript compilation)
+RUN npm ci
+# Copy TypeScript source and config, then compile
+COPY host/tsconfig.json /app/host/
+COPY host/src/ /app/host/src/
+RUN npm run build
+# Remove devDependencies after build to keep runtime image lean
+RUN npm prune --omit=dev
 
 # ---- Stage 2: Runtime ----
 FROM node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb
@@ -185,8 +192,8 @@ RUN mkdir -p /app/host
 
 # Copy pre-compiled host server from builder stage
 COPY --from=builder /app/host/node_modules /app/host/node_modules
+COPY --from=builder /app/host/dist /app/host/dist
 COPY host/package.json /app/host/
-COPY host/*.js /app/host/
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -965,7 +965,7 @@ fi
 # ============================================================================
 
 echo "[entrypoint] Starting terminal server on port 8080..."
-cd /app/host && HOME="$USER_HOME" TERMINAL_PORT=8080 node server.js &
+cd /app/host && HOME="$USER_HOME" TERMINAL_PORT=8080 node dist/server.js &
 TERMINAL_PID=$!
 echo "$TERMINAL_PID" > /tmp/terminal.pid
 echo "[entrypoint] Terminal server started with PID $TERMINAL_PID"

--- a/host/__tests__/activity-tracker.test.js
+++ b/host/__tests__/activity-tracker.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { createActivityTracker } from '../activity-tracker.js';
+import { createActivityTracker } from '../dist/activity-tracker.js';
 
 describe('activity-tracker', () => {
   let tracker;

--- a/host/__tests__/fuzz-host.test.js
+++ b/host/__tests__/fuzz-host.test.js
@@ -2,8 +2,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fc from 'fast-check';
 
-import { getPrewarmConfig } from '../prewarm-config.js';
-import { createActivityTracker } from '../activity-tracker.js';
+import { getPrewarmConfig } from '../dist/prewarm-config.js';
+import { createActivityTracker } from '../dist/activity-tracker.js';
 
 const NUM_RUNS = parseInt(process.env.FAST_CHECK_NUM_RUNS || '1000', 10);
 

--- a/host/__tests__/host-fixes.test.js
+++ b/host/__tests__/host-fixes.test.js
@@ -5,15 +5,18 @@ import fs from 'fs';
 import path from 'path';
 
 const HOST_DIR = path.resolve(import.meta.dirname, '..');
+const SRC_DIR = path.join(HOST_DIR, 'src');
 
 /**
  * Tests for FIX-26 (DF3): safeTokenCompare SHA-256 hash comparison
  * and FIX-20 (DC1): isAlive dead code removal.
+ *
+ * Source inspection reads .ts files from src/.
  */
 
 describe('FIX-26: safeTokenCompare uses SHA-256 hash comparison', () => {
-  // Extract safeTokenCompare from server.js source for functional testing
-  // Since server.js has side effects (http.createServer), we test the function
+  // Extract safeTokenCompare from server.ts source for functional testing
+  // Since server.ts has side effects (http.createServer), we test the function
   // by extracting its logic and verifying the source pattern.
 
   // Helper that mirrors the expected implementation
@@ -38,8 +41,8 @@ describe('FIX-26: safeTokenCompare uses SHA-256 hash comparison', () => {
     assert.equal(safeTokenCompare('x', 'xy'), false);
   });
 
-  it('server.js uses SHA-256 hash in safeTokenCompare (no length pre-check)', () => {
-    const serverSrc = fs.readFileSync(path.join(HOST_DIR, 'server.js'), 'utf8');
+  it('server.ts uses SHA-256 hash in safeTokenCompare (no length pre-check)', () => {
+    const serverSrc = fs.readFileSync(path.join(SRC_DIR, 'server.ts'), 'utf8');
 
     // Must use createHash('sha256') for constant-time length normalization
     assert.ok(
@@ -73,22 +76,22 @@ describe('FIX-26: safeTokenCompare uses SHA-256 hash comparison', () => {
 
 describe('FIX-20: isAlive dead code removal', () => {
   it('Session class does not have isAlive method', () => {
-    const sessionSrc = fs.readFileSync(path.join(HOST_DIR, 'session.js'), 'utf8');
+    const sessionSrc = fs.readFileSync(path.join(SRC_DIR, 'session.ts'), 'utf8');
 
     // isAlive() was dead code — never called anywhere. It should be removed.
     assert.ok(
       !sessionSrc.includes('isAlive('),
-      'session.js must not contain isAlive method (dead code)'
+      'session.ts must not contain isAlive method (dead code)'
     );
   });
 
   it('Session class still has isPtyAlive method (not dead code)', () => {
-    const sessionSrc = fs.readFileSync(path.join(HOST_DIR, 'session.js'), 'utf8');
+    const sessionSrc = fs.readFileSync(path.join(SRC_DIR, 'session.ts'), 'utf8');
 
-    // isPtyAlive() IS used in server.js — must remain
+    // isPtyAlive() IS used in server.ts — must remain
     assert.ok(
       sessionSrc.includes('isPtyAlive('),
-      'session.js must still have isPtyAlive method'
+      'session.ts must still have isPtyAlive method'
     );
   });
 });

--- a/host/__tests__/prewarm-readiness.test.js
+++ b/host/__tests__/prewarm-readiness.test.js
@@ -9,7 +9,7 @@ import assert from 'node:assert/strict';
  * command from TAB_CONFIG for logging purposes.
  */
 
-import { getPrewarmConfig } from '../prewarm-config.js';
+import { getPrewarmConfig } from '../dist/prewarm-config.js';
 
 describe('getPrewarmConfig', () => {
   describe('when TAB_CONFIG is absent or empty', () => {

--- a/host/__tests__/server-prewarm.test.js
+++ b/host/__tests__/server-prewarm.test.js
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
  * the command name from TAB_CONFIG for logging — no patterns or quiescence.
  */
 
-import { getPrewarmConfig } from '../prewarm-config.js';
+import { getPrewarmConfig } from '../dist/prewarm-config.js';
 
 describe('getPrewarmConfig (server integration)', () => {
   it('returns command: null when tabConfig is undefined', () => {

--- a/host/__tests__/server-security.test.js
+++ b/host/__tests__/server-security.test.js
@@ -4,19 +4,22 @@ import fs from 'fs';
 import path from 'path';
 
 const HOST_DIR = path.resolve(import.meta.dirname, '..');
+const SRC_DIR = path.join(HOST_DIR, 'src');
 
 /**
  * Security-focused tests for the host terminal server.
  * These verify security hardening by inspecting source code text
  * and checking module structure after the M6 extraction.
+ *
+ * Source inspection reads .ts files from src/; dynamic imports use dist/.
  */
 
 describe('Security hardening', () => {
   // L16: PREWARM_SESSION_ID constant
   it('defines PREWARM_SESSION_ID constant and uses it consistently', () => {
-    // After extraction, session-manager.js should define the constant
-    const sessionManagerSrc = fs.readFileSync(path.join(HOST_DIR, 'session-manager.js'), 'utf8');
-    const serverSrc = fs.readFileSync(path.join(HOST_DIR, 'server.js'), 'utf8');
+    // After extraction, session-manager.ts should define the constant
+    const sessionManagerSrc = fs.readFileSync(path.join(SRC_DIR, 'session-manager.ts'), 'utf8');
+    const serverSrc = fs.readFileSync(path.join(SRC_DIR, 'server.ts'), 'utf8');
 
     // The constant must be defined somewhere
     const allSrc = sessionManagerSrc + serverSrc;
@@ -26,35 +29,35 @@ describe('Security hardening', () => {
     );
 
     // No raw 'prewarm-1' string literals should remain (except in the constant definition itself)
-    // Check server.js for raw literals
+    // Check server.ts for raw literals
     const serverLines = serverSrc.split('\n');
     const rawLiterals = serverLines.filter(line =>
       line.includes("'prewarm-1'") && !line.includes('PREWARM_SESSION_ID')
     );
     assert.equal(
       rawLiterals.length, 0,
-      `server.js should not have raw 'prewarm-1' literals, found: ${rawLiterals.join('\n')}`
+      `server.ts should not have raw 'prewarm-1' literals, found: ${rawLiterals.join('\n')}`
     );
 
-    // Check session-manager.js for raw literals (excluding the definition line)
+    // Check session-manager.ts for raw literals (excluding the definition line)
     const smLines = sessionManagerSrc.split('\n');
     const smRawLiterals = smLines.filter(line =>
       line.includes("'prewarm-1'") && !line.includes('PREWARM_SESSION_ID') && !line.includes('const PREWARM_SESSION_ID')
     );
     assert.equal(
       smRawLiterals.length, 0,
-      `session-manager.js should not have raw 'prewarm-1' literals (except definition), found: ${smRawLiterals.join('\n')}`
+      `session-manager.ts should not have raw 'prewarm-1' literals (except definition), found: ${smRawLiterals.join('\n')}`
     );
   });
 
   // L17: CONTAINER_AUTH_TOKEN missing = 503
   it('returns 503 when CONTAINER_AUTH_TOKEN is not set', () => {
-    const serverSrc = fs.readFileSync(path.join(HOST_DIR, 'server.js'), 'utf8');
+    const serverSrc = fs.readFileSync(path.join(SRC_DIR, 'server.ts'), 'utf8');
 
     // The auth check must return 503 (not skip auth) when token is unset
     assert.ok(
       serverSrc.includes('503'),
-      'server.js must return 503 when CONTAINER_AUTH_TOKEN is not set'
+      'server.ts must return 503 when CONTAINER_AUTH_TOKEN is not set'
     );
 
     // Verify the pattern: check for the 503 status code in auth context
@@ -68,23 +71,23 @@ describe('Security hardening', () => {
 
   // L18: Timing-safe comparison for auth token
   it('uses timing-safe comparison for auth token', () => {
-    const serverSrc = fs.readFileSync(path.join(HOST_DIR, 'server.js'), 'utf8');
+    const serverSrc = fs.readFileSync(path.join(SRC_DIR, 'server.ts'), 'utf8');
 
     assert.ok(
       serverSrc.includes('timingSafeEqual'),
-      'server.js must use crypto.timingSafeEqual for token comparison'
+      'server.ts must use crypto.timingSafeEqual for token comparison'
     );
 
     // Verify crypto is imported
     assert.ok(
       serverSrc.includes("from 'crypto'") || serverSrc.includes("require('crypto')") || serverSrc.includes("from 'node:crypto'"),
-      'server.js must import crypto module'
+      'server.ts must import crypto module'
     );
   });
 
   // M2: Shutdown handler kills all active sessions
   it('shutdown handler kills all active sessions before exit', () => {
-    const serverSrc = fs.readFileSync(path.join(HOST_DIR, 'server.js'), 'utf8');
+    const serverSrc = fs.readFileSync(path.join(SRC_DIR, 'server.ts'), 'utf8');
 
     // SIGTERM handler must iterate sessions and kill them
     // Look for session killing in shutdown context
@@ -107,18 +110,18 @@ describe('Security hardening', () => {
 });
 
 describe('Module extraction (M6)', () => {
-  it('metrics.js exists and exports expected functions', async () => {
-    const metrics = await import('../metrics.js');
+  it('metrics module exists and exports expected functions', async () => {
+    const metrics = await import('../dist/metrics.js');
     assert.ok(typeof metrics.getSyncStatus === 'function', 'getSyncStatus must be exported');
     assert.ok(typeof metrics.getDiskMetrics === 'function', 'getDiskMetrics must be exported');
     assert.ok(typeof metrics.getSystemMetrics === 'function', 'getSystemMetrics must be exported');
   });
 
-  // session.js and session-manager.js import node-pty (native module, only available inside
+  // session.ts and session-manager.ts import node-pty (native module, only available inside
   // the Docker container), so we verify their structure via source text inspection instead.
-  it('session.js exists and exports Session class', () => {
-    const src = fs.readFileSync(path.join(HOST_DIR, 'session.js'), 'utf8');
-    assert.ok(src.includes('export class Session'), 'session.js must export Session class');
+  it('session.ts exists and exports Session class', () => {
+    const src = fs.readFileSync(path.join(SRC_DIR, 'session.ts'), 'utf8');
+    assert.ok(src.includes('export class Session'), 'session.ts must export Session class');
     assert.ok(src.includes('start('), 'Session must have start method');
     assert.ok(src.includes('attach('), 'Session must have attach method');
     assert.ok(src.includes('detach('), 'Session must have detach method');
@@ -126,12 +129,12 @@ describe('Module extraction (M6)', () => {
     assert.ok(src.includes('toJSON('), 'Session must have toJSON method');
   });
 
-  it('session-manager.js exists and exports SessionManager class', () => {
-    const src = fs.readFileSync(path.join(HOST_DIR, 'session-manager.js'), 'utf8');
-    assert.ok(src.includes('export class SessionManager'), 'session-manager.js must export SessionManager class');
+  it('session-manager.ts exists and exports SessionManager class', () => {
+    const src = fs.readFileSync(path.join(SRC_DIR, 'session-manager.ts'), 'utf8');
+    assert.ok(src.includes('export class SessionManager'), 'session-manager.ts must export SessionManager class');
     assert.ok(src.includes('PREWARM_SESSION_ID'), 'must export PREWARM_SESSION_ID');
     assert.ok(src.includes('getOrCreate('), 'SessionManager must have getOrCreate method');
     assert.ok(src.includes('killAll('), 'SessionManager must have killAll method');
-    assert.ok(src.includes("import { Session }"), 'session-manager.js must import Session');
+    assert.ok(src.includes("import { Session }"), 'session-manager.ts must import Session');
   });
 });

--- a/host/knip.json
+++ b/host/knip.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "project": ["*.js"]
+  "project": ["src/**/*.ts"]
 }

--- a/host/package.json
+++ b/host/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "description": "Terminal server for codeflare container",
-  "main": "server.js",
+  "main": "dist/server.js",
   "scripts": {
-    "start": "node server.js",
+    "build": "tsc",
+    "start": "node dist/server.js",
     "test": "node --test __tests__/*.test.js"
   },
   "dependencies": {
@@ -16,6 +17,9 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "fast-check": "^4.5.3"
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
+    "fast-check": "^4.5.3",
+    "typescript": "^5.7.0"
   }
 }

--- a/host/src/activity-tracker.ts
+++ b/host/src/activity-tracker.ts
@@ -1,19 +1,28 @@
-function createActivityTracker() {
-  const tracker = {
+/**
+ * Activity tracker for smart hibernation.
+ *
+ * Tracks WebSocket client connection/disconnection events to determine
+ * container idle time for hibernation decisions.
+ */
+
+import type { ActivityTracker, ActivityInfo, ActivitySessionManager } from './types.js';
+
+export function createActivityTracker(): ActivityTracker {
+  const tracker: ActivityTracker = {
     // Initialize to Date.now() so fresh containers auto-expire after 30min if nobody connects
     lastAllDisconnectedAt: Date.now(),
 
     // Called on every WS attach (idempotent — just clears the disconnect timer)
-    recordClientConnected() {
+    recordClientConnected(): void {
       tracker.lastAllDisconnectedAt = null;
     },
 
     // Called when the GLOBAL client count drops to 0
-    recordAllClientsDisconnected() {
+    recordAllClientsDisconnected(): void {
       tracker.lastAllDisconnectedAt = Date.now();
     },
 
-    getActivityInfo(sessionManager) {
+    getActivityInfo(sessionManager: ActivitySessionManager | null | undefined): ActivityInfo {
       const connectedClients = sessionManager ? sessionManager.clients.size : 0;
       const hasActiveConnections = connectedClients > 0;
       const sessions = sessionManager?.sessions
@@ -22,7 +31,7 @@ function createActivityTracker() {
       const activeSessions = sessions.filter(s => s.ptyProcess != null).length;
 
       // Duration since last disconnection (null if currently connected)
-      let disconnectedForMs = null;
+      let disconnectedForMs: number | null = null;
       if (!hasActiveConnections && tracker.lastAllDisconnectedAt !== null) {
         disconnectedForMs = Date.now() - tracker.lastAllDisconnectedAt;
       }
@@ -37,5 +46,3 @@ function createActivityTracker() {
   };
   return tracker;
 }
-
-export { createActivityTracker };

--- a/host/src/metrics.ts
+++ b/host/src/metrics.ts
@@ -5,36 +5,35 @@
  * for the /health endpoint.
  */
 
-import fs from 'fs';
-import os from 'os';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
+import fs from 'node:fs';
+import os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { Logger, SyncStatus, SystemMetrics, CachedDiskMetrics } from './types.js';
 
 const execFileAsync = promisify(execFile);
 
 /**
  * Read sync status from the file written by the rclone daemon.
- * @returns {{ status: string, error: string|null, userPath: string|null }}
  */
-export function getSyncStatus() {
+export function getSyncStatus(): SyncStatus {
   try {
     const data = fs.readFileSync('/tmp/sync-status.json', 'utf8');
-    return JSON.parse(data);
-  } catch (e) {
+    return JSON.parse(data) as SyncStatus;
+  } catch {
     return { status: 'pending', error: null, userPath: null };
   }
 }
 
 // Cached disk metrics to avoid shelling out on every health check
-let cachedDiskMetrics = { value: '...', lastUpdated: 0 };
+let cachedDiskMetrics: CachedDiskMetrics = { value: '...', lastUpdated: 0 };
 const DISK_CACHE_TTL = 30000; // 30 seconds
 
 /**
  * Get disk usage for /home/user (cached for 30s).
- * @param {function} log - Structured logger
- * @returns {Promise<string>}
  */
-export async function getDiskMetrics(log) {
+export async function getDiskMetrics(log: Logger): Promise<string> {
   if (Date.now() - cachedDiskMetrics.lastUpdated < DISK_CACHE_TTL) {
     return cachedDiskMetrics.value;
   }
@@ -45,22 +44,26 @@ export async function getDiskMetrics(log) {
       const fields = lines[1].split(/\s+/);
       cachedDiskMetrics = { value: `${fields[2]}/${fields[1]}`, lastUpdated: Date.now() };
     }
-  } catch (e) { log('debug', 'Disk metrics fetch failed', { error: e.message }); }
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    log('debug', 'Disk metrics fetch failed', { error: message });
+  }
   return cachedDiskMetrics.value;
 }
 
 /**
  * Get system metrics: CPU load, memory usage, and disk usage.
- * @param {function} log - Structured logger
- * @returns {Promise<{ cpu: string, mem: string, hdd: string }>}
  */
-export async function getSystemMetrics(log) {
+export async function getSystemMetrics(log: Logger): Promise<SystemMetrics> {
   const metrics = { cpu: '...', mem: '...', hdd: '...' };
   try {
     const loadAvg = os.loadavg()[0];
     const cpus = os.cpus().length;
     metrics.cpu = ((loadAvg / cpus) * 100).toFixed(0) + '%';
-  } catch (e) { log('debug', 'CPU metrics fetch failed', { error: e.message }); }
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    log('debug', 'CPU metrics fetch failed', { error: message });
+  }
   try {
     const totalMem = os.totalmem();
     const freeMem = os.freemem();
@@ -68,7 +71,10 @@ export async function getSystemMetrics(log) {
     const usedGB = (usedMem / 1024 / 1024 / 1024).toFixed(1);
     const totalGB = (totalMem / 1024 / 1024 / 1024).toFixed(1);
     metrics.mem = usedGB + '/' + totalGB + 'G';
-  } catch (e) { log('debug', 'Memory metrics fetch failed', { error: e.message }); }
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    log('debug', 'Memory metrics fetch failed', { error: message });
+  }
   metrics.hdd = await getDiskMetrics(log);
   return metrics;
 }

--- a/host/src/prewarm-config.ts
+++ b/host/src/prewarm-config.ts
@@ -4,21 +4,20 @@
  * Readiness is detected by first PTY output — as soon as the agent produces
  * any terminal output, the pre-warm is considered ready. This works reliably
  * regardless of whether the agent is logged in, needs auth, or shows update
- * prompts. The 20s hard timeout in server.js is the safety net.
+ * prompts. The 20s hard timeout in server.ts is the safety net.
  *
  * Previously, agent-specific regex patterns were used to detect readiness
  * (e.g., /╭/ for Claude Unleashed, /Ask anything/ for OpenCode). This failed
  * when agents weren't logged in, as the startup output was completely different.
  */
 
+import type { TabConfigEntry, PrewarmConfig } from './types.js';
+
 /**
  * Given a parsed TAB_CONFIG array, return readiness parameters for the
  * pre-warm PTY (which always spawns tab 1).
- *
- * @param {Array<{id: string, command: string, label: string}>|undefined} tabConfig
- * @returns {{ command: string|null }}
  */
-export function getPrewarmConfig(tabConfig) {
+export function getPrewarmConfig(tabConfig: TabConfigEntry[] | undefined | null): PrewarmConfig {
   if (!tabConfig || !Array.isArray(tabConfig) || tabConfig.length === 0) {
     return { command: null };
   }

--- a/host/src/server.ts
+++ b/host/src/server.ts
@@ -15,21 +15,22 @@
  * - GET  /sync-log            - rclone sync log
  */
 
-import http from 'http';
+import http from 'node:http';
 import { WebSocketServer, WebSocket } from 'ws';
-import { parse as parseUrl } from 'url';
-import fs from 'fs';
-import crypto from 'crypto';
+import { parse as parseUrl } from 'node:url';
+import fs from 'node:fs';
+import crypto from 'node:crypto';
 import { createActivityTracker } from './activity-tracker.js';
 import { getPrewarmConfig } from './prewarm-config.js';
 import { getSyncStatus, getSystemMetrics } from './metrics.js';
 import { Session } from './session.js';
 import { SessionManager, PREWARM_SESSION_ID } from './session-manager.js';
+import type { LogLevel, Logger, WsEventLogger, WsEvent, TabConfigEntry } from './types.js';
 
 const WS_KEEPALIVE_PING_MS = 30000;
 
 // Structured logger — replaces raw console.log/console.error calls
-function log(level, msg, meta) {
+const log: Logger = (level: LogLevel, msg: string, meta?: Record<string, unknown>): void => {
   const entry = `[${level.toUpperCase()}] ${msg}`;
   if (meta) {
     const metaStr = JSON.stringify(meta);
@@ -45,21 +46,21 @@ function log(level, msg, meta) {
       console.log(entry);
     }
   }
-}
+};
 
 // Start time for uptime calculation
 const SERVER_START_TIME = Date.now();
 
-const PORT = process.env.TERMINAL_PORT || 8080;
+const PORT = process.env.TERMINAL_PORT ?? '8080';
 // Spawn a login shell so .bashrc runs and auto-starts the configured agent
 // The .bashrc has agent auto-start logic that only works in interactive login shells
-const TERMINAL_COMMAND = process.env.TERMINAL_COMMAND || '/bin/bash';
-const TERMINAL_ARGS = process.env.TERMINAL_ARGS || '-l';  // Login shell flag
-const WORKSPACE_DEFAULT = process.env.WORKSPACE || '/home/user/workspace';
+const TERMINAL_COMMAND = process.env.TERMINAL_COMMAND ?? '/bin/bash';
+const TERMINAL_ARGS = process.env.TERMINAL_ARGS ?? '-l';  // Login shell flag
+const WORKSPACE_DEFAULT = process.env.WORKSPACE ?? '/home/user/workspace';
 
 // PTY persistence settings
-const PTY_KEEPALIVE_MS = parseInt(process.env.PTY_KEEPALIVE_MS || '2700000', 10); // 45 minutes
-const PTY_CLEANUP_INTERVAL_MS = parseInt(process.env.PTY_CLEANUP_INTERVAL_MS || '60000', 10); // Check every minute
+const PTY_KEEPALIVE_MS = parseInt(process.env.PTY_KEEPALIVE_MS ?? '2700000', 10); // 45 minutes
+const PTY_CLEANUP_INTERVAL_MS = parseInt(process.env.PTY_CLEANUP_INTERVAL_MS ?? '60000', 10); // Check every minute
 
 // Named constants for magic numbers
 const WS_MAX_PAYLOAD = 64 * 1024;        // 64KB WebSocket max payload
@@ -67,9 +68,9 @@ const MAX_CONTROL_MSG_LENGTH = 200;       // Max length for JSON control message
 
 // Parse TAB_CONFIG for expected process names per terminal tab
 // TAB_CONFIG is set by the Container DO before container start
-let tabConfigMap = {};
+const tabConfigMap: Record<string, string> = {};
 try {
-  const tabConfig = JSON.parse(process.env.TAB_CONFIG || '[]');
+  const tabConfig: TabConfigEntry[] = JSON.parse(process.env.TAB_CONFIG ?? '[]');
   for (const tab of tabConfig) {
     if (tab.command) {
       tabConfigMap[tab.id] = tab.command;
@@ -81,15 +82,15 @@ try {
 
 // Determine actual working directory - fall back if WORKSPACE doesn't exist
 // This handles the case where R2 mount fails or hasn't completed yet
-let cachedWorkingDir = null;
-function getWorkingDirectory() {
+let cachedWorkingDir: string | null = null;
+function getWorkingDirectory(): string {
   if (cachedWorkingDir) return cachedWorkingDir;
   if (fs.existsSync(WORKSPACE_DEFAULT)) {
     cachedWorkingDir = WORKSPACE_DEFAULT;
     return cachedWorkingDir;
   }
   // Fall back to HOME or /tmp if workspace doesn't exist
-  const fallback = process.env.HOME || '/tmp';
+  const fallback = process.env.HOME ?? '/tmp';
   log('warn', 'Workspace not found, falling back', { workspace: WORKSPACE_DEFAULT, fallback });
   cachedWorkingDir = fallback;
   return cachedWorkingDir;
@@ -97,9 +98,9 @@ function getWorkingDirectory() {
 
 // Ring buffer for recent WebSocket events (for debugging disconnects)
 const WS_EVENT_BUFFER_SIZE = 100;
-const wsEventLog = [];
-function logWsEvent(sessionId, type, details) {
-  const event = {
+const wsEventLog: WsEvent[] = [];
+const logWsEvent: WsEventLogger = (sessionId: string, type: string, details?: Record<string, unknown>): void => {
+  const event: WsEvent = {
     ts: new Date().toISOString(),
     session: sessionId.substring(0, 8),
     type,
@@ -109,7 +110,7 @@ function logWsEvent(sessionId, type, details) {
   if (wsEventLog.length > WS_EVENT_BUFFER_SIZE) {
     wsEventLog.shift();
   }
-}
+};
 
 // Activity tracking for smart hibernation (WebSocket disconnect tracking)
 const activityTracker = createActivityTracker();
@@ -134,18 +135,15 @@ const sessionManager = new SessionManager(sessionOptions);
 /**
  * Timing-safe comparison of bearer tokens.
  * Uses crypto.timingSafeEqual to prevent timing side-channel attacks.
- * @param {string} provided - The token from the Authorization header
- * @param {string} expected - The expected CONTAINER_AUTH_TOKEN
- * @returns {boolean}
  */
-function safeTokenCompare(provided, expected) {
-  const h = (s) => crypto.createHash('sha256').update(s).digest();
+function safeTokenCompare(provided: string, expected: string): boolean {
+  const h = (s: string): Buffer => crypto.createHash('sha256').update(s).digest();
   return crypto.timingSafeEqual(h(provided), h(expected));
 }
 
 // Create HTTP server
-const server = http.createServer(async (req, res) => {
-  const { pathname } = parseUrl(req.url);
+const server = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+  const { pathname } = parseUrl(req.url ?? '');
   const method = req.method;
 
   // Internal endpoints exempt from auth — used by DO schedule-based callbacks
@@ -153,7 +151,7 @@ const server = http.createServer(async (req, res) => {
   // the DO's fetch() override that injects auth headers.
   // These endpoints are behind the container network boundary (no external access).
   const authExemptPaths = new Set(['/health', '/activity']);
-  if (!authExemptPaths.has(pathname)) {
+  if (!authExemptPaths.has(pathname ?? '')) {
     // Validate container auth token (internal-only service, no CORS needed)
     const expectedToken = process.env.CONTAINER_AUTH_TOKEN;
     if (!expectedToken) {
@@ -223,7 +221,7 @@ const server = http.createServer(async (req, res) => {
     const MAX_BODY_SIZE = 64 * 1024; // 64KB
     let body = '';
     let bodySize = 0;
-    req.on('data', (chunk) => {
+    req.on('data', (chunk: Buffer) => {
       bodySize += chunk.length;
       if (bodySize > MAX_BODY_SIZE) {
         res.writeHead(413, { 'Content-Type': 'application/json' });
@@ -236,14 +234,14 @@ const server = http.createServer(async (req, res) => {
     req.on('end', () => {
       if (bodySize > MAX_BODY_SIZE) return;
       try {
-        const { id, name } = JSON.parse(body || '{}');
+        const { id, name } = JSON.parse(body || '{}') as { id?: string; name?: string };
         if (!id) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Session ID required' }));
           return;
         }
 
-        const session = sessionManager.getOrCreate(id, name || 'Terminal');
+        const session = sessionManager.getOrCreate(id, name ?? 'Terminal');
         if (!session) {
           res.writeHead(503, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Session limit reached' }));
@@ -251,7 +249,7 @@ const server = http.createServer(async (req, res) => {
         }
         res.writeHead(201, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ session: session.toJSON() }));
-      } catch (e) {
+      } catch {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Invalid JSON' }));
       }
@@ -260,7 +258,7 @@ const server = http.createServer(async (req, res) => {
   }
 
   // Delete session
-  const deleteMatch = pathname.match(/^\/sessions\/([^\/]+)$/);
+  const deleteMatch = (pathname ?? '').match(/^\/sessions\/([^/]+)$/);
   if (deleteMatch && method === 'DELETE') {
     const id = deleteMatch[1];
     const deleted = sessionManager.delete(id);
@@ -279,7 +277,7 @@ const server = http.createServer(async (req, res) => {
     try {
       const MAX_LOG_SIZE = 100 * 1024; // 100KB
       const stat = fs.statSync('/tmp/sync.log');
-      let logContent;
+      let logContent: string;
       if (stat.size > MAX_LOG_SIZE) {
         // Read only the last 100KB
         const buffer = Buffer.alloc(MAX_LOG_SIZE);
@@ -307,9 +305,9 @@ const server = http.createServer(async (req, res) => {
 // Create WebSocket server
 const wss = new WebSocketServer({ server, path: '/terminal', maxPayload: WS_MAX_PAYLOAD });
 
-wss.on('connection', (ws, req) => {
-  const { query } = parseUrl(req.url, true);
-  const sessionId = query.session;
+wss.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
+  const { query } = parseUrl(req.url ?? '', true);
+  const sessionId = query.session as string | undefined;
   const isManualTab = query.manual === '1';
   const connectedAt = Date.now();
 
@@ -334,7 +332,7 @@ wss.on('connection', (ws, req) => {
   });
 
   // Sanitize session name
-  const name = (query.name || '').replace(/[^a-zA-Z0-9 _-]/g, '').slice(0, 100) || 'Terminal';
+  const name = ((query.name as string) ?? '').replace(/[^a-zA-Z0-9 _-]/g, '').slice(0, 100) || 'Terminal';
 
   // Get or create session (pass manual flag for user-created tabs)
   const session = sessionManager.getOrCreate(sessionId, name, isManualTab);
@@ -346,30 +344,30 @@ wss.on('connection', (ws, req) => {
   // Attach client to session
   session.attach(ws);
 
-  log('info', 'WS connected', { session: shortId, ptyAlive: session.isPtyAlive(), ptyPid: session.ptyProcess?.pid || null, totalClients: session.clients.size });
-  logWsEvent(sessionId, 'connect', { clients: session.clients.size, ptyAlive: session.isPtyAlive(), ptyPid: session.ptyProcess?.pid || null });
+  log('info', 'WS connected', { session: shortId, ptyAlive: session.isPtyAlive(), ptyPid: session.ptyProcess?.pid ?? null, totalClients: session.clients.size });
+  logWsEvent(sessionId, 'connect', { clients: session.clients.size, ptyAlive: session.isPtyAlive(), ptyPid: session.ptyProcess?.pid ?? null });
 
   // Handle incoming messages
   // RAW data goes directly to PTY, JSON only for control messages (resize)
-  ws.on('message', (message) => {
+  ws.on('message', (message: Buffer | string) => {
     const str = message.toString();
 
     // Try to parse as JSON for known control messages only
     // Length-gated: control messages are small; skip parsing for large terminal input
     if (str.length < MAX_CONTROL_MSG_LENGTH && str.startsWith('{')) {
       try {
-        const msg = JSON.parse(str);
+        const msg = JSON.parse(str) as Record<string, unknown>;
 
         // Validate type field AND correct field types before acting
         if (msg.type === 'resize' && typeof msg.cols === 'number' && typeof msg.rows === 'number') {
           if (msg.cols > 0 && msg.cols < 10000 && msg.rows > 0 && msg.rows < 10000) {
-            session.resize(msg.cols, msg.rows);
+            session.resize(msg.cols as number, msg.rows as number);
           }
           return;
         }
 
         if (msg.type === 'data' && typeof msg.data === 'string') {
-          session.write(msg.data);
+          session.write(msg.data as string);
           return;
         }
 
@@ -392,7 +390,7 @@ wss.on('connection', (ws, req) => {
   });
 
   // Handle client disconnect
-  ws.on('close', (code, reason) => {
+  ws.on('close', (code: number, reason: Buffer) => {
     clearInterval(pingInterval);
     const duration = Math.floor((Date.now() - connectedAt) / 1000);
     const reasonStr = reason ? reason.toString() : '';
@@ -404,10 +402,10 @@ wss.on('connection', (ws, req) => {
   });
 
   // Handle errors
-  ws.on('error', (err) => {
+  ws.on('error', (err: Error & { code?: string }) => {
     const duration = Math.floor((Date.now() - connectedAt) / 1000);
-    log('error', 'WS error', { session: shortId, message: err.message, errCode: err.code || null, durationSec: duration, ptyAlive: session.isPtyAlive() });
-    logWsEvent(sessionId, 'error', { message: err.message, errCode: err.code || null, durationSec: duration, ptyAlive: session.isPtyAlive() });
+    log('error', 'WS error', { session: shortId, message: err.message, errCode: err.code ?? null, durationSec: duration, ptyAlive: session.isPtyAlive() });
+    logWsEvent(sessionId, 'error', { message: err.message, errCode: err.code ?? null, durationSec: duration, ptyAlive: session.isPtyAlive() });
     session.detach(ws, sessionManager);
   });
 
@@ -418,8 +416,8 @@ wss.on('connection', (ws, req) => {
 let prewarmReady = false;
 let prewarmStartTime = 0;
 
-const parsedTabConfig = (() => {
-  try { return JSON.parse(process.env.TAB_CONFIG || '[]'); } catch { return []; }
+const parsedTabConfig: TabConfigEntry[] = (() => {
+  try { return JSON.parse(process.env.TAB_CONFIG ?? '[]') as TabConfigEntry[]; } catch { return []; }
 })();
 const prewarmConfig = getPrewarmConfig(parsedTabConfig);
 const PREWARM_TIMEOUT_MS = 20000;     // Hard cap: consider ready after 20s regardless
@@ -443,7 +441,7 @@ server.listen(PORT, '0.0.0.0', () => {
   // Readiness = first PTY output + 1.5s settle delay.
   // The delay lets the agent render its initial UI before the user can click "Open".
   const PREWARM_SETTLE_MS = 1500;
-  let prewarmDataListener = null;
+  let prewarmDataListener: { dispose(): void } | null = null;
   if (prewarmSession.ptyProcess) {
     prewarmDataListener = prewarmSession.ptyProcess.onData(() => {
       if (!prewarmReady) {
@@ -464,7 +462,7 @@ server.listen(PORT, '0.0.0.0', () => {
   }
 
   // Hard timeout safety net (20s) — in case PTY produces no output at all
-  const timeoutId = setTimeout(() => {
+  setTimeout(() => {
     if (!prewarmReady) {
       prewarmReady = true;
       log('info', 'Pre-warm ready (timeout)', { elapsedSec: (PREWARM_TIMEOUT_MS / 1000).toFixed(1), command: prewarmConfig.command });
@@ -485,7 +483,7 @@ server.listen(PORT, '0.0.0.0', () => {
 });
 
 // Graceful shutdown helper
-function shutdown(signal) {
+function shutdown(signal: string): void {
   log('info', `Received ${signal}, shutting down`);
   // M2: Kill all active sessions before exit to avoid orphaned PTY processes
   sessionManager.killAll();

--- a/host/src/session-manager.ts
+++ b/host/src/session-manager.ts
@@ -5,7 +5,9 @@
  * and client aggregation across sessions.
  */
 
+import { WebSocket } from 'ws';
 import { Session } from './session.js';
+import type { SessionOptions, SessionJSON, Logger } from './types.js';
 
 export const PREWARM_SESSION_ID = 'prewarm-1';
 
@@ -13,25 +15,26 @@ export const PREWARM_SESSION_ID = 'prewarm-1';
  * SessionManager handles all PTY sessions.
  */
 export class SessionManager {
-  /**
-   * @param {object} options - Configuration options passed to new Session instances
-   * @param {number} options.maxSessions - Maximum number of active sessions
-   * @param {number} options.ptyCleanupIntervalMs - Cleanup interval in ms
-   * @param {function} options.log - Structured logger
-   */
-  constructor(options = {}) {
+  sessions: Map<string, Session>;
+  cleanupInterval: ReturnType<typeof setInterval> | null;
+  private readonly _options: SessionOptions;
+  private readonly _maxSessions: number;
+  private readonly _ptyCleanupIntervalMs: number;
+  private readonly _log: Logger;
+
+  constructor(options: SessionOptions = {}) {
     this.sessions = new Map();
     this.cleanupInterval = null;
     this._options = options;
-    this._maxSessions = options.maxSessions || 20;
-    this._ptyCleanupIntervalMs = options.ptyCleanupIntervalMs || 60000;
-    this._log = options.log || (() => {});
+    this._maxSessions = options.maxSessions ?? 20;
+    this._ptyCleanupIntervalMs = options.ptyCleanupIntervalMs ?? 60000;
+    this._log = options.log ?? (() => {});
   }
 
   /**
    * Start periodic cleanup of dead sessions
    */
-  startCleanup() {
+  startCleanup(): void {
     if (this.cleanupInterval) return;
 
     this.cleanupInterval = setInterval(() => {
@@ -44,7 +47,7 @@ export class SessionManager {
   /**
    * Stop periodic cleanup
    */
-  stopCleanup() {
+  stopCleanup(): void {
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
@@ -54,8 +57,8 @@ export class SessionManager {
   /**
    * Clean up sessions that have no clients and no PTY
    */
-  cleanupDeadSessions() {
-    const toDelete = [];
+  cleanupDeadSessions(): void {
+    const toDelete: string[] = [];
     for (const [id, session] of this.sessions) {
       if (!session.isPtyAlive() && session.clients.size === 0) {
         toDelete.push(id);
@@ -75,7 +78,7 @@ export class SessionManager {
   /**
    * Get or create a session
    */
-  getOrCreate(id, name, manual = false) {
+  getOrCreate(id: string, name: string, manual = false): Session | null {
     let session = this.sessions.get(id);
 
     if (session) {
@@ -118,14 +121,14 @@ export class SessionManager {
   /**
    * Get a session by ID
    */
-  get(id) {
+  get(id: string): Session | undefined {
     return this.sessions.get(id);
   }
 
   /**
    * Delete a session
    */
-  delete(id) {
+  delete(id: string): boolean {
     const session = this.sessions.get(id);
     if (session) {
       session.kill();
@@ -139,7 +142,7 @@ export class SessionManager {
   /**
    * Kill all active sessions. Used during shutdown.
    */
-  killAll() {
+  killAll(): void {
     for (const [id, session] of this.sessions) {
       session.kill();
       this._log('info', 'Killed session during shutdown', { session: id });
@@ -150,15 +153,15 @@ export class SessionManager {
   /**
    * List all sessions
    */
-  list() {
+  list(): SessionJSON[] {
     return Array.from(this.sessions.values()).map((s) => s.toJSON());
   }
 
   /**
    * Get a Map of all connected WebSocket clients across all sessions.
    */
-  get clients() {
-    const allClients = new Map();
+  get clients(): Map<string, WebSocket> {
+    const allClients = new Map<string, WebSocket>();
     let idx = 0;
     for (const session of this.sessions.values()) {
       for (const ws of session.clients) {
@@ -171,7 +174,7 @@ export class SessionManager {
   /**
    * Get session count
    */
-  get size() {
+  get size(): number {
     return this.sessions.size;
   }
 }

--- a/host/src/session.ts
+++ b/host/src/session.ts
@@ -6,33 +6,61 @@
  */
 
 import pty from 'node-pty';
+import type { IPty } from 'node-pty';
 import { WebSocket } from 'ws';
 import HeadlessPkg from '@xterm/headless';
 const { Terminal: HeadlessTerminal } = HeadlessPkg;
 import SerializePkg from '@xterm/addon-serialize';
 const { SerializeAddon } = SerializePkg;
 
+import type {
+  SessionOptions,
+  SessionJSON,
+  TabConfigMap,
+  Logger,
+  WsEventLogger,
+  ActivityTracker,
+} from './types.js';
+
 const PROCESS_NAME_POLL_MS = 2000;
+
+// Forward reference — SessionManager is imported only as a type to avoid
+// circular runtime dependencies.
+interface SessionManagerLike {
+  clients: Map<string, WebSocket>;
+  sessions: Map<string, Session>;
+}
 
 /**
  * Session represents a PTY terminal instance.
  */
 export class Session {
-  /**
-   * @param {string} id - Session ID
-   * @param {string} name - Display name
-   * @param {boolean} manual - Whether this is a manually-created tab
-   * @param {object} options - Configuration options
-   * @param {object} options.tabConfigMap - Map of terminal ID to configured command
-   * @param {string} options.terminalCommand - Command to spawn
-   * @param {string} options.terminalArgs - Arguments for the command
-   * @param {function} options.getWorkingDirectory - Function to resolve working directory
-   * @param {function} options.log - Structured logger
-   * @param {function} options.logWsEvent - WebSocket event logger
-   * @param {object} options.activityTracker - Activity tracker instance
-   * @param {number} options.ptyKeepaliveMs - PTY keepalive timeout in ms
-   */
-  constructor(id, name = 'Terminal', manual = false, options = {}) {
+  id: string;
+  name: string;
+  manual: boolean;
+  ptyProcess: IPty | null;
+  clients: Set<WebSocket>;
+  headlessTerminal: InstanceType<typeof HeadlessTerminal>;
+  serializeAddon: InstanceType<typeof SerializeAddon>;
+  createdAt: string;
+  lastAccessedAt: string;
+  disconnectedAt: string | null;
+  keepAliveTimeout: ReturnType<typeof setTimeout> | null;
+  lastProcessName: string | null;
+  processNameInterval: ReturnType<typeof setInterval> | null;
+  orphanTimeout: ReturnType<typeof setTimeout> | null;
+
+  // Injected dependencies
+  private readonly _tabConfigMap: TabConfigMap;
+  private readonly _terminalCommand: string;
+  private readonly _terminalArgs: string;
+  private readonly _getWorkingDirectory: () => string;
+  private readonly _log: Logger;
+  private readonly _logWsEvent: WsEventLogger;
+  private readonly _activityTracker: ActivityTracker | null;
+  private readonly _ptyKeepaliveMs: number;
+
+  constructor(id: string, name = 'Terminal', manual = false, options: SessionOptions = {}) {
     this.id = id;
     this.name = name;
     this.manual = manual;
@@ -50,20 +78,20 @@ export class Session {
     this.orphanTimeout = null;
 
     // Injected dependencies
-    this._tabConfigMap = options.tabConfigMap || {};
-    this._terminalCommand = options.terminalCommand || '/bin/bash';
-    this._terminalArgs = options.terminalArgs || '-l';
-    this._getWorkingDirectory = options.getWorkingDirectory || (() => '/tmp');
-    this._log = options.log || (() => {});
-    this._logWsEvent = options.logWsEvent || (() => {});
-    this._activityTracker = options.activityTracker || null;
-    this._ptyKeepaliveMs = options.ptyKeepaliveMs || 2700000;
+    this._tabConfigMap = options.tabConfigMap ?? {};
+    this._terminalCommand = options.terminalCommand ?? '/bin/bash';
+    this._terminalArgs = options.terminalArgs ?? '-l';
+    this._getWorkingDirectory = options.getWorkingDirectory ?? (() => '/tmp');
+    this._log = options.log ?? (() => {});
+    this._logWsEvent = options.logWsEvent ?? (() => {});
+    this._activityTracker = options.activityTracker ?? null;
+    this._ptyKeepaliveMs = options.ptyKeepaliveMs ?? 2700000;
   }
 
   /**
    * Get the terminal ID from the compound session ID (e.g., "abc123-2" -> "2")
    */
-  get terminalId() {
+  get terminalId(): string {
     const parts = this.id.split('-');
     return parts[parts.length - 1];
   }
@@ -71,25 +99,25 @@ export class Session {
   /**
    * Resolve the display name for the foreground process.
    */
-  resolveProcessName() {
+  resolveProcessName(): string | null {
     const rawName = this.ptyProcess ? this.ptyProcess.process : null;
     if (!rawName) return null;
 
     const configuredCmd = this._tabConfigMap[this.terminalId];
     if (configuredCmd) {
       const baseName = rawName.split('/').pop();
-      if (['node', 'nodejs', 'bash', 'sh', 'zsh'].includes(baseName)) {
+      if (['node', 'nodejs', 'bash', 'sh', 'zsh'].includes(baseName ?? '')) {
         return configuredCmd.split(/\s+/)[0];
       }
     }
 
-    return rawName.split('/').pop() || rawName;
+    return rawName.split('/').pop() ?? rawName;
   }
 
   /**
    * Start the PTY process
    */
-  start(cols = 80, rows = 24) {
+  start(cols = 80, rows = 24): void {
     if (this.ptyProcess) {
       return;
     }
@@ -103,12 +131,12 @@ export class Session {
     const cwd = this._getWorkingDirectory();
     const terminalId = this.id.includes('-') ? this.id.split('-').pop() : '1';
 
-    const ptyEnv = {
-      ...process.env,
+    const ptyEnv: Record<string, string> = {
+      ...process.env as Record<string, string>,
       TERM: 'xterm-256color',
       COLORTERM: 'truecolor',
-      HOME: process.env.HOME || '/root',
-      TERMINAL_ID: terminalId,
+      HOME: process.env.HOME ?? '/root',
+      TERMINAL_ID: terminalId ?? '1',
     };
     if (this.manual) {
       ptyEnv.MANUAL_TAB = '1';
@@ -122,7 +150,7 @@ export class Session {
       env: ptyEnv,
     });
 
-    this.ptyProcess.onData((data) => {
+    this.ptyProcess.onData((data: string) => {
       this.headlessTerminal.write(data);
 
       for (const client of this.clients) {
@@ -132,7 +160,7 @@ export class Session {
       }
     });
 
-    this.ptyProcess.onExit(({ exitCode, signal }) => {
+    this.ptyProcess.onExit(({ exitCode, signal }: { exitCode: number; signal?: number }) => {
       this._log('info', 'PTY exited', { session: this.id, exitCode, signal, connectedClients: this.clients.size });
       this._logWsEvent(this.id, 'pty_exit', { exitCode, signal, connectedClients: this.clients.size });
       for (const client of this.clients) {
@@ -151,7 +179,7 @@ export class Session {
     this.lastProcessName = this.resolveProcessName();
     this.processNameInterval = setInterval(() => {
       if (!this.ptyProcess) {
-        clearInterval(this.processNameInterval);
+        clearInterval(this.processNameInterval!);
         this.processNameInterval = null;
         return;
       }
@@ -173,7 +201,7 @@ export class Session {
   /**
    * Attach a WebSocket client to this session
    */
-  attach(ws) {
+  attach(ws: WebSocket): void {
     this.clients.add(ws);
     this.lastAccessedAt = new Date().toISOString();
     if (this._activityTracker) {
@@ -205,10 +233,8 @@ export class Session {
 
   /**
    * Detach a WebSocket client from this session
-   * @param {WebSocket} ws
-   * @param {SessionManager} sessionManager - Reference to session manager for cleanup
    */
-  detach(ws, sessionManager = null) {
+  detach(ws: WebSocket, sessionManager: SessionManagerLike | null = null): void {
     this.clients.delete(ws);
     this._log('info', 'Client detached', { session: this.id.substring(0, 8), totalClients: this.clients.size });
 
@@ -236,7 +262,7 @@ export class Session {
   /**
    * Write data to the PTY
    */
-  write(data) {
+  write(data: string): void {
     if (this.ptyProcess) {
       this.ptyProcess.write(data);
     }
@@ -245,7 +271,7 @@ export class Session {
   /**
    * Resize the PTY
    */
-  resize(cols, rows) {
+  resize(cols: number, rows: number): void {
     if (this.ptyProcess) {
       this.ptyProcess.resize(cols, rows);
     }
@@ -255,7 +281,7 @@ export class Session {
   /**
    * Kill the PTY process
    */
-  kill() {
+  kill(): void {
     if (this.keepAliveTimeout) {
       clearTimeout(this.keepAliveTimeout);
       this.keepAliveTimeout = null;
@@ -283,18 +309,18 @@ export class Session {
   /**
    * Check if PTY process is still running
    */
-  isPtyAlive() {
+  isPtyAlive(): boolean {
     return this.ptyProcess !== null;
   }
 
   /**
    * Get session info
    */
-  toJSON() {
+  toJSON(): SessionJSON {
     return {
       id: this.id,
       name: this.name,
-      pid: this.ptyProcess?.pid || null,
+      pid: this.ptyProcess?.pid ?? null,
       clients: this.clients.size,
       createdAt: this.createdAt,
       lastAccessedAt: this.lastAccessedAt,

--- a/host/src/types.ts
+++ b/host/src/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared type definitions for the codeflare host terminal server.
+ */
+
+import type { WebSocket } from 'ws';
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+/** Log severity levels used by the structured logger. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/** Structured logger function signature. */
+export type Logger = (level: LogLevel, msg: string, meta?: Record<string, unknown>) => void;
+
+/** WebSocket event logger function signature. */
+export type WsEventLogger = (sessionId: string, type: string, details?: Record<string, unknown>) => void;
+
+// ---------------------------------------------------------------------------
+// Tab / Pre-warm configuration
+// ---------------------------------------------------------------------------
+
+/** A single entry from the TAB_CONFIG environment variable. */
+export interface TabConfigEntry {
+  readonly id: string;
+  readonly command: string;
+  readonly label: string;
+}
+
+/** Result of getPrewarmConfig — the command extracted from tab 1. */
+export interface PrewarmConfig {
+  readonly command: string | null;
+}
+
+/** Map of terminal ID to configured command string. */
+export type TabConfigMap = Readonly<Record<string, string>>;
+
+// ---------------------------------------------------------------------------
+// Activity Tracker
+// ---------------------------------------------------------------------------
+
+/** Snapshot returned by ActivityTracker.getActivityInfo(). */
+export interface ActivityInfo {
+  readonly hasActiveConnections: boolean;
+  readonly connectedClients: number;
+  readonly activeSessions: number;
+  readonly disconnectedForMs: number | null;
+}
+
+/** Minimal SessionManager surface needed by the activity tracker. */
+export interface ActivitySessionManager {
+  readonly clients: ReadonlyMap<string, unknown>;
+  readonly sessions?: ReadonlyMap<string, { ptyProcess: unknown | null }>;
+}
+
+/** Activity tracker instance returned by createActivityTracker(). */
+export interface ActivityTracker {
+  lastAllDisconnectedAt: number | null;
+  recordClientConnected(): void;
+  recordAllClientsDisconnected(): void;
+  getActivityInfo(sessionManager: ActivitySessionManager | null | undefined): ActivityInfo;
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+/** Sync status written by the rclone daemon. */
+export interface SyncStatus {
+  readonly status: string;
+  readonly error: string | null;
+  readonly userPath: string | null;
+}
+
+/** System resource metrics (CPU, memory, disk). */
+export interface SystemMetrics {
+  readonly cpu: string;
+  readonly mem: string;
+  readonly hdd: string;
+}
+
+/** Cached disk metrics with TTL tracking. */
+export interface CachedDiskMetrics {
+  value: string;
+  lastUpdated: number;
+}
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+/** Options passed to Session and SessionManager constructors. */
+export interface SessionOptions {
+  readonly tabConfigMap?: TabConfigMap;
+  readonly terminalCommand?: string;
+  readonly terminalArgs?: string;
+  readonly getWorkingDirectory?: () => string;
+  readonly log?: Logger;
+  readonly logWsEvent?: WsEventLogger;
+  readonly activityTracker?: ActivityTracker | null;
+  readonly ptyKeepaliveMs?: number;
+  readonly maxSessions?: number;
+  readonly ptyCleanupIntervalMs?: number;
+}
+
+/** JSON representation of a session (returned by Session.toJSON()). */
+export interface SessionJSON {
+  readonly id: string;
+  readonly name: string;
+  readonly pid: number | null;
+  readonly clients: number;
+  readonly createdAt: string;
+  readonly lastAccessedAt: string;
+  readonly disconnectedAt: string | null;
+  readonly ptyAlive: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket event log
+// ---------------------------------------------------------------------------
+
+/** A single entry in the WebSocket event ring buffer. */
+export interface WsEvent {
+  readonly ts: string;
+  readonly session: string;
+  readonly type: string;
+  readonly [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Server / Health
+// ---------------------------------------------------------------------------
+
+/** Health check response payload. */
+export interface HealthResponse {
+  readonly status: string;
+  readonly sessions: number;
+  readonly uptime: number;
+  readonly syncStatus: string;
+  readonly syncError: string | null;
+  readonly userPath: string | null;
+  readonly prewarmReady: boolean;
+  readonly cpu: string;
+  readonly mem: string;
+  readonly hdd: string;
+  readonly timestamp: string;
+}

--- a/host/tsconfig.json
+++ b/host/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}


### PR DESCRIPTION
## Summary
- Migrate all 6 host source files (1,129 LOC) from JavaScript to TypeScript with strict types
- Add TypeScript infrastructure: `tsconfig.json`, build script, `@types/node`, `@types/ws`
- Create shared `types.ts` with 15+ interfaces for session, config, metrics, and WebSocket types
- Update Dockerfile to compile TypeScript in builder stage
- Update all 10 test file imports for new `dist/` output paths
- Update `entrypoint.sh` to run from `dist/server.js`

## Test plan
- [ ] CI passes — all host tests run against compiled output
- [ ] Verify Docker build completes with TypeScript compilation
- [ ] Verify host server starts from `dist/server.js`