### PR TITLE
refactor: subscribe page layout + dashboard/storage spacing polish

### DIFF
--- a/web-ui/src/components/SubscribePage.tsx
+++ b/web-ui/src/components/SubscribePage.tsx
@@ -830,7 +830,7 @@ const SubscribePage: Component = () => {
                           </For>
                         </ul>
                         <p class="subscribe-mode-card-feature" style={{ "margin-top": "1rem", color: "rgba(113, 113, 122, 0.6)", display: "block" }}>
-                          Pro features are designed for claude-code. Other agents receive rules and agent definitions but may not support all capabilities.
+                          Pro features are designed for Claude Code. Other agents receive rules and agent definitions but may not support all capabilities.
                         </p>
                       </div>
                     </div>

--- a/web-ui/src/components/SubscribePage.tsx
+++ b/web-ui/src/components/SubscribePage.tsx
@@ -658,118 +658,10 @@ const SubscribePage: Component = () => {
               </div>
             </Show>
 
-            {/* ── Tier selection: mode cards + lifeline + detail — all visible ── */}
+            {/* ── Tier selection: detail panel → lifeline → mode section ── */}
             <Show when={subscribePhase() === 'tiers'}>
               <div ref={tierPhaseRef}>
-                {/* Merged mode card with Standard/Pro toggle */}
-                <div class="subscribe-mode-card-merged" data-testid="mode-chooser">
-                  {/* Mode toggle at top */}
-                  <div class="subscribe-mode-toggle">
-                    <button
-                      type="button"
-                      class="subscribe-mode-toggle-btn"
-                      classList={{
-                        'subscribe-mode-toggle-btn--active': globalMode() === 'default',
-                        'subscribe-mode-toggle-btn--current': isActive() && currentMode() === 'default',
-                      }}
-                      data-testid="mode-card-standard"
-                      onClick={() => setGlobalMode('default')}
-                    >
-                      Standard
-                    </button>
-                    <button
-                      type="button"
-                      class="subscribe-mode-toggle-btn"
-                      classList={{
-                        'subscribe-mode-toggle-btn--active': globalMode() === 'advanced',
-                        'subscribe-mode-toggle-btn--current': isActive() && currentMode() === 'advanced',
-                        'subscribe-mode-toggle-btn--disabled': !selectedTierSupportsPro(),
-                      }}
-                      data-testid="mode-card-pro"
-                      disabled={!selectedTierSupportsPro()}
-                      onClick={() => {
-                        if (!selectedTierSupportsPro()) return;
-                        setGlobalMode('advanced');
-                      }}
-                    >
-                      Pro
-                    </button>
-                  </div>
-
-                  {/* Standard features (always visible) */}
-                  <ul class="subscribe-mode-card-features">
-                    <For each={STANDARD_MODE_FEATURES}>
-                      {(f) => (
-                        <li class="subscribe-mode-card-feature">
-                          <Icon path={f.icon} size={16} />
-                          <span>{typeof f.text === 'function' ? f.text() : f.text}</span>
-                        </li>
-                      )}
-                    </For>
-                  </ul>
-                  <p class="subscribe-mode-card-feature" style={{ "margin-top": "1rem", color: "rgba(113, 113, 122, 0.6)", display: "block" }}>
-                    Voice input requires a compatible browser like Chrome or Samsung Internet.
-                  </p>
-                  <p class="subscribe-mode-card-feature" style={{ "margin-top": "0.5rem", color: "rgba(113, 113, 122, 0.6)", display: "block" }}>
-                    Coding agent subscription is <span style={{ color: '#22c55e', "font-weight": "700" }}>NOT INCLUDED</span>, bring your own.
-                  </p>
-
-                  {/* Pro features (animated expand/collapse) */}
-                  <div class={`subscribe-pro-expand ${globalMode() === 'advanced' ? 'subscribe-pro-expand--open' : ''}`}>
-                    <div class="subscribe-pro-expand-inner">
-                      <div class="subscribe-mode-separator" />
-                      <p class="subscribe-mode-pro-label">{scrambledProLabel()}</p>
-                      <ul class="subscribe-mode-card-features subscribe-mode-card-features--pro">
-                        <For each={PRO_MODE_FEATURES}>
-                          {(f, i) => (
-                            <li class="subscribe-mode-card-feature">
-                              <Icon path={f.icon} size={16} />
-                              <span>{scrambledProFeatures[i()]()}</span>
-                            </li>
-                          )}
-                        </For>
-                      </ul>
-                      <p class="subscribe-mode-card-feature" style={{ "margin-top": "1rem", color: "rgba(113, 113, 122, 0.6)", display: "block" }}>
-                        Pro features are designed for Claude Code. Other agents receive rules and agent definitions but may not support all capabilities.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Lifeline — CSS dashed line through icon centers */}
-                <div class="subscribe-lifeline" data-testid="lifeline-rail">
-                  <div class="subscribe-lifeline-track" />
-                  <div class="subscribe-lifeline-stops">
-                    <For each={[...TIER_ORDER]}>
-                      {(tierId) => {
-                        const tierData = () => tiers().find(t => t.id === tierId);
-                        return (
-                          <Show when={tierData()}>
-                            {(td) => (
-                              <button
-                                type="button"
-                                class="subscribe-lifeline-stop"
-                                classList={{
-                                  'subscribe-lifeline-stop--selected': selectedTierId() === tierId,
-                                  'subscribe-lifeline-stop--passed': TIER_ORDER.indexOf(tierId as typeof TIER_ORDER[number]) <= TIER_ORDER.indexOf(selectedTierId() as typeof TIER_ORDER[number]),
-                                }}
-                                onClick={() => setSelectedTierId(tierId)}
-                                data-testid={`lifeline-stop-${tierId}`}
-                              >
-                                <span class={`subscribe-lifeline-icon ${isActive() && currentTierId() === tierId ? 'subscribe-lifeline-icon--current' : ''}`}>
-                                  <Icon path={TIER_ICONS[tierId] ?? mdiStarOutline} size={20} />
-                                </span>
-                                <span class="subscribe-lifeline-label">{td().displayName}</span>
-                              </button>
-                            )}
-                          </Show>
-                        );
-                      }}
-                    </For>
-                  </div>
-                </div>
-
-                {/* Detail panel for selected tier */}
+                {/* Detail panel for selected tier — TOP */}
                 <Show when={selectedTier()} fallback={
                   <div class="subscribe-error">No subscription tiers available.</div>
                 }>
@@ -854,6 +746,116 @@ const SubscribePage: Component = () => {
                     <div class="cf-turnstile" data-sitekey={turnstileSiteKey()} data-callback="onTurnstileSuccess" />
                   </div>
                 </Show>
+
+                {/* Lifeline — CSS dashed line through icon centers */}
+                <div class="subscribe-lifeline" data-testid="lifeline-rail">
+                  <div class="subscribe-lifeline-track" />
+                  <div class="subscribe-lifeline-stops">
+                    <For each={[...TIER_ORDER]}>
+                      {(tierId) => {
+                        const tierData = () => tiers().find(t => t.id === tierId);
+                        return (
+                          <Show when={tierData()}>
+                            {(td) => (
+                              <button
+                                type="button"
+                                class="subscribe-lifeline-stop"
+                                classList={{
+                                  'subscribe-lifeline-stop--selected': selectedTierId() === tierId,
+                                  'subscribe-lifeline-stop--passed': TIER_ORDER.indexOf(tierId as typeof TIER_ORDER[number]) <= TIER_ORDER.indexOf(selectedTierId() as typeof TIER_ORDER[number]),
+                                }}
+                                onClick={() => setSelectedTierId(tierId)}
+                                data-testid={`lifeline-stop-${tierId}`}
+                              >
+                                <span class={`subscribe-lifeline-icon ${isActive() && currentTierId() === tierId ? 'subscribe-lifeline-icon--current' : ''}`}>
+                                  <Icon path={TIER_ICONS[tierId] ?? mdiStarOutline} size={20} />
+                                </span>
+                                <span class="subscribe-lifeline-label">{td().displayName}</span>
+                              </button>
+                            )}
+                          </Show>
+                        );
+                      }}
+                    </For>
+                  </div>
+                </div>
+
+                {/* Mode section — toggle + Pro card (animated) + Standard card */}
+                <div class="subscribe-mode-section" data-testid="mode-chooser">
+                  <div class="subscribe-mode-toggle">
+                    <button
+                      type="button"
+                      class="subscribe-mode-toggle-btn"
+                      classList={{
+                        'subscribe-mode-toggle-btn--active': globalMode() === 'default',
+                        'subscribe-mode-toggle-btn--current': isActive() && currentMode() === 'default',
+                      }}
+                      data-testid="mode-card-standard"
+                      onClick={() => setGlobalMode('default')}
+                    >
+                      Standard
+                    </button>
+                    <button
+                      type="button"
+                      class="subscribe-mode-toggle-btn"
+                      classList={{
+                        'subscribe-mode-toggle-btn--active': globalMode() === 'advanced',
+                        'subscribe-mode-toggle-btn--current': isActive() && currentMode() === 'advanced',
+                        'subscribe-mode-toggle-btn--disabled': !selectedTierSupportsPro(),
+                      }}
+                      data-testid="mode-card-pro"
+                      disabled={!selectedTierSupportsPro()}
+                      onClick={() => {
+                        if (!selectedTierSupportsPro()) return;
+                        setGlobalMode('advanced');
+                      }}
+                    >
+                      Pro
+                    </button>
+                  </div>
+
+                  {/* Pro card — animates in above Standard */}
+                  <div class={`subscribe-pro-expand ${globalMode() === 'advanced' ? 'subscribe-pro-expand--open' : ''}`}>
+                    <div class="subscribe-pro-expand-inner">
+                      <div class="subscribe-mode-card subscribe-mode-card--pro">
+                        <p class="subscribe-mode-pro-label">{scrambledProLabel()}</p>
+                        <ul class="subscribe-mode-card-features subscribe-mode-card-features--pro">
+                          <For each={PRO_MODE_FEATURES}>
+                            {(f, i) => (
+                              <li class="subscribe-mode-card-feature">
+                                <Icon path={f.icon} size={16} />
+                                <span>{scrambledProFeatures[i()]()}</span>
+                              </li>
+                            )}
+                          </For>
+                        </ul>
+                        <p class="subscribe-mode-card-feature" style={{ "margin-top": "1rem", color: "rgba(113, 113, 122, 0.6)", display: "block" }}>
+                          Pro features are designed for claude-code. Other agents receive rules and agent definitions but may not support all capabilities.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Standard card — always visible */}
+                  <div class="subscribe-mode-card subscribe-mode-card--standard">
+                    <ul class="subscribe-mode-card-features">
+                      <For each={STANDARD_MODE_FEATURES}>
+                        {(f) => (
+                          <li class="subscribe-mode-card-feature">
+                            <Icon path={f.icon} size={16} />
+                            <span>{typeof f.text === 'function' ? f.text() : f.text}</span>
+                          </li>
+                        )}
+                      </For>
+                    </ul>
+                    <p class="subscribe-mode-card-feature" style={{ "margin-top": "1rem", color: "rgba(113, 113, 122, 0.6)", display: "block" }}>
+                      Voice input requires a compatible browser like Chrome or Samsung Internet.
+                    </p>
+                    <p class="subscribe-mode-card-feature" style={{ "margin-top": "0.5rem", color: "rgba(113, 113, 122, 0.6)", display: "block" }}>
+                      Coding agent subscription is <span style={{ color: '#22c55e', "font-weight": "700" }}>NOT INCLUDED</span>, bring your own.
+                    </p>
+                  </div>
+                </div>
 
                 <button
                   type="button"

--- a/web-ui/src/styles/dashboard-card.css
+++ b/web-ui/src/styles/dashboard-card.css
@@ -16,9 +16,7 @@
 }
 
 .dashboard-card__text {
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  line-height: 1.6;
+  line-height: 1.75;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/web-ui/src/styles/dashboard-card.css
+++ b/web-ui/src/styles/dashboard-card.css
@@ -16,7 +16,9 @@
 }
 
 .dashboard-card__text {
-  line-height: 1.75;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/web-ui/src/styles/stat-cards.css
+++ b/web-ui/src/styles/stat-cards.css
@@ -52,7 +52,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-1) 0;
+  padding: 2px 0;
 }
 
 .stat-card__metric-label {

--- a/web-ui/src/styles/storage-browser.css
+++ b/web-ui/src/styles/storage-browser.css
@@ -185,8 +185,6 @@
   white-space: nowrap;
   font-size: var(--text-sm);
   color: var(--color-text-primary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
 .storage-item-size,

--- a/web-ui/src/styles/subscribe-page.css
+++ b/web-ui/src/styles/subscribe-page.css
@@ -91,18 +91,27 @@
 .subscribe-manage-button:hover { color: #ff9633; border-color: rgba(243, 128, 32, 0.5); }
 .subscribe-manage-button:disabled { opacity: 0.5; cursor: wait; }
 
-/* ── Merged mode card with Standard/Pro toggle ── */
+/* ── Mode section: toggle + Pro card + Standard card ── */
 
-.subscribe-mode-card-merged {
-  background: rgba(24, 24, 27, 0.7);
-  border: 1px solid var(--color-glass-border); border-radius: var(--radius-xl);
-  padding: var(--space-6); text-align: left; width: 100%; max-width: 420px;
+.subscribe-mode-section {
+  width: 100%; max-width: 420px;
   margin: 0 auto var(--space-6);
-  animation: fadeSlideIn 0.4s ease-out;
+  display: flex; flex-direction: column;
+  gap: var(--space-3);
+  animation: fadeSlideIn 0.5s ease-out 0.2s both;
+}
+
+.subscribe-mode-card {
+  background: rgba(24, 24, 27, 0.7);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  text-align: left;
+  width: 100%;
 }
 
 .subscribe-mode-toggle {
-  display: flex; gap: 0; margin-bottom: var(--space-4);
+  display: flex; gap: 0;
   border: 1px solid rgba(255, 255, 255, 0.1); border-radius: var(--radius-lg);
   overflow: hidden; background: rgba(24, 24, 27, 0.5);
 }
@@ -145,10 +154,6 @@
   box-shadow: 0 0 8px rgba(34, 197, 94, 0.3) !important;
 }
 
-.subscribe-mode-separator {
-  height: 1px; background: rgba(255, 255, 255, 0.06);
-  margin: var(--space-3) 0;
-}
 .subscribe-mode-pro-label {
   margin: 0 0 var(--space-2); font-size: var(--text-sm); color: var(--color-accent);
   font-weight: var(--font-medium); letter-spacing: 0.02em;
@@ -186,7 +191,7 @@
   padding: var(--space-8); margin-bottom: var(--space-8); width: 100%;
   max-width: 420px; margin-left: auto; margin-right: auto;
   text-align: center;
-  animation: fadeSlideIn 0.5s ease-out 0.1s both;
+  animation: fadeSlideIn 0.5s ease-out;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(59, 130, 246, 0.05) inset;
 }
 
@@ -247,7 +252,7 @@
 .subscribe-lifeline {
   position: relative; width: 100%; max-width: 540px;
   margin: var(--space-6) auto; padding-bottom: 0;
-  animation: fadeSlideIn 0.5s ease-out 0.2s both;
+  animation: fadeSlideIn 0.5s ease-out 0.1s both;
 }
 
 /* Dashed line through icon centers — pure CSS, no SVG alignment issues */
@@ -316,7 +321,7 @@
 /* ── Responsive ── */
 
 @media (max-width: 640px) {
-  .subscribe-mode-card-merged { padding: var(--space-4); }
+  .subscribe-mode-card { padding: var(--space-4); }
   .subscribe-detail-panel { padding: var(--space-4); }
   .subscribe-lifeline-label { font-size: 0.6rem; }
   .subscribe-lifeline-icon { width: 32px; height: 32px; }


### PR DESCRIPTION
## Summary

### Subscribe page restructure
Inverted the vertical order and split the merged mode card into separate animated cards so the plan decision is front-loaded.
- **New order**: detail panel (plans) → lifeline rail → mode section
- **Mode card split**: merged card replaced with toggle + Pro card (animated) + Standard card
- **Pro card slide-in animation**: reuses existing subscribe-pro-expand grid-template-rows transition (250ms ease-out) — Pro card grows from 0 to full height above Standard, pushing Standard down naturally
- Fade-slide-in animation delays staggered top-to-bottom: detail (0s), lifeline (0.1s), mode section (0.2s)
- All data-testids preserved: mode-chooser, mode-card-standard, mode-card-pro, lifeline-rail, lifeline-stop-*, tier-detail-panel
- Documentation updated: documentation/authentication.md Phase 2 section reflects new layout

### Dashboard and storage spacing polish
Iterative visual alignment after integration testing on mobile.
- **Metric card rows**: padding halved from var(--space-1) 0 to 2px 0 — tighter row spacing on R2 metrics and session metrics cards
- **R2 file names**: removed uppercase + letter-spacing (file names read as-is, no distortion)
- **Tips card text**: now identical style to metrics — uppercase, 0.05em letter-spacing, 1.4 line-height — for consistent dashboard hierarchy

## Test plan
- [x] Subscribe page: detail panel at top, lifeline in middle, mode toggle + Standard card at bottom
- [x] Click Pro toggle: Pro card slides in above Standard with smooth animation, both cards visible
- [x] Click Standard toggle: Pro card collapses upward
- [x] Free tier: Pro toggle disabled, clicking does nothing
- [x] Mobile: section stacking preserved, cards max-width 420px centered
- [x] prefers-reduced-motion: animations disabled
- [x] Dashboard: R2 metrics + session metrics rows tighter than before
- [x] Dashboard: tips card text matches metric text style (uppercase, same tracking)
- [x] R2 file browser: file names mixed case (not uppercased)