### PR TITLE
fix(entrypoint): normalize matcher null to empty string in hooks merge

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1146,12 +1146,12 @@ if [ -f "$SETTINGS_FILE" ]; then
           ($orig.hooks[$type] // []) as $existArr |
           ($cfg.hooks[$type] // []) as $cfgArr |
           {key: $type, value: (
-            [$existArr[].matcher, $cfgArr[].matcher] | unique |
+            [($existArr[].matcher // ""), ($cfgArr[].matcher // "")] | unique |
             map(. as $m |
-              [$existArr[] | select(.matcher == $m) | (.hooks // [])[] |
+              [$existArr[] | select((.matcher // "") == $m) | (.hooks // [])[] |
                 select((.command // "") | test("codeflare-(hooks|memory)/scripts/") | not)
               ] as $user |
-              [$cfgArr[] | select(.matcher == $m) | (.hooks // [])[]] as $mgr |
+              [$cfgArr[] | select((.matcher // "") == $m) | (.hooks // [])[]] as $mgr |
               {matcher: $m, hooks: ($user + $mgr)}
             ) | map(select(.hooks | length > 0))
           )}

--- a/host/__tests__/entrypoint-matcher-null.test.js
+++ b/host/__tests__/entrypoint-matcher-null.test.js
@@ -1,0 +1,172 @@
+// Tests for the settings.json hooks-merge jq filter in entrypoint.sh.
+//
+// Reads the actual jq expression from entrypoint.sh, feeds it real input
+// containing matcher: null (the shape Claude Code self-installs for the
+// context-mode-cache-heal SessionStart hook), and asserts the output is
+// valid per the Claude Code settings parser (matcher MUST be a string).
+//
+// Antipattern guardrail (per tdd-discipline): this is NOT a text-matching
+// test. It runs the real jq filter and asserts on observable output.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENTRYPOINT = readFileSync(resolve(__dirname, '../../entrypoint.sh'), 'utf8');
+
+// Extract the jq filter body between `jq --argjson cfg "$SETTINGS_CONFIG" '`
+// and the closing `'`. Single-quoted heredoc style in entrypoint.sh.
+function extractMergeFilter() {
+  const start = ENTRYPOINT.indexOf("jq --argjson cfg \"$SETTINGS_CONFIG\" '");
+  assert.ok(start > -1, 'merge jq filter not found in entrypoint.sh');
+  const filterStart = ENTRYPOINT.indexOf("'", start) + 1;
+  const filterEnd = ENTRYPOINT.indexOf("' \"$SETTINGS_FILE\"", filterStart);
+  assert.ok(filterEnd > filterStart, 'merge jq filter end not found');
+  return ENTRYPOINT.slice(filterStart, filterEnd);
+}
+
+function runMerge(existing, cfg) {
+  const filter = extractMergeFilter();
+  const dir = mkdtempSync(join(tmpdir(), 'merge-'));
+  const inputPath = join(dir, 'settings.json');
+  writeFileSync(inputPath, JSON.stringify(existing));
+  const result = spawnSync(
+    'jq',
+    ['--argjson', 'cfg', JSON.stringify(cfg), filter, inputPath],
+    { encoding: 'utf-8' }
+  );
+  assert.equal(
+    result.status,
+    0,
+    `jq failed: ${result.stderr}`
+  );
+  return JSON.parse(result.stdout);
+}
+
+const MANAGED_CFG = {
+  hooks: {
+    PreToolUse: [{
+      matcher: 'Bash',
+      hooks: [{ type: 'command', command: 'bash /home/user/.claude/plugins/codeflare-hooks/scripts/block-attributed-commits.sh' }],
+    }],
+    Stop: [{
+      matcher: '',
+      hooks: [{ type: 'command', command: 'bash /home/user/.claude/plugins/codeflare-hooks/scripts/enforce-review-spawn.sh' }],
+    }],
+  },
+};
+
+describe('entrypoint settings.json hooks merge - matcher null guard', () => {
+  it('coerces matcher: null to "" for SessionStart entries written by Claude Code', () => {
+    // Claude Code self-installs context-mode-cache-heal.mjs as a SessionStart
+    // hook with matcher: null. The Claude Code settings parser then errors:
+    // "Expected string, but received null". The merge must normalize.
+    const existing = {
+      hooks: {
+        SessionStart: [{
+          matcher: null,
+          hooks: [{
+            type: 'command',
+            command: '"/home/user/.claude/hooks/context-mode-cache-heal.mjs"',
+          }],
+        }],
+      },
+    };
+
+    const merged = runMerge(existing, MANAGED_CFG);
+
+    assert.ok(merged.hooks.SessionStart, 'SessionStart should be preserved');
+    assert.equal(
+      merged.hooks.SessionStart.length,
+      1,
+      'one matcher group expected'
+    );
+    assert.equal(
+      merged.hooks.SessionStart[0].matcher,
+      '',
+      'matcher null must be normalized to empty string'
+    );
+    // The user hook itself must survive (not stripped as a "managed" hook).
+    assert.equal(
+      merged.hooks.SessionStart[0].hooks[0].command,
+      '"/home/user/.claude/hooks/context-mode-cache-heal.mjs"'
+    );
+  });
+
+  it('preserves matcher "" untouched (already-correct case)', () => {
+    const existing = {
+      hooks: {
+        SessionStart: [{
+          matcher: '',
+          hooks: [{ type: 'command', command: '/some/user/hook' }],
+        }],
+      },
+    };
+    const merged = runMerge(existing, MANAGED_CFG);
+    assert.equal(merged.hooks.SessionStart[0].matcher, '');
+  });
+
+  it('preserves named matchers (e.g., "Bash") untouched', () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [{
+          matcher: 'Bash',
+          hooks: [{ type: 'command', command: '/some/user/git-hook' }],
+        }],
+      },
+    };
+    const merged = runMerge(existing, MANAGED_CFG);
+    const bashGroup = merged.hooks.PreToolUse.find(g => g.matcher === 'Bash');
+    assert.ok(bashGroup, 'Bash matcher group expected');
+    // Both the user hook and the managed hook should appear under Bash.
+    const commands = bashGroup.hooks.map(h => h.command);
+    assert.ok(commands.includes('/some/user/git-hook'));
+    assert.ok(commands.some(c => c.includes('block-attributed-commits.sh')));
+  });
+
+  it('does not collapse two distinct matchers (null and "Bash") into one group', () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          { matcher: null, hooks: [{ type: 'command', command: '/a' }] },
+          { matcher: 'Bash', hooks: [{ type: 'command', command: '/b' }] },
+        ],
+      },
+    };
+    const merged = runMerge(existing, MANAGED_CFG);
+    // null normalizes to "" - so the resulting groups are "" and "Bash"
+    // (two distinct groups, never merged).
+    const matchers = merged.hooks.PreToolUse.map(g => g.matcher).sort();
+    assert.deepEqual(matchers, ['', 'Bash']);
+    // Each group keeps its own commands.
+    const emptyGroup = merged.hooks.PreToolUse.find(g => g.matcher === '');
+    assert.ok(emptyGroup.hooks.some(h => h.command === '/a'));
+    const bashGroup = merged.hooks.PreToolUse.find(g => g.matcher === 'Bash');
+    assert.ok(bashGroup.hooks.some(h => h.command === '/b'));
+  });
+
+  it('output settings file passes the Claude Code matcher schema (string only)', () => {
+    // Cross-cutting: every emitted matcher must be a string, never null.
+    const existing = {
+      hooks: {
+        SessionStart: [{ matcher: null, hooks: [{ type: 'command', command: '/x' }] }],
+        PreCompact: [{ matcher: null, hooks: [{ type: 'command', command: '/y' }] }],
+      },
+    };
+    const merged = runMerge(existing, MANAGED_CFG);
+    for (const [eventType, groups] of Object.entries(merged.hooks)) {
+      for (const group of groups) {
+        assert.equal(
+          typeof group.matcher,
+          'string',
+          `${eventType} matcher must be string, got ${typeof group.matcher} (${group.matcher})`
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Production hotfix

Users see a Settings Error on session start:

\`\`\`
/home/user/.claude/settings.json
└ hooks
  └ SessionStart
    └ 0
      └ matcher: Expected string, but received null
\`\`\`

\`Files with errors are skipped entirely\` (the parser's own message), so this disables EVERY managed hook (block-attributed-commits, push-review-reminder, enforce-review-spawn, memory-capture). The session keeps running but every hook-driven discipline silently degrades.

## Root cause

The CLI auto-installs \`context-mode-cache-heal.mjs\` as a SessionStart hook in \`~/.claude/settings.json\` with \`matcher: null\`. Our entrypoint then runs a jq merge that combines the existing user-side hooks with the codeflare-managed hooks. The merge groups entries by \`.matcher\` and re-emits the literal value. When the existing entry has \`matcher: null\`, that null flows straight through to the output. The parser blows up on the next session start.

## Fix

Three sites in the jq filter coerce \`null\` → \`\"\"\`:

- \`[$existArr[].matcher, $cfgArr[].matcher]\` → \`[($existArr[].matcher // \"\"), ($cfgArr[].matcher // \"\")]\`
- \`select(.matcher == \$m)\` (twice) → \`select((.matcher // \"\") == \$m)\`

Empty string is the canonical \"match everything\" value the parser accepts; null was always illegal.

## Tests

\`host/__tests__/entrypoint-matcher-null.test.js\` extracts the real jq filter from \`entrypoint.sh\` and runs it against fixtures. Five tests:

1. \`matcher: null\` SessionStart hook is preserved with matcher coerced to \`\"\"\`
2. Existing \`matcher: \"\"\` is left untouched (happy path)
3. Existing \`matcher: \"Bash\"\` is left untouched (happy path with managed merge)
4. Two distinct matchers (null + \"Bash\") don't collapse into one group
5. Cross-cutting: every emitted matcher across all event types is a string

Per tdd-discipline: real jq invocation, real fixtures, output assertions. No text-matching theater.

## Test plan

- [ ] CI green on develop
- [ ] Smoke test on integration: start a fresh session, verify no Settings Error in the UI
- [ ] Promote to main once integration is clean