### PR TITLE
fix: persist sleepAfter to DO storage + docs overhaul + CVE suppression

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,6 +9,7 @@ CVE-2026-33186
 # rclone/lazygit: jsonparser DoS via crafted JSON input.
 # These are CLI tools in sandboxed container, not processing untrusted JSON.
 GHSA-6g7g-w4f8-9c9x
+CVE-2026-32285
 
 # lazygit v0.60.0 built with Go 1.25.x — may still need Go 1.25.8+ for fix.
 # Risk: crypto/tls session resumption — lazygit doesn't expose TLS services.


### PR DESCRIPTION
## Summary

- **Bug fix**: sleepAfter idle timeout lost on DO resets — now persisted to DO storage
- **CVE fix**: suppress CVE-2026-32285 (jsonparser in rclone/lazygit, sandboxed CLI tools)
- **Documentation**: three-pass review of all docs, 40+ accuracy fixes

## Bug fix — sleepAfter persistence

User's configured idle timeout reverted to 5m default on Durable Object resets (Cloudflare infrastructure events), killing active sessions prematurely.

- Constructor loads sleepAfter from DO storage with regex validation
- Both setBucketName paths persist to storage
- destroy() cleans up alongside other operational keys
- 7 new tests

## CVE suppression

CVE-2026-32285 in github.com/buger/jsonparser v1.1.1 (rclone/lazygit transitive dep). Same category as existing GHSA-6g7g-w4f8-9c9x — CLI tools in sandboxed container, not processing untrusted JSON.

## Documentation (6 commits)

- Rebuilt TECHNICAL.md ToC, fixed 20+ numerical counts, removed phantom endpoints
- Added missing API sections (Billing, Deploy Keys, Public)
- Updated SECURITY.md with GitHub OIDC auth mode
- Fixed cross-references across all 6 doc files

## Test plan
- [x] All CI passed on develop (Fuzz, PR Checks, CodeQL)
- [x] 7 new sleepAfter tests pass
- [x] Three audit passes + three code reviews
- [ ] Deploy to integration and verify sleepAfter survives DO reset