### PR TITLE
Fix mobile dropdown positioning broken by desktop getBoundingClientRect

### DIFF
--- a/web-ui/src/components/Dashboard.tsx
+++ b/web-ui/src/components/Dashboard.tsx
@@ -154,7 +154,7 @@ const Dashboard: Component<DashboardProps> = (props) => {
                     class="header-user-dropdown header-user-dropdown--portal"
                     data-testid="header-user-dropdown"
                     onClick={(e) => e.stopPropagation()}
-                    style={{ top: `${userMenuPos().top}px`, right: `${userMenuPos().right}px` }}
+                    style={window.innerWidth > 640 ? { top: `${userMenuPos().top}px`, right: `${userMenuPos().right}px` } : undefined}
                   >
                     <a
                       href="/app/subscribe"


### PR DESCRIPTION
## Summary

Inline `style={{ top, right }}` from the desktop dropdown positioning fix was overriding the mobile CSS bottom-sheet rules (inline styles beat class selectors). The dropdown appeared partially off-screen on mobile instead of as a full-width bottom sheet.

**Fix:** Only apply computed position on viewports > 640px. On mobile, `style` is `undefined` so CSS bottom-sheet rules take effect.

## Test Plan
- [x] CI: PR Checks, Fuzz, CodeQL all green
- [x] Desktop: dropdown appears below avatar button
- [x] Mobile: dropdown appears as bottom sheet