### PR TITLE
fix(pentest): accept 401 on URL path-traversal probes

### DIFF
--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -293,7 +293,10 @@ jobs:
 
           for payload in "%2e%2e/%2e%2e/etc/passwd" "..%252f..%252f" "..%2f..%2f" "..%5c..%5c"; do
             code=$(curl -s -o /dev/null -w "%{http_code}" "$TARGET/api/storage/files/$payload")
-            if [ "$code" = "302" ] || [ "$code" = "400" ] || [ "$code" = "403" ] || [ "$code" = "404" ]; then
+            # 401 is a valid response: auth gate fires before path validation,
+            # which is fine - the unauthenticated traversal cannot reach the
+            # storage layer at all.
+            if [ "$code" = "302" ] || [ "$code" = "400" ] || [ "$code" = "401" ] || [ "$code" = "403" ] || [ "$code" = "404" ]; then
               echo "PASS: URL path traversal $payload -> $code"
             else
               echo "FAIL: URL path traversal $payload -> $code (unexpected)"


### PR DESCRIPTION
## Summary

The Pentest workflow's unauthenticated URL path-traversal probe against `/api/storage/files/...` expected one of `302/400/403/404` but production returns `401` because the auth middleware fires before the path validator. 401 is a strictly stronger response - the request never reaches the storage layer to be tested for traversal at all - so accepting it as PASS is correct.

The Delete-endpoint probes (lines 309, 321) already accept 401 alongside 302/403; this brings the URL-traversal probe into line with that convention.

## What changed

`.github/workflows/pentest.yml`: add `401` to the accepted-response list in the URL path-traversal block, with a comment explaining why.

## Failing run

https://github.com/nikolanovoselec/codeflare/actions/runs/25307092563

## Test plan

- [ ] CI green on this branch
- [ ] After merge: re-run Pentest workflow on main and verify all probes PASS