### PR TITLE
fix(agents): grant ctx_* MCP tools to subagents + dedup enforce-ctx-mode hook

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1180,8 +1180,10 @@ if [ -f "$SETTINGS_FILE" ]; then
     # Implements REQ-AGENT-008
     # Merge non-hooks settings with *, rebuild hooks separately to avoid
     # jq array-replace destroying user-added hooks or leaving stale managed hooks.
-    # "Managed" = command path contains codeflare-(hooks|memory)/scripts/ OR
-    # is a context-mode hook invocation (any of: bare `context-mode`,
+    # "Managed" = command path contains codeflare-(hooks|memory)/scripts/,
+    # references enforce-ctx-mode.sh (both the legacy ~/.claude/hooks/ path
+    # and the current ~/.claude/plugins/context-mode/scripts/ path), OR is
+    # a context-mode hook invocation (any of: bare `context-mode`,
     # `bunx context-mode@*`, or `npx -y context-mode@*` for legacy compat
     # with sessions that still have stale settings.json from before the
     # build-time install landed). Adding to MANAGED_HOOKS_REGEX must
@@ -1198,7 +1200,7 @@ if [ -f "$SETTINGS_FILE" ]; then
             [($existArr[] | .matcher // ""), ($cfgArr[] | .matcher // "")] | unique |
             map(. as $m |
               [$existArr[] | select((.matcher // "") == $m) | (.hooks // [])[] |
-                select((.command // "") | test("codeflare-(hooks|memory)/scripts/|(^context-mode |(bunx|npx) (-y )?context-mode@.* hook claude-code)") | not)
+                select((.command // "") | test("codeflare-(hooks|memory)/scripts/|enforce-ctx-mode\\.sh|(^context-mode |(bunx|npx) (-y )?context-mode@.* hook claude-code)") | not)
               ] as $user |
               [$cfgArr[] | select((.matcher // "") == $m) | (.hooks // [])[]] as $mgr |
               {matcher: $m, hooks: ($user + $mgr)}

--- a/host/__tests__/entrypoint-enforce-ctx-mode-dedup.test.js
+++ b/host/__tests__/entrypoint-enforce-ctx-mode-dedup.test.js
@@ -1,0 +1,198 @@
+// Behavioral test for entrypoint.sh's settings.json hook merge: verifies that
+// duplicated `enforce-ctx-mode.sh` entries get pruned by the "managed hooks"
+// regex on every entrypoint run, both when context-mode hooks are being
+// re-applied (advanced+manifest) and when downgrading to default mode.
+//
+// "Run the real thing" per tdd-discipline.md: extracts the actual jq filter
+// from entrypoint.sh and runs jq against a fixture settings.json that
+// reproduces the prod accumulation pattern (4× duplicate strict-hook
+// entries on the Bash|WebFetch|Grep matcher). If the regex doesn't match
+// the enforce-ctx-mode.sh paths, the test fails.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const entrypoint = readFileSync(resolve(__dirname, '../../entrypoint.sh'), 'utf8');
+
+// Extract the jq filter expression used to merge SETTINGS_CONFIG into
+// settings.json. Bounded by the literal opener `jq --argjson cfg
+// "$SETTINGS_CONFIG" '` and the literal closer `' "$SETTINGS_FILE"`.
+function extractMergeFilter() {
+  const opener = `jq --argjson cfg "$SETTINGS_CONFIG" '`;
+  const closer = `' "$SETTINGS_FILE"`;
+  const start = entrypoint.indexOf(opener);
+  if (start === -1) throw new Error('settings.json merge jq opener not found');
+  const filterStart = start + opener.length;
+  const end = entrypoint.indexOf(closer, filterStart);
+  if (end === -1) throw new Error('settings.json merge jq closer not found');
+  return entrypoint.slice(filterStart, end);
+}
+
+// Build a settings.json fixture that mirrors the prod accumulation pattern:
+// the matcher `Bash|WebFetch|Grep` carries FOUR copies of the strict hook
+// invocation (once at the legacy ~/.claude/hooks/ path + three identical
+// entries under ~/.claude/plugins/context-mode/scripts/). Plus a user-added
+// hook on a different matcher that must be preserved.
+function accumulatedSettingsFixture() {
+  const strictLegacy = 'bash /home/user/.claude/hooks/enforce-ctx-mode.sh';
+  const strictPlugin = 'bash /home/user/.claude/plugins/context-mode/scripts/enforce-ctx-mode.sh';
+  return JSON.stringify({
+    skipDangerousModePermissionPrompt: true,
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [
+            { type: 'command', command: 'bash /home/user/.claude/plugins/codeflare-hooks/scripts/block-attributed-commits.sh' },
+          ],
+        },
+        {
+          matcher: 'Bash|Read|WebFetch|Grep|Glob|Agent',
+          hooks: [
+            { type: 'command', command: 'context-mode hook claude-code pretooluse' },
+          ],
+        },
+        {
+          matcher: 'Bash|WebFetch|Grep',
+          hooks: [
+            { type: 'command', command: strictLegacy },
+            { type: 'command', command: strictPlugin },
+            { type: 'command', command: strictPlugin },
+            { type: 'command', command: strictPlugin },
+          ],
+        },
+        {
+          // User-added hook on its own matcher — must survive merge.
+          matcher: 'Edit',
+          hooks: [
+            { type: 'command', command: 'bash /home/user/custom/my-hook.sh' },
+          ],
+        },
+      ],
+    },
+  });
+}
+
+// The advanced+manifest SETTINGS_CONFIG that entrypoint.sh builds when the
+// plugin manifest is present. We assemble it inline rather than re-extracting
+// from bash because we only need the merge target to contain ONE strict-hook
+// entry on the Bash|WebFetch|Grep matcher — the surface we're testing.
+function advancedContextModeSettingsConfig() {
+  const strictPlugin = 'bash /home/user/.claude/plugins/context-mode/scripts/enforce-ctx-mode.sh';
+  return {
+    skipDangerousModePermissionPrompt: true,
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [
+            { type: 'command', if: 'Bash(git *)', command: 'bash /home/user/.claude/plugins/codeflare-hooks/scripts/block-attributed-commits.sh' },
+            { type: 'command', if: 'Bash(gh *)', command: 'bash /home/user/.claude/plugins/codeflare-hooks/scripts/block-attributed-commits.sh' },
+          ],
+        },
+        {
+          matcher: 'Bash|Read|WebFetch|Grep|Glob|Agent',
+          hooks: [
+            { type: 'command', command: 'context-mode hook claude-code pretooluse' },
+          ],
+        },
+        {
+          matcher: 'Bash|WebFetch|Grep',
+          hooks: [
+            { type: 'command', command: strictPlugin },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+// Default-mode SETTINGS_CONFIG: no hooks. Used to verify downgrade prunes
+// previously-managed strict-hook entries.
+function defaultModeSettingsConfig() {
+  return { skipDangerousModePermissionPrompt: true };
+}
+
+function runJqMerge(settingsJson, settingsConfig) {
+  const filter = extractMergeFilter();
+  const cwd = mkdtempSync(join(tmpdir(), 'ctx-dedup-'));
+  const settingsPath = join(cwd, 'settings.json');
+  writeFileSync(settingsPath, settingsJson);
+  const result = spawnSync(
+    'jq',
+    ['--argjson', 'cfg', JSON.stringify(settingsConfig), filter, settingsPath],
+    { encoding: 'utf-8' },
+  );
+  if (result.status !== 0) {
+    throw new Error(`jq exited ${result.status}: ${result.stderr}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function strictHookEntries(merged) {
+  const pre = merged?.hooks?.PreToolUse ?? [];
+  const strict = pre.find((entry) => entry.matcher === 'Bash|WebFetch|Grep');
+  return strict?.hooks ?? [];
+}
+
+describe('entrypoint settings.json hook merge - enforce-ctx-mode.sh dedup', () => {
+  it('advanced re-apply: 4× duplicated strict hook entries collapse to exactly 1', () => {
+    const merged = runJqMerge(accumulatedSettingsFixture(), advancedContextModeSettingsConfig());
+    const strict = strictHookEntries(merged);
+    assert.equal(
+      strict.length,
+      1,
+      `expected exactly 1 strict-hook entry after merge, got ${strict.length}: ${JSON.stringify(strict)}`,
+    );
+    assert.ok(
+      strict[0].command.includes('enforce-ctx-mode.sh'),
+      'surviving entry should be the canonical enforce-ctx-mode.sh path',
+    );
+  });
+
+  it('advanced re-apply: legacy ~/.claude/hooks/ path is also pruned', () => {
+    const merged = runJqMerge(accumulatedSettingsFixture(), advancedContextModeSettingsConfig());
+    const strict = strictHookEntries(merged);
+    const legacySurvives = strict.some((h) => h.command.includes('/.claude/hooks/enforce-ctx-mode.sh'));
+    assert.equal(
+      legacySurvives,
+      false,
+      'legacy ~/.claude/hooks/enforce-ctx-mode.sh entry must be pruned by the managed-hooks regex',
+    );
+  });
+
+  it('user-added hooks on unmanaged matchers are preserved', () => {
+    const merged = runJqMerge(accumulatedSettingsFixture(), advancedContextModeSettingsConfig());
+    const userMatcher = merged.hooks.PreToolUse.find((e) => e.matcher === 'Edit');
+    assert.ok(userMatcher, 'user-added Edit matcher should survive');
+    assert.equal(userMatcher.hooks[0].command, 'bash /home/user/custom/my-hook.sh');
+  });
+
+  it('downgrade to default mode: all strict-hook entries are pruned', () => {
+    const merged = runJqMerge(accumulatedSettingsFixture(), defaultModeSettingsConfig());
+    const pre = merged?.hooks?.PreToolUse ?? [];
+    const anyStrict = pre.some((entry) =>
+      (entry.hooks ?? []).some((h) => (h.command ?? '').includes('enforce-ctx-mode.sh')),
+    );
+    assert.equal(
+      anyStrict,
+      false,
+      'after downgrade, no enforce-ctx-mode.sh entries should remain in any PreToolUse matcher',
+    );
+  });
+
+  it('downgrade to default mode: user-added Edit matcher is still preserved', () => {
+    const merged = runJqMerge(accumulatedSettingsFixture(), defaultModeSettingsConfig());
+    const userMatcher = merged?.hooks?.PreToolUse?.find((e) => e.matcher === 'Edit');
+    assert.ok(
+      userMatcher,
+      'user-added Edit matcher must survive downgrade (only managed hooks are pruned)',
+    );
+  });
+});

--- a/preseed/agents/claude/agents/architect.md
+++ b/preseed/agents/claude/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Software architecture specialist for system design, scalability, and technical decision-making. Use PROACTIVELY when planning new features, refactoring large systems, or making architectural decisions.
-tools: ["Read", "Grep", "Glob", "Write"]
+tools: ["Read", "Grep", "Glob", "Write", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: opus
 ---
 

--- a/preseed/agents/claude/agents/build-error-resolver.md
+++ b/preseed/agents/claude/agents/build-error-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist. Use PROACTIVELY when build fails or type errors occur. Fixes build/type errors only with minimal diffs, no architectural edits. Focuses on getting the build green quickly.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: sonnet
 ---
 

--- a/preseed/agents/claude/agents/code-reviewer.md
+++ b/preseed/agents/claude/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code. MUST BE USED for all code changes.
-tools: ["Read", "Grep", "Glob", "Bash", "Write", "mcp__consult-llm__consult_llm", "mcp__memory__search_nodes", "mcp__memory__open_nodes"]
+tools: ["Read", "Grep", "Glob", "Bash", "Write", "mcp__consult-llm__consult_llm", "mcp__memory__search_nodes", "mcp__memory__open_nodes", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: opus
 ---
 

--- a/preseed/agents/claude/agents/doc-updater.md
+++ b/preseed/agents/claude/agents/doc-updater.md
@@ -1,7 +1,7 @@
 ---
 name: doc-updater
 description: Documentation specialist. Runs only on SDD-bootstrapped projects (sdd/ folder exists). Enforces spec-vs-docs boundary, generates REQ backlinks, updates documentation/ to match code. Use PROACTIVELY when a PR opens or syncs on SDD projects. Can also be invoked manually on any project.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: sonnet
 ---
 

--- a/preseed/agents/claude/agents/refactor-cleaner.md
+++ b/preseed/agents/claude/agents/refactor-cleaner.md
@@ -1,7 +1,7 @@
 ---
 name: refactor-cleaner
 description: Dead code cleanup and consolidation specialist. Use PROACTIVELY for removing unused code, duplicates, and refactoring. Runs analysis tools (knip, depcheck, ts-prune) to identify dead code and safely removes it.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: sonnet
 ---
 

--- a/preseed/agents/claude/agents/security-reviewer.md
+++ b/preseed/agents/claude/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security vulnerability detection and remediation specialist. Use PROACTIVELY after writing code that handles user input, authentication, API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe crypto, and OWASP Top 10 vulnerabilities.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: sonnet
 ---
 

--- a/preseed/agents/claude/agents/spec-reviewer.md
+++ b/preseed/agents/claude/agents/spec-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-reviewer
 description: Specification maintenance agent. Keeps sdd/ valid as the single source of truth. Updates spec when code changes, validates quality, removes stale content. Project-agnostic — auto-detects sdd/ folder. Only runs when sdd/ exists.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: opus
 ---
 

--- a/preseed/agents/claude/agents/tdd-guide.md
+++ b/preseed/agents/claude/agents/tdd-guide.md
@@ -1,7 +1,7 @@
 ---
 name: tdd-guide
 description: Test-Driven Development specialist enforcing write-tests-first methodology. Use PROACTIVELY when writing new features, fixing bugs, or refactoring code. Ensures 80%+ test coverage.
-tools: ["Read", "Write", "Edit", "Bash", "Grep"]
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "mcp__context-mode__ctx_search", "mcp__context-mode__ctx_batch_execute", "mcp__context-mode__ctx_execute", "mcp__context-mode__ctx_execute_file", "mcp__context-mode__ctx_fetch_and_index"]
 model: sonnet
 ---
 

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -2,6 +2,10 @@
 
 Semantic changes to the specification. Git history captures diffs; this file captures intent.
 
+## 2026-05-11
+- Subagents spawned via the Task tool (architect, build-error-resolver, code-reviewer, doc-updater, refactor-cleaner, security-reviewer, spec-reviewer, tdd-guide) now have the `mcp__context-mode__ctx_*` tools in their inventory (REQ-AGENT-005). Previously the strict PreToolUse hook denied native `Grep` / unwhitelisted `Bash` and instructed agents to route through `ctx_execute` / `ctx_search` — but those MCP tools were not in the subagent's tool schema, so the redirect was a dead end. `/review` reports and review-pipeline agents (code-reviewer / spec-reviewer / doc-updater) can now actually search code on Custom + Pro tiers instead of degrading to Read+Glob.
+- Entrypoint hook merge now treats `enforce-ctx-mode.sh` invocations as managed (REQ-AGENT-008), so duplicate strict-hook entries no longer accumulate across container restarts. Previously every entrypoint run silently re-appended the strict hook because the managed-hooks regex matched only `codeflare-(hooks|memory)/scripts/` and bare `context-mode` invocations; production settings.json grew to 4× duplicate entries on the `Bash|WebFetch|Grep` matcher.
+
 ## 2026-05-10
 - context-mode routing is now hard-enforced for Custom + Pro users (REQ-AGENT-005 AC6). A fifth PreToolUse hook denies `Bash` outside `{git, mkdir, rm, mv, cd, ls, npm install, pip install}` and every `WebFetch` and `Grep` call, redirecting to the matching `ctx_*` tool. Per-call bypass via `/tmp/ctx-bypass` (user-only sentinel). The four advisory hooks remain.
 - Reverted: the disk bump from 6 GB to 8 GB on the default/saas tiers (REQ-OPS-002 AC7, REQ-OPS-007 AC1). Cloudflare's containers cap disk at 2x memory in GiB, so 8 GB requires at least 4 GiB memory; the default tier ships with 3 GiB and the deploy was rejected. Default disk stays at 6 GB until a future tier upgrade raises memory first.


### PR DESCRIPTION
## Problem

Two related issues surfaced after probing how the 6 \`/review\` subagents (plus the SDD agents spec-reviewer, build-error-resolver) behave under Custom+Pro context-mode enforcement:

1. **Phantom-tool routing.** Each subagent's frontmatter declared \`Read, Bash, Grep, Glob, ...\` but **none** included \`mcp__context-mode__ctx_*\`. The strict \`enforce-ctx-mode.sh\` PreToolUse hook denies \`Grep\` and non-whitelisted \`Bash\` with a message instructing the agent to route through \`ctx_execute\` / \`ctx_search\`. Those tools were not in the subagent's schema, so the redirect was a dead end. Net effect: review agents under context-mode could Read+Glob but could not search code content at all.

2. **Hook duplication.** Production \`~/.claude/settings.json\` accumulated **4× duplicate** \`enforce-ctx-mode.sh\` entries on the \`Bash|WebFetch|Grep\` matcher. Root cause: the entrypoint's managed-hooks regex at line 1201 only matched \`codeflare-(hooks|memory)/scripts/\` and \`^context-mode \` / \`(bunx|npx) context-mode@*\`. It did not match \`bash /home/user/.claude/plugins/context-mode/scripts/enforce-ctx-mode.sh\`, so every entrypoint run re-appended the strict hook without pruning the old one.

Glob was investigated as part of (1). Upstream \`mksglu/context-mode/hooks/core/routing.mjs\` has **no Glob branch** — Glob output is bounded (paths only, not content) so it doesn't flood context. Decision: leave Glob as passthrough, matching upstream design intent.

## Changes

**Agent tool grants (additive, all 8 agents):**

- \`mcp__context-mode__ctx_search\`
- \`mcp__context-mode__ctx_batch_execute\`
- \`mcp__context-mode__ctx_execute\`
- \`mcp__context-mode__ctx_execute_file\`
- \`mcp__context-mode__ctx_fetch_and_index\`

Existing tools (Read, Write, Edit, Bash, Grep, Glob, mcp__memory__\*, mcp__consult-llm__\*) untouched. Non-Custom+Pro users are unaffected because the context-mode MCP server is gated by tier — undeclared MCP tools are simply not callable, same as before.

**Entrypoint dedup fix:** \`entrypoint.sh\` line 1203 — managed-hooks regex extended to include \`enforce-ctx-mode\\.sh\`, which covers both the current \`~/.claude/plugins/context-mode/scripts/\` path and the legacy \`~/.claude/hooks/\` path from older deploys.

**New behavioral test:** \`host/__tests__/entrypoint-enforce-ctx-mode-dedup.test.js\` extracts the actual jq filter from \`entrypoint.sh\` and runs it against a fixture mirroring the prod accumulation pattern (4× duplicates on the strict matcher + a user-added matcher on \`Edit\`). Asserts: duplicates collapse to 1, legacy path also pruned, downgrade to default mode clears all strict entries, user-added matchers survive merge.

## Verification

I ran the test logic directly with jq before pushing (one-shot verification, not the test suite):

- 4× duplicated strict hooks → 1 surviving entry, canonical plugin path
- Legacy \`~/.claude/hooks/enforce-ctx-mode.sh\` pruned
- User-added \`Edit\` matcher hook preserved
- Downgrade to default mode: zero \`enforce-ctx-mode.sh\` entries remain, user-added matcher still present

CI tests will run the full \`entrypoint-enforce-ctx-mode-dedup.test.js\` plus the existing \`entrypoint-hooks-merge.test.js\` and \`entrypoint-context-mode.test.js\` to confirm no regression on the merge logic.

## Out of scope (deliberate)

- No change to \`enforce-ctx-mode.sh\` script logic. Glob stays passthrough.
- No change to upstream context-mode behavior.
- The \`<context_window_protection>\` block that gets injected into subagent prompts via the PreToolUse Agent matcher still lists \`ctx_*\` tools. After this PR those tools are now actually present in the subagent's inventory, so the guidance is finally actionable.