### PR TITLE
Simplify footer: end on Region: Earth

### DIFF
--- a/web-ui/src/components/LoginPage.tsx
+++ b/web-ui/src/components/LoginPage.tsx
@@ -8,7 +8,6 @@ import {
   mdiLightningBolt,
 } from '@mdi/js';
 import { getAuthProviders, getAuthStatus } from '../api/client';
-import { CloudflareIcon } from './settings/BrandIcons';
 import type { AuthProvider } from '../types';
 import ScrambleText from './ScrambleText';
 import Icon from './Icon';
@@ -171,7 +170,7 @@ const LoginPage: Component = () => {
           </div>
         </Show>
 
-        <p class="login-footer">From Switzerland <span class="login-footer-flag" aria-label="Swiss flag">&#127464;&#127469;</span> for <span style={{ color: '#f6821f' }}>Region: Earth</span> on <CloudflareIcon size={14} style={{ display: 'inline-block', 'vertical-align': 'middle', 'margin-left': '2px' }} /></p>
+        <p class="login-footer">From Switzerland <span class="login-footer-flag" aria-label="Swiss flag">&#127464;&#127469;</span> for <span style={{ color: '#f6821f' }}>Region: Earth</span></p>
       </div>
     </div>
   );

--- a/web-ui/src/components/OnboardingPage.tsx
+++ b/web-ui/src/components/OnboardingPage.tsx
@@ -376,7 +376,7 @@ const OnboardingPage: Component = () => {
           <Icon path={mdiArrowRight} size={16} />
         </a>
 
-        <p class="login-footer">From Switzerland <span class="login-footer-flag" aria-label="Swiss flag">&#127464;&#127469;</span> for <span style={{ color: '#f6821f' }}>Region: Earth</span> on <CloudflareIcon size={14} style={{ display: 'inline-block', 'vertical-align': 'middle', 'margin-left': '2px' }} /></p>
+        <p class="login-footer">From Switzerland <span class="login-footer-flag" aria-label="Swiss flag">&#127464;&#127469;</span> for <span style={{ color: '#f6821f' }}>Region: Earth</span></p>
       </div>
     </div>
   );

--- a/web-ui/src/components/SubscribePage.tsx
+++ b/web-ui/src/components/SubscribePage.tsx
@@ -21,7 +21,6 @@ import type { AuthStatus } from '../types';
 import ScrambleText from './ScrambleText';
 import Icon from './Icon';
 import { logger } from '../lib/logger';
-import { CloudflareIcon } from './settings/BrandIcons';
 import '../styles/login-page.css';
 import '../styles/subscribe-page.css';
 
@@ -302,7 +301,7 @@ const SubscribePage: Component = () => {
           >Log out</a>
         </Show>
 
-        <p class="login-footer">From Switzerland <span class="login-footer-flag" aria-label="Swiss flag">&#127464;&#127469;</span> for <span style={{ color: '#f6821f' }}>Region: Earth</span> on <CloudflareIcon size={14} style={{ display: 'inline-block', 'vertical-align': 'middle', 'margin-left': '2px' }} /></p>
+        <p class="login-footer">From Switzerland <span class="login-footer-flag" aria-label="Swiss flag">&#127464;&#127469;</span> for <span style={{ color: '#f6821f' }}>Region: Earth</span></p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Remove "on" + Cloudflare logo from footer
- Footer now reads: "From Switzerland 🇨🇭 for **Region: Earth**"
- Region: Earth stays in Cloudflare orange (#f6821f)
- Removed unused CloudflareIcon imports from LoginPage and SubscribePage

## Test plan

- [ ] Visual check on login, subscribe, and onboarding pages