### PR TITLE
fix(test): replace regex-escape with substring match (CodeQL #40)

### DIFF
--- a/host/__tests__/memory-capture-hook.test.js
+++ b/host/__tests__/memory-capture-hook.test.js
@@ -163,7 +163,10 @@ describe('memory-capture.sh — user-message counting', () => {
     const out = JSON.parse(r.stdout);
     // additionalContext must reference the vars file the agent will read
     const vars = join(home, '.memory/counter/sess-t.vars');
-    assert.match(out.hookSpecificOutput.additionalContext, new RegExp(vars.replace(/\//g, '\\/')));
+    assert.ok(
+      out.hookSpecificOutput.additionalContext.includes(vars),
+      `additionalContext should mention vars path; got: ${out.hookSpecificOutput.additionalContext}`,
+    );
     assert.equal(existsSync(vars), true,
       'capture path must write the .vars file');
     const v = JSON.parse(readFileSync(vars, 'utf-8'));


### PR DESCRIPTION
Addresses CodeQL finding on PR #307. Replaces a regex with incomplete metachar escaping with a plain substring check. Same assertion intent, no escaping concerns.