### PR TITLE
feat: multi-currency Stripe pricing (#181)

### DIFF
--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -281,6 +281,7 @@ function connect() {
 | `src/lib/cf-api.ts` | Cloudflare API client. `parseCfResponse` checks `Content-Type` header before JSON parsing. When content-type is not `application/json`, attempts `JSON.parse` on the text body as a lenient fallback (Cloudflare sometimes omits content-type on valid JSON). Only throws a structured `AppError` with the first 200 chars of the response body if the parse actually fails -- this gives clear diagnostics for HTML error pages or plain text from expired tokens, instead of opaque JSON parse errors. |
 | `src/lib/request-helpers.ts` | Shared request handling: `parseJsonBody(c)` (JSON parse with ValidationError on malformed input), `firstZodError(error)` (first Zod issue message with fallback), `validateSessionId(id)` (throws on invalid format), `maskSecret(value)` (shows last 4 chars). |
 | `src/lib/kv-keys.ts` | KV key utilities: session/user key helpers, `SETUP_KEYS` const for all 20 `setup:*` configuration keys, `getBaseUrl(kv, requestUrl)`, `listAllKvKeys()`. |
+| `src/lib/currency.ts` | `getCurrencyForCountry(country)` — maps a 2-letter ISO country code to a supported currency (`chf`/`usd`/`eur`/`gbp`). CH/LI → CHF, GB → GBP, 20 Eurozone countries → EUR, all others → USD. Used by billing and tiers routes to detect visitor currency from the `CF-IPCountry` header. Implements [REQ-SUB-020](../sdd/subscription.md#req-sub-020). |
 | `src/types.ts` | `BillingStatus` union type (`'active' | 'trialing' | 'past_due' | 'canceled'`) with `BILLING_STATUS` const and `isBillingStatus()` guard. `ContainerConfigPayload` groups 16 container initialization params into logical sub-objects (R2 creds, LlmKeys, DeployKeys, preferences). |
 
 ### Setup Wizard Resilience
@@ -503,7 +504,7 @@ All module-level caches in the codebase. Workers isolates do not share memory, s
 | `src/lib/subscription.ts` | `cachedTierConfig` | 60s | Tier configuration from `tiers:config` KV key | `resetTierConfigCache()` |
 | `src/lib/cors-cache.ts` | `cachedKvOrigins` | 5 min | CORS origins from `setup:custom_domain` + `setup:allowed_origins` | `resetCorsOriginsCache()` |
 | `src/lib/jwt.ts` | JWKS key cache | 30s freshness threshold | Cloudflare Access JWKS public keys (re-fetched on kid miss after 30s) | `resetJWKSCache()` |
-| `src/lib/stripe.ts` | `priceCache` | 1 hour | Stripe price amount/currency per price ID | (none — TTL-only) |
+| `src/lib/stripe.ts` | `priceCache` | 1 hour | Stripe price amount/currency per price ID, including `currency_options` for multi-currency pricing | (none — TTL-only) |
 | `src/lib/kv-crypto.ts` | imported CryptoKey | Isolate lifetime | AES-256 key from `ENCRYPTION_KEY` env var | (none — persists for isolate lifetime) |
 | `src/lib/rate-limit-core.ts` | `failedKvOps` | Isolate lifetime | Counter for consecutive KV failures (circuit breaker) | (none) |
 | `src/lib/circuit-breakers.ts` | per-container breakers | Isolate lifetime | Circuit breaker state per container ID | (none) |

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -275,14 +275,15 @@ When `STRIPE_SECRET_KEY` is set as a Worker secret, paid tiers (standard, advanc
 **Architecture — Signal and Sync pattern:**
 Webhooks are signals that trigger a fetch of the latest state from the Stripe API. KV is a read cache, not the source of truth. This eliminates race conditions from incremental KV patching and ensures KV always reflects the latest Stripe state.
 
-- Library: `src/lib/stripe.ts` — checkout session creation, webhook signature verification, `fetchSubscription()` (Signal and Sync), Stripe API communication
+- Library: `src/lib/stripe.ts` — checkout session creation, webhook signature verification, `fetchSubscription()` (Signal and Sync), Stripe API communication; `getStripePrices()` expands `currency_options` from the Stripe API and returns amounts in the requested currency
+- Currency detection: `src/lib/currency.ts` — `getCurrencyForCountry(country)` maps a 2-letter ISO country code to a supported currency (CHF/USD/EUR/GBP). Implements [REQ-SUB-020](../sdd/subscription.md#req-sub-020).
 - Billing routes: `src/routes/billing.ts` — `POST /api/billing/checkout` (authenticated), `GET /api/billing/status` (Stripe-verified), `POST /api/billing/switch` (portal deep-link for plan changes)
 - Webhook: `src/routes/stripe-webhook.ts` — `POST /public/stripe/webhook` (unauthenticated, HMAC-verified), `syncSubscriptionState()`
 - Types: billing fields defined in `parseUserRecord` Zod schema in `src/lib/user-record.ts`
 
 **Checkout flow:**
 1. User selects paid tier on subscribe page → frontend calls `POST /api/billing/checkout` with `{ tier, mode }`
-2. Backend creates Stripe Checkout Session with `customer_email` and tier/mode metadata
+2. Backend detects visitor currency from the `CF-IPCountry` request header via `getCurrencyForCountry()`, then creates a Stripe Checkout Session with `customer_email`, tier/mode metadata, and the detected `currency`
 3. Frontend redirects to Stripe-hosted checkout page
 4. After payment, Stripe redirects to `/app/subscribe?checkout=success`
 5. Frontend polls `GET /api/auth/status` every 2s (max 30s) waiting for webhook to activate the subscription
@@ -498,9 +499,10 @@ Priority in `AppContent.onMount` (`web-ui/src/App.tsx`): pending tier → subscr
 **`GET /api/auth/tiers`** (requires identity) and **`GET /public/tiers`** (unauthenticated, only available when `ONBOARDING_LANDING_PAGE=active`):
 - Both return subscribable tier configs: `free`, `standard`, `advanced`, `max`, `unlimited` (filtered from full 8-tier config)
 - The frontend SubscribePage uses `/api/auth/tiers` (identity-gated) via `getPublicTiers()` in `web-ui/src/api/client.ts`; `/public/tiers` is gated behind onboarding landing page middleware
+- **Multi-currency:** the tiers endpoint detects the visitor's currency from the `CF-IPCountry` request header via `getCurrencyForCountry()` and passes it to `getStripePrices()`, which fetches `currency_options` from the Stripe API. Returned `priceMonthly`/`advancedPriceMonthly` values are in the visitor's currency (CHF, USD, EUR, or GBP). Implements [REQ-SUB-020](../sdd/subscription.md#req-sub-020).
 - Response: `{ tiers: SubscriptionTierConfig[] }` — each tier object includes all properties:
   - `id`, `displayName`, `monthlySeconds`, `maxSessions`, `sessionModes`
-  - `priceMonthly` (cents), `advancedPriceMonthly` (cents, optional), `trialQuotaHours`, `description`
+  - `priceMonthly` (cents, in visitor currency), `advancedPriceMonthly` (cents, in visitor currency, optional), `trialQuotaHours`, `description`
   - `order`, `canLogin`, `isDefault`
 - Used by subscribe page to render tier selection cards
 - Data is cached at 60-second TTL via `getTierConfig()`

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -3,6 +3,8 @@
 Semantic changes to the specification. Git history captures diffs; this file captures intent.
 
 ## 2026-04-10
+- Added REQ-SUB-020: Multi-currency pricing via Stripe `currency_options`. Subscribe page and checkout auto-detect visitor currency from `CF-IPCountry` (CHF/USD/EUR/GBP).
+- Removed multi-currency pricing from Out of Scope.
 - Updated REQ-AGENT-004 AC4-AC6: session mode now auto-reconciles on Stripe mode change, subscription termination, and Settings toggle -- no longer requires explicit recreate click
 - Updated REQ-SUB-015 AC6-AC7: reconciliation generalized from downgrade-only to any mode change; added AC7 for subscription deletion reconciliation
 

--- a/sdd/subscription.md
+++ b/sdd/subscription.md
@@ -504,7 +504,7 @@ Tiers, billing, usage tracking, and quotas.
 1. Each Stripe Price object has `currency_options` for USD, EUR, and GBP (CHF is the base currency), all at the same nominal amount.
 2. `GET /api/auth/tiers` detects visitor currency from the `CF-IPCountry` request header and returns Stripe prices in that currency.
 3. `POST /api/billing/checkout` detects visitor currency from `CF-IPCountry` and passes it to the Stripe Checkout Session so Stripe charges in the visitor's currency.
-4. Country-to-currency mapping: CH/LI to CHF, GB to GBP, 19 Eurozone countries to EUR, all others to USD.
+4. Country-to-currency mapping: CH/LI to CHF, GB to GBP, 20 Eurozone countries to EUR, all others to USD.
 5. Currency detection is server-side only; no user-facing currency switcher.
 
 **Constraints:**

--- a/sdd/subscription.md
+++ b/sdd/subscription.md
@@ -17,7 +17,6 @@ Tiers, billing, usage tracking, and quotas.
 
 - **Per-feature billing** -- All features within a tier are available to all users on that tier. No add-on purchases or feature flags gated by separate payments.
 - **Usage-based overage billing** -- Users who exceed quota are stopped, not charged extra. No metered billing or pay-per-minute beyond the tier allowance.
-- **Multi-currency pricing** -- Prices are set in a single currency via Stripe. No currency conversion, localized pricing, or regional price differentiation.
 
 ### Domain Dependencies
 
@@ -494,3 +493,28 @@ Tiers, billing, usage tracking, and quotas.
 **Verification:** Integration test
 
 **Status:** Implemented
+
+---
+
+## REQ-SUB-020: Multi-Currency Pricing
+
+**Intent:** Visitors must see subscription prices in their local currency (CHF, USD, EUR, GBP) with Stripe charging the exact displayed amount -- no surprise FX conversion on the bank statement.
+
+**Acceptance Criteria:**
+1. Each Stripe Price object has `currency_options` for USD, EUR, and GBP (CHF is the base currency), all at the same nominal amount.
+2. `GET /api/auth/tiers` detects visitor currency from the `CF-IPCountry` request header and returns Stripe prices in that currency.
+3. `POST /api/billing/checkout` detects visitor currency from `CF-IPCountry` and passes it to the Stripe Checkout Session so Stripe charges in the visitor's currency.
+4. Country-to-currency mapping: CH/LI to CHF, GB to GBP, 19 Eurozone countries to EUR, all others to USD.
+5. Currency detection is server-side only; no user-facing currency switcher.
+
+**Constraints:**
+- Currency is auto-detected per request; there is no override mechanism.
+- Stripe `currency_options` must be configured on each Price object in the Stripe Dashboard before this feature works.
+
+**Applies To:** User
+**Priority:** P1
+**Dependencies:** REQ-SUB-004
+**Verification:** Automated test
+
+**Status:** Partial
+Notes: Stripe `currency_options` must be configured on each Price object in the Dashboard. Code is implemented but not yet verified end-to-end.

--- a/sdd/subscription.md
+++ b/sdd/subscription.md
@@ -504,7 +504,7 @@ Tiers, billing, usage tracking, and quotas.
 1. Each Stripe Price object has `currency_options` for USD, EUR, and GBP (CHF is the base currency), all at the same nominal amount.
 2. `GET /api/auth/tiers` detects visitor currency from the `CF-IPCountry` request header and returns Stripe prices in that currency.
 3. `POST /api/billing/checkout` detects visitor currency from `CF-IPCountry` and passes it to the Stripe Checkout Session so Stripe charges in the visitor's currency.
-4. Country-to-currency mapping: CH/LI to CHF, GB to GBP, 20 Eurozone countries to EUR, all others to USD.
+4. Country-to-currency mapping: CH/LI to CHF, GB to GBP, all other European countries to EUR, rest of world to USD.
 5. Currency detection is server-side only; no user-facing currency switcher.
 
 **Constraints:**

--- a/src/__tests__/lib/currency.test.ts
+++ b/src/__tests__/lib/currency.test.ts
@@ -11,8 +11,12 @@ describe('getCurrencyForCountry', () => {
     expect(getCurrencyForCountry('LI')).toBe('chf');
   });
 
-  it('returns GBP for United Kingdom', () => {
+  it('returns GBP for United Kingdom and British territories', () => {
     expect(getCurrencyForCountry('GB')).toBe('gbp');
+    expect(getCurrencyForCountry('GI')).toBe('gbp');
+    expect(getCurrencyForCountry('GG')).toBe('gbp');
+    expect(getCurrencyForCountry('JE')).toBe('gbp');
+    expect(getCurrencyForCountry('IM')).toBe('gbp');
   });
 
   it('returns EUR for Germany', () => {
@@ -31,8 +35,8 @@ describe('getCurrencyForCountry', () => {
       // EU non-Eurozone
       'BG', 'CZ', 'DK', 'HU', 'PL', 'RO', 'SE',
       // Non-EU European
-      'AD', 'AL', 'BA', 'BY', 'FO', 'IS', 'MC', 'MD', 'ME', 'MK',
-      'NO', 'RS', 'SM', 'TR', 'UA', 'VA', 'XK',
+      'AD', 'AL', 'AX', 'BA', 'BY', 'FO', 'IS', 'MC', 'MD', 'ME',
+      'MK', 'NO', 'RS', 'SJ', 'SM', 'TR', 'UA', 'VA', 'XK',
     ];
     for (const country of european) {
       expect(getCurrencyForCountry(country)).toBe('eur');

--- a/src/__tests__/lib/currency.test.ts
+++ b/src/__tests__/lib/currency.test.ts
@@ -23,8 +23,8 @@ describe('getCurrencyForCountry', () => {
     expect(getCurrencyForCountry('FR')).toBe('eur');
   });
 
-  it('returns EUR for all 19 Eurozone countries', () => {
-    const eurozone = ['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT', 'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY'];
+  it('returns EUR for all 20 Eurozone countries', () => {
+    const eurozone = ['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT', 'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY', 'HR'];
     for (const country of eurozone) {
       expect(getCurrencyForCountry(country)).toBe('eur');
     }

--- a/src/__tests__/lib/currency.test.ts
+++ b/src/__tests__/lib/currency.test.ts
@@ -23,11 +23,27 @@ describe('getCurrencyForCountry', () => {
     expect(getCurrencyForCountry('FR')).toBe('eur');
   });
 
-  it('returns EUR for all 20 Eurozone countries', () => {
-    const eurozone = ['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT', 'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY', 'HR'];
-    for (const country of eurozone) {
+  it('returns EUR for all European countries (except CH/LI/GB)', () => {
+    const european = [
+      // Eurozone
+      'AT', 'BE', 'CY', 'DE', 'EE', 'ES', 'FI', 'FR', 'GR', 'HR',
+      'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PT', 'SI', 'SK',
+      // EU non-Eurozone
+      'BG', 'CZ', 'DK', 'HU', 'PL', 'RO', 'SE',
+      // Non-EU European
+      'AD', 'AL', 'BA', 'BY', 'FO', 'IS', 'MC', 'MD', 'ME', 'MK',
+      'NO', 'RS', 'SM', 'TR', 'UA', 'VA', 'XK',
+    ];
+    for (const country of european) {
       expect(getCurrencyForCountry(country)).toBe('eur');
     }
+  });
+
+  it('returns EUR for non-Eurozone European countries', () => {
+    expect(getCurrencyForCountry('NO')).toBe('eur');
+    expect(getCurrencyForCountry('SE')).toBe('eur');
+    expect(getCurrencyForCountry('PL')).toBe('eur');
+    expect(getCurrencyForCountry('UA')).toBe('eur');
   });
 
   it('returns USD for United States', () => {

--- a/src/__tests__/lib/currency.test.ts
+++ b/src/__tests__/lib/currency.test.ts
@@ -1,0 +1,60 @@
+// Implements REQ-SUB-020
+import { describe, it, expect } from 'vitest';
+import { getCurrencyForCountry, SUPPORTED_CURRENCIES } from '../../lib/currency';
+
+describe('getCurrencyForCountry', () => {
+  it('returns CHF for Switzerland', () => {
+    expect(getCurrencyForCountry('CH')).toBe('chf');
+  });
+
+  it('returns CHF for Liechtenstein', () => {
+    expect(getCurrencyForCountry('LI')).toBe('chf');
+  });
+
+  it('returns GBP for United Kingdom', () => {
+    expect(getCurrencyForCountry('GB')).toBe('gbp');
+  });
+
+  it('returns EUR for Germany', () => {
+    expect(getCurrencyForCountry('DE')).toBe('eur');
+  });
+
+  it('returns EUR for France', () => {
+    expect(getCurrencyForCountry('FR')).toBe('eur');
+  });
+
+  it('returns EUR for all 19 Eurozone countries', () => {
+    const eurozone = ['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT', 'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY'];
+    for (const country of eurozone) {
+      expect(getCurrencyForCountry(country)).toBe('eur');
+    }
+  });
+
+  it('returns USD for United States', () => {
+    expect(getCurrencyForCountry('US')).toBe('usd');
+  });
+
+  it('returns USD for unknown country codes', () => {
+    expect(getCurrencyForCountry('JP')).toBe('usd');
+    expect(getCurrencyForCountry('BR')).toBe('usd');
+    expect(getCurrencyForCountry('AU')).toBe('usd');
+    expect(getCurrencyForCountry('XX')).toBe('usd');
+  });
+
+  it('returns USD for empty string', () => {
+    expect(getCurrencyForCountry('')).toBe('usd');
+  });
+});
+
+describe('SUPPORTED_CURRENCIES', () => {
+  it('contains exactly 4 currencies', () => {
+    expect(SUPPORTED_CURRENCIES).toHaveLength(4);
+  });
+
+  it('includes chf, usd, eur, gbp', () => {
+    expect(SUPPORTED_CURRENCIES).toContain('chf');
+    expect(SUPPORTED_CURRENCIES).toContain('usd');
+    expect(SUPPORTED_CURRENCIES).toContain('eur');
+    expect(SUPPORTED_CURRENCIES).toContain('gbp');
+  });
+});

--- a/src/__tests__/lib/stripe.test.ts
+++ b/src/__tests__/lib/stripe.test.ts
@@ -487,3 +487,155 @@ describe('fetchSubscription', () => {
     expect(snapshot!.billingPeriodEnd).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// REQ-SUB-020: Multi-currency pricing
+// ---------------------------------------------------------------------------
+
+describe('createCheckoutSession with currency', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('passes currency as top-level param when provided', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'cs_eur', url: 'https://checkout.stripe.com/eur' }), { status: 200 }),
+    ) as typeof globalThis.fetch;
+
+    await createCheckoutSession({
+      priceId: 'price_test_123',
+      customerEmail: 'user@example.com',
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+      secretKey: 'sk_test_key',
+      currency: 'eur',
+    });
+
+    const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = fetchCall[1].body as string;
+    expect(body).toContain('currency=eur');
+  });
+
+  it('does NOT include currency param when not provided', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'cs_default', url: 'https://checkout.stripe.com/default' }), { status: 200 }),
+    ) as typeof globalThis.fetch;
+
+    await createCheckoutSession({
+      priceId: 'price_test_123',
+      customerEmail: 'user@example.com',
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+      secretKey: 'sk_test_key',
+    });
+
+    const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = fetchCall[1].body as string;
+    expect(body).not.toContain('currency=');
+  });
+});
+
+describe('getStripePrices with currency', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    // Clear the module-level price cache between tests
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('expands currency_options when fetching prices', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({
+        unit_amount: 2400,
+        currency: 'chf',
+        currency_options: {
+          usd: { unit_amount: 2400 },
+          eur: { unit_amount: 2400 },
+          gbp: { unit_amount: 2400 },
+        },
+      }), { status: 200 }),
+    ) as typeof globalThis.fetch;
+
+    // Re-import to get fresh cache
+    const { getStripePrices } = await import('../../lib/stripe');
+    await getStripePrices(['price_test'], 'sk_test_key');
+
+    const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[0]).toContain('expand');
+    expect(fetchCall[0]).toContain('currency_options');
+  });
+
+  it('returns base currency amount when no currency specified', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({
+        unit_amount: 2400,
+        currency: 'chf',
+        currency_options: {
+          usd: { unit_amount: 2400 },
+          eur: { unit_amount: 2400 },
+        },
+      }), { status: 200 }),
+    ) as typeof globalThis.fetch;
+
+    const { getStripePrices } = await import('../../lib/stripe');
+    const result = await getStripePrices(['price_test'], 'sk_test_key');
+
+    const price = result.get('price_test');
+    expect(price).toBeDefined();
+    expect(price!.currency).toBe('CHF');
+    expect(price!.amount).toBe(2400);
+  });
+
+  it('returns currency_options amount when currency is specified', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({
+        unit_amount: 2400,
+        currency: 'chf',
+        currency_options: {
+          usd: { unit_amount: 2400 },
+          eur: { unit_amount: 2400 },
+          gbp: { unit_amount: 2400 },
+        },
+      }), { status: 200 }),
+    ) as typeof globalThis.fetch;
+
+    const { getStripePrices } = await import('../../lib/stripe');
+    const result = await getStripePrices(['price_test'], 'sk_test_key', 'eur');
+
+    const price = result.get('price_test');
+    expect(price).toBeDefined();
+    expect(price!.currency).toBe('EUR');
+    expect(price!.amount).toBe(2400);
+  });
+
+  it('falls back to base currency when requested currency not in options', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({
+        unit_amount: 2400,
+        currency: 'chf',
+        currency_options: {
+          usd: { unit_amount: 2400 },
+        },
+      }), { status: 200 }),
+    ) as typeof globalThis.fetch;
+
+    const { getStripePrices } = await import('../../lib/stripe');
+    const result = await getStripePrices(['price_test'], 'sk_test_key', 'jpy');
+
+    const price = result.get('price_test');
+    expect(price).toBeDefined();
+    expect(price!.currency).toBe('CHF');
+    expect(price!.amount).toBe(2400);
+  });
+});

--- a/src/__tests__/routes/auth.test.ts
+++ b/src/__tests__/routes/auth.test.ts
@@ -21,6 +21,15 @@ vi.mock('../../lib/access', () => ({
   }),
 }));
 
+const mockGetStripePrices = vi.fn(async () => new Map());
+vi.mock('../../lib/stripe', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/stripe')>();
+  return {
+    ...actual,
+    getStripePrices: mockGetStripePrices,
+  };
+});
+
 // Import after mock
 import authRoutes from '../../routes/auth';
 
@@ -188,6 +197,58 @@ describe('Auth routes', () => {
       expect(body.accessTier).toBe('advanced');
       expect(body.subscriptionTier).toBe('advanced');
       expect(body.role).toBe('user');
+    });
+  });
+
+  // REQ-SUB-020: Multi-currency pricing
+  describe('GET /tiers currency detection', () => {
+    it('passes detected EUR currency to getStripePrices for German visitor', async () => {
+      // Seed tier config with Stripe price IDs
+      const { getDefaultTiers, resetTierConfigCache } = await import('../../lib/subscription');
+      resetTierConfigCache();
+      const tiersWithPrices = getDefaultTiers().map((t) => {
+        if (t.id === 'standard') return { ...t, stripePriceId: 'price_std' };
+        return t;
+      });
+      mockKV._set('tiers:config', tiersWithPrices);
+
+      mockGetStripePrices.mockResolvedValue(
+        new Map([['price_std', { amount: 2400, currency: 'EUR' }]]),
+      );
+
+      const app = createApp({ STRIPE_SECRET_KEY: 'sk_test_123' });
+      await app.request('/auth/tiers', {
+        headers: { 'CF-IPCountry': 'DE' },
+      });
+
+      expect(mockGetStripePrices).toHaveBeenCalledWith(
+        expect.any(Array),
+        'sk_test_123',
+        'eur',
+      );
+    });
+
+    it('passes USD currency when CF-IPCountry is absent', async () => {
+      const { getDefaultTiers, resetTierConfigCache } = await import('../../lib/subscription');
+      resetTierConfigCache();
+      const tiersWithPrices = getDefaultTiers().map((t) => {
+        if (t.id === 'standard') return { ...t, stripePriceId: 'price_std' };
+        return t;
+      });
+      mockKV._set('tiers:config', tiersWithPrices);
+
+      mockGetStripePrices.mockResolvedValue(
+        new Map([['price_std', { amount: 2400, currency: 'USD' }]]),
+      );
+
+      const app = createApp({ STRIPE_SECRET_KEY: 'sk_test_123' });
+      await app.request('/auth/tiers');
+
+      expect(mockGetStripePrices).toHaveBeenCalledWith(
+        expect.any(Array),
+        'sk_test_123',
+        'usd',
+      );
     });
   });
 });

--- a/src/__tests__/routes/billing.test.ts
+++ b/src/__tests__/routes/billing.test.ts
@@ -152,6 +152,68 @@ describe('POST /billing/checkout', () => {
 
     expect(res.status).toBe(400);
   });
+
+  // REQ-SUB-020: Multi-currency pricing
+  it('passes detected currency from CF-IPCountry to createCheckoutSession', async () => {
+    const { app } = createApp();
+    await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-IPCountry': 'DE',
+      },
+      body: JSON.stringify({ tier: 'standard', mode: 'default' }),
+    });
+
+    expect(createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: 'eur' }),
+    );
+  });
+
+  it('defaults to USD currency when CF-IPCountry is absent', async () => {
+    const { app } = createApp();
+    await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tier: 'standard', mode: 'default' }),
+    });
+
+    expect(createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: 'usd' }),
+    );
+  });
+
+  it('passes CHF for Swiss visitors', async () => {
+    const { app } = createApp();
+    await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-IPCountry': 'CH',
+      },
+      body: JSON.stringify({ tier: 'standard', mode: 'default' }),
+    });
+
+    expect(createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: 'chf' }),
+    );
+  });
+
+  it('passes GBP for UK visitors', async () => {
+    const { app } = createApp();
+    await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-IPCountry': 'GB',
+      },
+      body: JSON.stringify({ tier: 'standard', mode: 'default' }),
+    });
+
+    expect(createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: 'gbp' }),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -11,14 +11,14 @@ const EUR_COUNTRIES = new Set([
   // EU members outside Eurozone
   'BG', 'CZ', 'DK', 'HU', 'PL', 'RO', 'SE',
   // Non-EU European
-  'AD', 'AL', 'BA', 'BY', 'FO', 'IS', 'MC', 'MD', 'ME', 'MK',
-  'NO', 'RS', 'SM', 'TR', 'UA', 'VA', 'XK',
+  'AD', 'AL', 'AX', 'BA', 'BY', 'FO', 'IS', 'MC', 'MD', 'ME',
+  'MK', 'NO', 'RS', 'SJ', 'SM', 'TR', 'UA', 'VA', 'XK',
 ]);
 
 /** Map a 2-letter ISO country code to a supported currency. */
 export function getCurrencyForCountry(country: string): SupportedCurrency {
   if (country === 'CH' || country === 'LI') return 'chf';
-  if (country === 'GB') return 'gbp';
+  if (country === 'GB' || country === 'GI' || country === 'GG' || country === 'JE' || country === 'IM') return 'gbp';
   if (EUR_COUNTRIES.has(country)) return 'eur';
   return 'usd';
 }

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -5,7 +5,7 @@ export type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number];
 
 const EUR_COUNTRIES = new Set([
   'DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT',
-  'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY',
+  'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY', 'HR',
 ]);
 
 /** Map a 2-letter ISO country code to a supported currency. */

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -3,9 +3,16 @@
 export const SUPPORTED_CURRENCIES = ['chf', 'usd', 'eur', 'gbp'] as const;
 export type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number];
 
+/** All European countries default to EUR (except CH/LI → CHF, GB → GBP). */
 const EUR_COUNTRIES = new Set([
-  'DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT',
-  'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY', 'HR',
+  // Eurozone members
+  'AT', 'BE', 'CY', 'DE', 'EE', 'ES', 'FI', 'FR', 'GR', 'HR',
+  'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PT', 'SI', 'SK',
+  // EU members outside Eurozone
+  'BG', 'CZ', 'DK', 'HU', 'PL', 'RO', 'SE',
+  // Non-EU European
+  'AD', 'AL', 'BA', 'BY', 'FO', 'IS', 'MC', 'MD', 'ME', 'MK',
+  'NO', 'RS', 'SM', 'TR', 'UA', 'VA', 'XK',
 ]);
 
 /** Map a 2-letter ISO country code to a supported currency. */

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,17 @@
+// Implements REQ-SUB-020
+
+export const SUPPORTED_CURRENCIES = ['chf', 'usd', 'eur', 'gbp'] as const;
+export type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number];
+
+const EUR_COUNTRIES = new Set([
+  'DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT',
+  'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY',
+]);
+
+/** Map a 2-letter ISO country code to a supported currency. */
+export function getCurrencyForCountry(country: string): SupportedCurrency {
+  if (country === 'CH' || country === 'LI') return 'chf';
+  if (country === 'GB') return 'gbp';
+  if (EUR_COUNTRIES.has(country)) return 'eur';
+  return 'usd';
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -46,14 +46,24 @@ export function isStripeConfigured(env: Pick<Env, 'STRIPE_SECRET_KEY'>): boolean
 // Stripe Price fetching — for displaying prices on subscribe page
 // ---------------------------------------------------------------------------
 
-/** Cached Stripe price data (1-hour TTL) */
-const priceCache = new Map<string, { amount: number; currency: string; cachedAt: number }>();
+/** Cached Stripe price data (1-hour TTL) — stores base + currency_options */
+interface CachedPrice {
+  amount: number;
+  currency: string;
+  currencyOptions?: Record<string, { unit_amount: number }>;
+  cachedAt: number;
+}
+const priceCache = new Map<string, CachedPrice>();
 const PRICE_CACHE_TTL_MS = 3_600_000; // 1 hour
 
-/** Fetch price amount + currency from Stripe API for multiple price IDs. */
+/**
+ * Fetch price amount + currency from Stripe API for multiple price IDs.
+ * When `currency` is provided, returns the amount from currency_options if available.
+ */
 export async function getStripePrices(
   priceIds: string[],
   secretKey: string,
+  currency?: string,
 ): Promise<Map<string, { amount: number; currency: string }>> {
   const result = new Map<string, { amount: number; currency: string }>();
   const now = Date.now();
@@ -63,26 +73,38 @@ export async function getStripePrices(
   for (const id of priceIds) {
     const cached = priceCache.get(id);
     if (cached && now - cached.cachedAt < PRICE_CACHE_TTL_MS) {
-      result.set(id, { amount: cached.amount, currency: cached.currency });
+      result.set(id, selectCurrency(cached, currency));
     } else {
       toFetch.push(id);
     }
   }
 
-  // Fetch uncached prices in parallel
+  // Fetch uncached prices in parallel (expand currency_options for multi-currency)
   if (toFetch.length > 0) {
     const fetches = toFetch.map(async (id) => {
       try {
-        const response = await fetch(`https://api.stripe.com/v1/prices/${id}`, {
-          headers: { 'Authorization': `Bearer ${secretKey}` },
-          signal: AbortSignal.timeout(10_000),
-        });
+        const response = await fetch(
+          `https://api.stripe.com/v1/prices/${id}?expand[]=currency_options`,
+          {
+            headers: { 'Authorization': `Bearer ${secretKey}` },
+            signal: AbortSignal.timeout(10_000),
+          },
+        );
         if (response.ok) {
-          const data = await response.json() as { unit_amount?: number; currency?: string };
+          const data = await response.json() as {
+            unit_amount?: number;
+            currency?: string;
+            currency_options?: Record<string, { unit_amount: number }>;
+          };
           if (data.unit_amount != null && data.currency) {
-            const entry = { amount: data.unit_amount, currency: data.currency.toUpperCase() };
-            priceCache.set(id, { ...entry, cachedAt: now });
-            result.set(id, entry);
+            const cached: CachedPrice = {
+              amount: data.unit_amount,
+              currency: data.currency.toUpperCase(),
+              currencyOptions: data.currency_options,
+              cachedAt: now,
+            };
+            priceCache.set(id, cached);
+            result.set(id, selectCurrency(cached, currency));
           }
         }
       } catch { /* non-fatal — price just won't be displayed */ }
@@ -91,6 +113,24 @@ export async function getStripePrices(
   }
 
   return result;
+}
+
+/** Pick the right amount/currency from cached price data. */
+function selectCurrency(
+  cached: CachedPrice,
+  currency?: string,
+): { amount: number; currency: string } {
+  if (currency) {
+    const key = currency.toLowerCase();
+    if (key === cached.currency.toLowerCase()) {
+      return { amount: cached.amount, currency: cached.currency };
+    }
+    const opt = cached.currencyOptions?.[key];
+    if (opt) {
+      return { amount: opt.unit_amount, currency: key.toUpperCase() };
+    }
+  }
+  return { amount: cached.amount, currency: cached.currency };
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +188,8 @@ interface CheckoutSessionOptions {
   trialDays?: number;
   /** Trial compute quota in hours — shown in checkout custom text. */
   trialQuotaHours?: number;
+  /** ISO 4217 currency code (lowercase). Selects from Price's currency_options. */
+  currency?: string;
 }
 
 interface CheckoutSessionResult {
@@ -165,6 +207,10 @@ export async function createCheckoutSession(opts: CheckoutSessionOptions): Promi
     'cancel_url': opts.cancelUrl,
     'customer_email': opts.customerEmail,
   };
+
+  if (opts.currency) {
+    params['currency'] = opts.currency;
+  }
 
   if (opts.metadata) {
     for (const [key, value] of Object.entries(opts.metadata)) {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -46,6 +46,8 @@ export function isStripeConfigured(env: Pick<Env, 'STRIPE_SECRET_KEY'>): boolean
 // Stripe Price fetching — for displaying prices on subscribe page
 // ---------------------------------------------------------------------------
 
+// Implements REQ-SUB-020
+
 /** Cached Stripe price data (1-hour TTL) — stores base + currency_options */
 interface CachedPrice {
   amount: number;
@@ -224,7 +226,7 @@ export async function createCheckoutSession(opts: CheckoutSessionOptions): Promi
   }
 
   // CF-030: Derive idempotency key to prevent duplicate checkout sessions on retry
-  const idempotencyInput = `${opts.customerEmail}:${opts.priceId}:${Math.floor(Date.now() / 60000)}`;
+  const idempotencyInput = `${opts.customerEmail}:${opts.priceId}:${opts.currency ?? ''}:${Math.floor(Date.now() / 60000)}`;
   const idempotencyBytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(idempotencyInput));
   const idempotencyKey = Array.from(new Uint8Array(idempotencyBytes)).map(b => b.toString(16).padStart(2, '0')).join('');
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -15,17 +15,9 @@ import { updateUserRecord } from '../lib/user-record';
 import { parseJsonBody, firstZodError } from '../lib/request-helpers';
 import { getPreferencesKey, SETUP_KEYS } from '../lib/kv-keys';
 import { isStripeConfigured, getStripePrices } from '../lib/stripe';
+import { getCurrencyForCountry } from '../lib/currency';
 
 const logger = createLogger('auth-routes');
-
-/** Map country code to currency for subscription email formatting. */
-const EUR_COUNTRIES = new Set(['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'FI', 'PT', 'GR', 'LU', 'SI', 'SK', 'EE', 'LV', 'LT', 'MT', 'CY']);
-function getCurrencyForCountry(country: string): string {
-  if (country === 'CH' || country === 'LI') return 'CHF';
-  if (country === 'GB') return 'GBP';
-  if (EUR_COUNTRIES.has(country)) return 'EUR';
-  return 'USD';
-}
 
 const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
 
@@ -53,14 +45,16 @@ app.get('/tiers', requireIdentity, async (c) => {
     return !!t.stripePriceId;
   });
 
-  // Enrich with Stripe prices when configured
+  // Enrich with Stripe prices when configured (REQ-SUB-020: detect visitor currency)
   if (isStripeConfigured(c.env) && c.env.STRIPE_SECRET_KEY) {
+    const country = c.req.header('CF-IPCountry') || '';
+    const currency = getCurrencyForCountry(country);
     const priceIds = subscribable.flatMap((t) =>
       [t.stripePriceId, t.stripeAdvancedPriceId].filter((id): id is string => !!id)
     );
     if (priceIds.length > 0) {
       try {
-        const prices = await getStripePrices(priceIds, c.env.STRIPE_SECRET_KEY);
+        const prices = await getStripePrices(priceIds, c.env.STRIPE_SECRET_KEY, currency);
         const enriched = subscribable.map((t) => {
           const stdPrice = t.stripePriceId ? prices.get(t.stripePriceId) : undefined;
           const advPrice = t.stripeAdvancedPriceId ? prices.get(t.stripeAdvancedPriceId) : undefined;
@@ -360,7 +354,7 @@ app.post('/subscribe', requireIdentity, subscribeRateLimiter, async (c) => {
       ? (tierConfig?.advancedPriceMonthly ?? tierConfig?.priceMonthly)
       : tierConfig?.priceMonthly;
     const priceStr = priceCents != null && priceCents > 0
-      ? `${cur === 'EUR' ? '\u20AC' : cur === 'GBP' ? '\u00A3' : cur === 'CHF' ? 'CHF ' : '$'}${(priceCents / 100).toFixed(0)}`
+      ? `${cur === 'eur' ? '\u20AC' : cur === 'gbp' ? '\u00A3' : cur === 'chf' ? 'CHF ' : '$'}${(priceCents / 100).toFixed(0)}`
       : undefined;
     const emailMonthlyHours = tierConfig?.monthlySeconds != null ? `${Math.round(tierConfig.monthlySeconds / 3600)}h` : 'Unlimited';
     const emailMaxSessions = tierConfig?.maxSessions ?? 1;

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -23,6 +23,7 @@ import {
   createSwitchPortalSession,
   fetchSubscription,
 } from '../lib/stripe';
+import { getCurrencyForCountry } from '../lib/currency';
 import { parseJsonBody, firstZodError } from '../lib/request-helpers';
 
 const logger = createLogger('billing');
@@ -94,6 +95,10 @@ app.post('/checkout', requireIdentity, checkoutRateLimiter, async (c) => {
   const tierConfig = tiers.find(t => t.id === tier);
   const trialQuotaHours = tierConfig?.trialQuotaHours ?? 4;
 
+  // REQ-SUB-020: detect visitor currency from Cloudflare geo header
+  const country = c.req.header('CF-IPCountry') || '';
+  const currency = getCurrencyForCountry(country);
+
   const session = await createCheckoutSession({
     priceId,
     customerEmail: user.email,
@@ -103,6 +108,7 @@ app.post('/checkout', requireIdentity, checkoutRateLimiter, async (c) => {
     metadata: { tier, mode, email: user.email },
     trialDays: trialUsed ? undefined : 7,
     trialQuotaHours: trialUsed ? undefined : trialQuotaHours,
+    currency,
   });
 
   // Store checkoutSessionId on user KV (non-fatal)


### PR DESCRIPTION
## Summary
- Auto-detect visitor currency from `CF-IPCountry` header (CHF, USD, EUR, GBP)
- Pass `currency` to Stripe Checkout Session via `currency_options` on existing Price objects
- Expand `currency_options` when fetching prices for the subscribe page so visitors see prices in their local currency
- All European countries default to EUR, British territories to GBP, CH/LI to CHF, rest of world to USD

## Changes
- **`src/lib/currency.ts`** (new) — shared `getCurrencyForCountry()` with 46 European country codes
- **`src/lib/stripe.ts`** — `getStripePrices()` expands `currency_options`, `createCheckoutSession()` accepts `currency`
- **`src/routes/auth.ts`** — tiers endpoint passes detected currency to price fetching
- **`src/routes/billing.ts`** — checkout endpoint passes detected currency to Stripe
- **`sdd/subscription.md`** — REQ-SUB-020 added, multi-currency removed from Out of Scope
- **`documentation/`** — architecture and auth docs updated with currency detection flow

## Test plan
- [ ] CI green (unit tests for currency detection, Stripe price fetching, checkout passthrough)
- [ ] Deploy to staging
- [ ] Verify subscribe page shows EUR for German IP, USD for US IP, CHF for Swiss IP
- [ ] Complete checkout from non-CHF IP — verify Stripe charges in detected currency
- [ ] Verify bank statement shows charge in displayed currency (no FX conversion)

Closes #181