### PR TITLE
ci: gate Deploy on PR Checks success (workflow_run pattern)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,15 +30,26 @@ permissions:
   contents: read
 
 jobs:
-  guard:
-    runs-on: ubuntu-latest
-    # On workflow_run: only proceed when PR Checks ended green.
-    # On workflow_dispatch (manual): always proceed (the dispatch
-    # itself is the operator's intent; the guard step below still
-    # rejects production deploys from non-main branches).
+  deploy:
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    # On workflow_run: only deploy when PR Checks ended green.
+    # On workflow_dispatch (manual): always run; the inner production-
+    # only-from-main step still rejects bad input.
+    #
+    # The if: lives on the deploy job itself (not on a separate guard
+    # job with `needs: guard`) because GitHub Actions treats a job
+    # skipped via if: as success() for `needs:` resolution. A failed
+    # PR Checks would skip the guard but the deploy job's needs:
+    # would still be satisfied — the gate must be on the job that
+    # actually performs the deploy.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    environment: ${{ github.ref == 'refs/heads/main' && (inputs.environment || 'production') || 'integration' }}
+    timeout-minutes: 20
+    env:
+      WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME || 'codeflare' }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Block production deploys from non-main branches
         if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' && inputs.environment == 'production'
@@ -46,16 +57,15 @@ jobs:
           echo "::error::Production deploys are only allowed from main. Got branch: ${{ github.ref }}"
           exit 1
 
-  deploy:
-    needs: guard
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    environment: ${{ github.ref == 'refs/heads/main' && (inputs.environment || 'production') || 'integration' }}
-    timeout-minutes: 20
-    env:
-      WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME || 'codeflare' }}
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # On workflow_run: pin to the SHA whose PR Checks just ended
+          # green. Without this, actions/checkout falls back to default-
+          # branch HEAD at deploy-job start time, which can drift if a
+          # second push lands on main between the green check and the
+          # deploy. On workflow_dispatch / push: github.ref is the
+          # dispatched ref; head_sha is empty so the OR falls through.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,16 @@
 name: Deploy
+# main is the protected production branch; the only push that reaches
+# it is a merged PR. workflow_run waits for that PR's "PR Checks" to
+# finish on the merge commit and only deploys when it ended green.
+# This closes the "we shipped a broken main" window that plain
+# `push: [main]` left open when the checks and deploy triggered in
+# parallel off the same SHA. workflow_dispatch stays so a stuck
+# deploy can be re-run manually, and so integration deploys from
+# develop (or any other branch) can still be triggered on demand.
 on:
-  push:
+  workflow_run:
+    workflows: ['PR Checks']
+    types: [completed]
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -13,7 +23,7 @@ on:
         default: integration
 
 concurrency:
-  group: deploy-${{ github.ref == 'refs/heads/main' && (inputs.environment || 'production') || 'integration' }}
+  group: deploy-${{ (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') && (inputs.environment || 'production') || 'integration' }}
   cancel-in-progress: true
 
 permissions:
@@ -22,9 +32,16 @@ permissions:
 jobs:
   guard:
     runs-on: ubuntu-latest
+    # On workflow_run: only proceed when PR Checks ended green.
+    # On workflow_dispatch (manual): always proceed (the dispatch
+    # itself is the operator's intent; the guard step below still
+    # rejects production deploys from non-main branches).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Block production deploys from non-main branches
-        if: github.ref != 'refs/heads/main' && inputs.environment == 'production'
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' && inputs.environment == 'production'
         run: |
           echo "::error::Production deploys are only allowed from main. Got branch: ${{ github.ref }}"
           exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,12 @@
 name: PR Checks
+# Fires on:
+#   - push to develop (fast feedback on integration-branch work)
+#   - push to main (post-merge regression gate; Deploy fires only on green)
+#   - pull_request targeting main (pre-merge gate)
+#   - workflow_dispatch (manual re-run)
 on:
+  push:
+    branches: [main, develop]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,22 @@ name: PR Checks
 # Fires on:
 #   - push to develop (fast feedback on integration-branch work)
 #   - push to main (post-merge regression gate; Deploy fires only on green)
-#   - pull_request targeting main (pre-merge gate)
+#   - pull_request targeting main OR develop (pre-merge gate; develop
+#     is included so the feature → develop step of the canonical flow
+#     gets the same pre-merge signal as feature → main does)
 #   - workflow_dispatch (manual re-run)
+#
+# Cost note: per merge to main this fires twice — once pre-merge on
+# the PR head (pull_request) and once post-merge on the merge commit
+# (push). The post-merge run is the one Deploy gates on via
+# workflow_run; the pre-merge run is what blocks the merge button.
+# The doubled run is the explicit cost of closing the parallel-
+# trigger race that the old `push: [main]` deploy left open.
 on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 concurrency:

--- a/documentation/ci-cd.md
+++ b/documentation/ci-cd.md
@@ -18,8 +18,8 @@ Dependabot runs weekly against the `develop` branch for three npm package direct
 
 | Workflow | Trigger | What it does |
 |----------|---------|-------------|
-| `deploy.yml` | Push to `main` + `workflow_dispatch` (production/integration) | Full pipeline: tests, typecheck, Docker build, Trivy vulnerability scan, wrangler deploy, worker secrets |
-| `test.yml` | PRs to `main` + `workflow_dispatch` | PR checks: lint (oxlint), tests, typecheck, build verification, dead code check (knip), `npm audit --omit=dev`, dependency review |
+| `deploy.yml` | `workflow_run` when PR Checks complete green on `main` + `workflow_dispatch` (production/integration) | Full pipeline: tests, typecheck, Docker build, Trivy vulnerability scan, wrangler deploy, worker secrets. Deploy only fires after checks pass - eliminates the parallel-trigger race where a broken merge could deploy before checks failed. |
+| `test.yml` | PRs to `main`, push to `main`/`develop` + `workflow_dispatch` | PR checks: lint (oxlint), tests, typecheck, build verification, dead code check (knip), `npm audit --omit=dev`, dependency review. Push-to-main trigger provides the post-merge signal that `deploy.yml` gates on. |
 | `e2e.yml` | `workflow_dispatch` (integration/production) | E2E tests against deployed worker - sequential jobs with dependency chains: `setup` -> `e2e-api` -> `e2e-ui-desktop` -> `e2e-ui-mobile` |
 | `codeql.yml` | Push to `main`, PRs to `main`, weekly (Monday 06:00 UTC) | CodeQL static analysis for JavaScript/TypeScript vulnerabilities, uploads SARIF to GitHub Security |
 | `fuzz.yml` | PRs to `main`, weekly (Sunday 04:00 UTC) + `workflow_dispatch` | Property-based fuzzing with fast-check (50,000 iterations) |


### PR DESCRIPTION
## Summary

Mirrors the ai-news-digest pattern. Closes the "shipped a broken main" window that plain `push: [main]` left open when Deploy and PR Checks triggered in parallel off the same merge SHA — Deploy won the race often enough that a failing test on main never blocked the production deploy.

## Changes

- **test.yml** — add `push: [main, develop]` to triggers:
  - main: post-merge regression gate that Deploy now waits on
  - develop: fast feedback on integration-branch work (no deploy)
- **deploy.yml** — replace `push: [main]` with `workflow_run` keyed on 'PR Checks' completing on main. Guard job gates the auto path on `workflow_run.conclusion == 'success'`. Manual `workflow_dispatch` (integration deploys, re-runs) still works unchanged.

## Test plan

- [ ] PR Checks runs on this PR (pull_request trigger)
- [ ] On merge to main, PR Checks fires again on the merge SHA (new push trigger)
- [ ] Deploy then fires via workflow_run, only when PR Checks ended green
- [ ] Manual `gh workflow run deploy.yml --ref develop -f environment=integration` still works