### PR TITLE
fix(pentest): correct auth-gate paths and treat /api/setup/status as public

### DIFF
--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -170,11 +170,25 @@ jobs:
 
           check_auth "/api/sessions"
           check_auth "/api/storage/files/"
-          check_auth "/api/setup/status"
           check_auth "/api/users"
           check_auth "/api/preferences"
-          check_auth "/api/containers"
+          check_auth "/api/container/health"
           check_auth "/api/presets"
+
+          # /api/setup/status is intentionally public (bootstrap problem — see
+          # sdd/security.md:40 and sdd/setup.md:38). Verify it returns 200 and
+          # does not leak secrets.
+          body=$(curl -s "$TARGET/api/setup/status")
+          code=$(curl -s -o /dev/null -w "%{http_code}" "$TARGET/api/setup/status")
+          if [ "$code" != "200" ]; then
+            echo "FAIL: /api/setup/status -> $code (expected 200, public by design)"
+            failed=1
+          elif echo "$body" | grep -qiE "(token|secret|api_key|password|private_key|cloudflare_api)"; then
+            echo "FAIL: /api/setup/status response may contain secrets"
+            failed=1
+          else
+            echo "PASS: /api/setup/status -> 200 (public by design, no secrets in response)"
+          fi
 
           exit $failed
 


### PR DESCRIPTION
Fixes the failing Pentest run [#25658645625](https://github.com/nikolanovoselec/codeflare/actions/runs/25658645625).

## Failures

`auth-gate` job (`.github/workflows/pentest.yml`):

1. `FAIL: /api/setup/status -> 200 (expected 302/401/403)`
2. `FAIL: /api/containers -> 404 (expected 302/401/403)`

## Root causes

- **`/api/setup/status`** is *intentionally* public by design. The spec is explicit: `sdd/security.md:40` ("`GET /api/setup/status` is always public — returns only configuration status, no secrets") and `sdd/setup.md:38`. This solves the bootstrap problem (AD7/AD10): the frontend has to read setup state before auth is configured.
- **`/api/containers`** does not exist. The route is mounted at `/api/container` (singular) in `src/index.ts:223`, with all paths gated by `authMiddleware` in `src/routes/container/index.ts:14`.

## Fix

- Drop `/api/setup/status` from the auth-gate list. Replace with a positive-shape check: HTTP 200 AND no secret-shaped tokens in the response body. This catches regressions where the endpoint accidentally starts leaking secrets.
- Switch `/api/containers` → `/api/container/health` (auth-gated GET).

## Test plan
- [ ] Merge → re-run Pentest via `workflow_dispatch` → all 6 jobs green
- [ ] Confirm `/api/setup/status` regression check fires if a secret-shaped string ever leaks into the response