### PR TITLE
fix(web-ui): make Manage Users page scrollable

### DIFF
--- a/web-ui/src/components/admin/UserManagement.tsx
+++ b/web-ui/src/components/admin/UserManagement.tsx
@@ -195,6 +195,7 @@ const UserManagement: Component<UserManagementProps> = (props) => {
   };
 
   return (
+    <div class="user-mgmt-page">
     <div class="user-mgmt">
       {/* Header */}
       <div class="user-mgmt-header">
@@ -384,6 +385,7 @@ const UserManagement: Component<UserManagementProps> = (props) => {
           }}
         </For>
       </Show>
+    </div>
     </div>
   );
 };

--- a/web-ui/src/styles/user-management.css
+++ b/web-ui/src/styles/user-management.css
@@ -2,6 +2,18 @@
    User Management — admin panel for access tiers
    ========================================================================== */
 
+/* Outer page shell — fixed-viewport scroll container, mirrors .setup-wizard
+   so the page itself scrolls when the user list overflows the viewport. */
+.user-mgmt-page {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--color-bg-gradient);
+  overflow-y: auto;
+}
+
 .user-mgmt {
   width: 100%;
   max-width: 800px;


### PR DESCRIPTION
## Summary
- The `/admin/users` route mounted `.user-mgmt` directly with `width: 100%; max-width: 800px; margin: 0 auto` but no scroll context — once the user list overflowed the viewport, the bottom of the page was unreachable.
- Same class of bug we already solved for the Setup wizard (`web-ui/src/styles/setup-wizard.css:1-10`). Mirroring that pattern: outer `.user-mgmt-page` shell is `position: fixed; inset: 0; overflow-y: auto` with the background gradient, while `.user-mgmt` keeps its 800px max-width and centering.

## Test plan
- [ ] CI green
- [ ] Open `/admin/users` with enough seeded users to overflow the viewport — verify the page scrolls
- [ ] Verify the back button + header still render correctly at the top of the scroll

## Related — possible follow-up
The `/admin/subscriptions` page (`SubscriptionManagement.tsx` + `subscription-management.css`) has the same `.sub-mgmt { max-width / margin }` pattern with no scroll context. Likely the same bug will appear there once the content overflows; not fixed in this PR to keep the change scope-bounded.