### PR TITLE
chore(trivy): suppress new Go stdlib HIGH CVEs in rclone/lazygit

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -258,3 +258,22 @@ CVE-2026-25835
 # never invoked with user-controlled credentials. No fix available in Debian
 # bookworm.
 CVE-2026-7598
+
+# Go stdlib in rclone v1.73.x (Go 1.26.2) and lazygit v0.60.0 (Go 1.25.7):
+# new batch of HIGH stdlib advisories. Fixes are in Go 1.25.10 / 1.26.3 but
+# rclone/lazygit upstream releases have not rebuilt yet. Exposure profile is
+# unchanged from prior Go stdlib entries above: both binaries are CLI tools
+# in the sandboxed container, do outbound network only, and do not parse
+# untrusted addresses, NUL-byte hostnames, HTTP/2 SETTINGS frames as a
+# server, or untrusted email phrases.
+#
+# CVE-2026-33811: net.LookupCNAME with cgo DNS resolver miscounts answers.
+# CVE-2026-33814: HTTP/2 SETTINGS frame handling enters error state on peer input.
+# CVE-2026-39820: ParseAddress / ParseAddressList input handling DoS.
+# CVE-2026-39836: Dial / LookupPort panic when hostname contains NUL byte.
+# CVE-2026-42499: net/mail consumePhrase DoS on pathological inputs.
+CVE-2026-33811
+CVE-2026-33814
+CVE-2026-39820
+CVE-2026-39836
+CVE-2026-42499


### PR DESCRIPTION
## Summary

Unblocks the production deploy by suppressing five new HIGH Go-stdlib advisories that Trivy v0.70 flagged in the Go binaries embedded in the container image (`rclone` v1.73.x built with Go 1.26.2, `lazygit` v0.60.0 built with Go 1.25.7).

The fixed Go releases (1.25.10 / 1.26.3) shipped recently, but neither `rclone` nor `lazygit` has rebuilt upstream against them yet. The CVEs are listed against the embedded Go runtime, not against any code path the binaries actually expose.

Failing CI run: [actions/runs/25695527867](https://github.com/nikolanovoselec/codeflare/actions/runs/25695527867/job/75442631686) - `deploy / Scan container image for vulnerabilities`, exit code 1 with `Total: 5 (HIGH: 5, CRITICAL: 0)`.

## Suppressed CVEs

| ID | Affected stdlib path | Why not exploitable here |
|---|---|---|
| `CVE-2026-33811` | `net.LookupCNAME` with cgo DNS resolver miscounts answers | rclone/lazygit do not call `LookupCNAME` with untrusted names; outbound network only |
| `CVE-2026-33814` | `net/http2` SETTINGS frame transport error | Neither CLI runs an HTTP/2 server; outbound HTTPS client only |
| `CVE-2026-39820` | `net/mail` `ParseAddress` / `ParseAddressList` DoS | Neither CLI parses untrusted email addresses |
| `CVE-2026-39836` | `Dial` / `LookupPort` panic on NUL-byte hostname | Hostnames are operator-supplied (rclone config, git remote) |
| `CVE-2026-42499` | `net/mail` `consumePhrase` DoS on pathological input | No untrusted email phrases |

## Exposure profile

Identical to the prior Go-stdlib entries already in `.trivyignore` for these same binaries (`CVE-2026-32280`, `32281`, `32282`, `32283`): rclone is invoked as `rclone bisync` only (no `rcd` / `--rc`), and lazygit is a terminal UI for the operator's own local git repo. Both run inside a sandboxed container with no inbound listeners.

## Resolution path

When `rclone` cuts a release built against Go 1.26.3+ and `lazygit` cuts a release built against Go 1.25.10+, remove the corresponding entries from `.trivyignore`. Tracked alongside the existing rclone/lazygit Go-stdlib suppression group; the monthly review note at the top of the file remains the trigger.

## Test plan

- [ ] Merge -> `deploy` workflow runs -> `Scan container image for vulnerabilities` reports `Total: 0` (or only LOW/MEDIUM) and exits 0
- [ ] Container image deploys to `codeflare-production`

## Scope

Single file, additive only:

```
.trivyignore | 19 ++++++++++++++++++-
1 file changed, 19 insertions(+)
```

No code, no workflow, no configuration changes.
