### PR TITLE
Release: Manage Users page scrollable

### DIFF
--- a/web-ui/src/components/admin/UserManagement.tsx
+++ b/web-ui/src/components/admin/UserManagement.tsx
@@ -195,6 +195,7 @@ const UserManagement: Component<UserManagementProps> = (props) => {
   };
 
   return (
+    <div class="user-mgmt-page">
     <div class="user-mgmt">
       {/* Header */}
       <div class="user-mgmt-header">
@@ -384,6 +385,7 @@ const UserManagement: Component<UserManagementProps> = (props) => {
           }}
         </For>
       </Show>
+    </div>
     </div>
   );
 };

--- a/web-ui/src/styles/user-management.css
+++ b/web-ui/src/styles/user-management.css
@@ -2,6 +2,18 @@
    User Management — admin panel for access tiers
    ========================================================================== */
 
+/* Outer page shell — fixed-viewport scroll container, mirrors .setup-wizard
+   so the page itself scrolls when the user list overflows the viewport. */
+.user-mgmt-page {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--color-bg-gradient);
+  overflow-y: auto;
+}
+
 .user-mgmt {
   width: 100%;
   max-width: 800px;


### PR DESCRIPTION
## Summary
- Fix the `/admin/users` page scroll: when the user list overflowed the viewport, the bottom of the page was unreachable. Wraps `.user-mgmt` in an outer `.user-mgmt-page` shell that mirrors the existing `.setup-wizard` pattern (`position: fixed; inset: 0; overflow-y: auto`).

Closes #249.

## Test plan
- [ ] CI green
- [ ] Open `/admin/users` with enough seeded users to overflow the viewport — verify the page scrolls
- [ ] Back button + header still render at the top of the scroll

## Follow-up note
`/admin/subscriptions` (`SubscriptionManagement.tsx`) likely has the same bug pattern — the `.sub-mgmt` container has `max-width / margin` but no scroll context. Not fixed here to keep the change scope-bounded.