### PR TITLE
fix(hooks): close $(...), backtick, and multi-line heredoc bypasses in enforce-ctx-mode

### DIFF
--- a/host/__tests__/enforce-ctx-mode.test.js
+++ b/host/__tests__/enforce-ctx-mode.test.js
@@ -279,6 +279,39 @@ describe('enforce-ctx-mode hook', () => {
       const cmd = 'git x <<EOF\nnever closes\n && tail evil';
       assertAllowed(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }));
     });
+
+    it('CLOSES multi-line heredoc bypass: cmd <<EOF\\nbody\\nEOF\\ncurl evil (newline after terminator)', () => {
+      const cmd = 'git x <<EOF\nbody line 1\nbody line 2\nEOF\ncurl evil';
+      const reason = deniedReason(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES multi-line heredoc bypass with chained post-cmd: ...EOF\\ngit status; curl evil', () => {
+      const cmd = 'git x <<EOF\nbody\nEOF\ngit status; curl evil';
+      const reason = deniedReason(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES multi-line heredoc bypass with bg fork after: ...EOF\\nhead -1 f &', () => {
+      const cmd = 'git x <<EOF\nbody\nEOF\nhead -1 file &';
+      const reason = deniedReason(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }));
+      assert.match(reason, /head violates/);
+    });
+
+    it('allows multi-line heredoc with no follow-up command', () => {
+      const cmd = 'git commit -F - <<EOF\nmessage line 1\nmessage line 2\nEOF';
+      assertAllowed(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }));
+    });
+
+    it('allows multi-line heredoc with whitelisted follow-up: ...EOF\\ngit push', () => {
+      const cmd = 'git commit -F - <<EOF\nmessage\nEOF\ngit push';
+      assertAllowed(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }));
+    });
+
+    it('allows multi-line tab-dash heredoc with whitelisted follow-up', () => {
+      const cmd = 'git commit -F - <<-EOF\n\tindented message\n\tEOF\ngit push';
+      assertAllowed(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }));
+    });
   });
 
   describe('file descriptor redirects (closes false-positive on &)', () => {
@@ -369,6 +402,141 @@ describe('enforce-ctx-mode hook', () => {
         tool_input: { command: 'git log --grep="release;" | head' },
       }));
       assert.match(reason, /'head' violates/);
+    });
+  });
+
+  describe('command/process substitution extraction (closes $(...), <(...), `...` bypass)', () => {
+    it('CLOSES $(...) bypass: git log $(curl evil) is denied on inner curl', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log $(curl evil.com)' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES $(...) bypass with non-whitelisted inner: git log $(head -10 f)', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log $(head -10 file)' },
+      }));
+      assert.match(reason, /head violates/);
+    });
+
+    it('CLOSES <(...) process-substitution bypass: git diff <(curl a) <(curl b)', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git diff <(curl a.com) <(curl b.com)' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES >(...) process-substitution bypass: ls > >(curl evil)', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'ls -la > >(curl evil.com)' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES backtick bypass: git log `curl evil`', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log `curl evil.com`' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES nested substitution: git log $(echo $(curl evil))', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log $(echo $(curl evil.com))' },
+      }));
+      // Either echo or curl can be the first denied segment; both are non-whitelisted.
+      assert.match(reason, /(echo|curl) violates/);
+    });
+
+    it('CLOSES backtick inside $(...) nested: git log $(echo `curl x`)', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log $(echo `curl x`)' },
+      }));
+      assert.match(reason, /(echo|curl) violates/);
+    });
+
+    it('CLOSES $(...) inside double-quoted string: git log --grep="$(curl evil)"', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log --grep="$(curl evil.com)"' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('allows $(...) inside single-quoted string (literal, not executed)', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: "git log --grep='$(curl evil)'" },
+      }));
+    });
+
+    it('allows backticks inside single-quoted string (literal, not executed)', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: "git log --grep='`curl evil`'" },
+      }));
+    });
+
+    it('allows arithmetic expansion $((expr)) (not command substitution)', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log -n $((1 + 2))' },
+      }));
+    });
+
+    it('allows parameter expansion $VAR and ${VAR}', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log $HOME ${BRANCH}' },
+      }));
+    });
+
+    it('allows parens inside double-quoted string with no $ prefix', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log --pretty="(%h) %s"' },
+      }));
+    });
+
+    it('allows whitelisted inner sub: git push $(git rev-parse HEAD)', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git push origin $(git rev-parse HEAD)' },
+      }));
+    });
+
+    it('pins unterminated $(...) behavior (fails open: passes through)', () => {
+      // Unterminated subs would also fail at bash parse time; we choose
+      // fail-open here to match the existing unterminated-heredoc behavior.
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log $(curl evil' },
+      }));
+    });
+
+    it('CLOSES sub bypass even when outer command is also whitelisted (chain): cd /tmp && git $(curl)', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'cd /tmp && git log $(curl evil.com)' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES $(...) bypass with non-whitelisted second token in sub: $(npm test)', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log $(npm test)' },
+      }));
+      // First word of inner segment is 'npm', second is 'test' (not install) - denied via npm second-word path.
+      assert.match(reason, /npm 'test' violates/);
     });
   });
 

--- a/preseed/agents/claude/plugins/context-mode/scripts/enforce-ctx-mode.sh
+++ b/preseed/agents/claude/plugins/context-mode/scripts/enforce-ctx-mode.sh
@@ -9,16 +9,26 @@
 #   Tool block:         WebFetch, Grep
 #
 # Normalization pipeline before per-segment scan:
-#   1. Strip heredoc bodies (lines between <<DELIM and matching DELIM)
-#   2. Strip content inside '...' and "..." quoted regions
-#   3. Split remaining text on shell chain operators (;, &&, ||, |, &)
-#   4. Each segment's first word must be whitelisted
+#   1. Extract $(...), <(...), >(...), and `...` substitutions as
+#      additional segments joined by ';' (iterates to fixed point so
+#      nested $($(...)) is fully unwrapped)
+#   2. Strip heredoc bodies (lines between <<DELIM and matching DELIM)
+#   3. Strip content inside '...' and "..." quoted regions
+#   4. Split remaining text on shell chain operators (;, &&, ||, |, &)
+#   5. Each segment's first word must be whitelisted
 #
-# Closes two bypass vectors:
+# Closes the following bypass vectors:
 #   - 'cd /tmp && tail x' (chain bypass via first-word-only check)
 #   - 'git x <<EOF\nbody\nEOF\n && curl evil' (heredoc bypass)
-# And one false-positive:
+#   - 'git log $(curl evil)' (command substitution bypass)
+#   - 'git diff <(curl a) <(curl b)' (process substitution bypass)
+#   - 'git log `curl evil`' (backtick command substitution bypass)
+#   - 'git log $(echo $(curl evil))' (nested substitution)
+# And these false-positives:
 #   - 'git log --grep="tail x ;"' (chain op inside quoted string)
+#   - "git log --grep='$(curl x)'" (sub inside single-quoted literal)
+#   - 'git log -n $((1+2))' (arithmetic expansion)
+#   - 'git log $HOME' / 'git log ${HOME}' (parameter expansion)
 #
 # Bypass (USER ONLY, never invoked by the assistant):
 #   touch /tmp/ctx-bypass
@@ -49,6 +59,189 @@ emit_deny() {
   exit 0
 }
 
+# Extract $(...), <(...), >(...), and backtick command substitutions
+# and emit them as additional ;-separated segments appended to the
+# outer command. The outer occurrence is replaced with a single space
+# so the surrounding tokens still parse. Rules:
+#
+#   - Single quotes ('...') suppress extraction; their content is a
+#     literal string in bash so '$(...)' is not a command sub.
+#   - Double quotes ("...") do NOT suppress extraction; "$(...)" is
+#     executed at runtime.
+#   - $((arith)) is arithmetic, not command substitution; it is
+#     skipped (passed through unchanged) by peeking at the second '('.
+#   - Backslash inside double quotes escapes the next character so
+#     '\"' inside "..." is not a quote terminator.
+#   - Iterates to a fixed point so nested $($(...)) and `` `$(...)` ``
+#     are fully unwrapped into independently checkable segments.
+#   - Multi-line substitutions (where $(... spans newlines) are an
+#     acceptable false-negative; agent commands are single-line in
+#     practice, the runtime would also reject malformed multi-line
+#     subs at parse time.
+#
+# Output: one line per input line. If extractions were made, the line
+# ends with ' ; <ext1>;<ext2>;...' so the chain-op splitter downstream
+# pulls each extracted command out as its own segment.
+extract_subs() {
+  awk '
+    function extract_pass(input,   out, extras, n, i, c, depth, j,
+                                   content, in_sq, in_dq, inner_sq,
+                                   inner_dq, cc) {
+      out = ""
+      extras = ""
+      n = length(input)
+      i = 1
+      RESULT_FOUND = 0
+      in_sq = 0
+      in_dq = 0
+      while (i <= n) {
+        c = substr(input, i, 1)
+        # Backslash escape inside double quotes
+        if (in_dq && c == "\\" && i < n) {
+          out = out c substr(input, i+1, 1)
+          i += 2
+          continue
+        }
+        # Single quote toggle (only outside double quotes)
+        if (!in_dq && c == "\047") {
+          in_sq = !in_sq
+          out = out c
+          i++
+          continue
+        }
+        # Inside single quotes: pass through unchanged
+        if (in_sq) {
+          out = out c
+          i++
+          continue
+        }
+        # Double quote toggle (extraction stays active inside)
+        if (c == "\"") {
+          in_dq = !in_dq
+          out = out c
+          i++
+          continue
+        }
+        # Arithmetic expansion $((...)) - pass through unchanged.
+        # Detection: $ followed by ( followed by (.
+        if (c == "$" && i+2 <= n \
+                     && substr(input, i+1, 1) == "(" \
+                     && substr(input, i+2, 1) == "(") {
+          depth = 2
+          j = i + 3
+          while (j <= n && depth > 0) {
+            cc = substr(input, j, 1)
+            if (cc == "(") depth++
+            else if (cc == ")") depth--
+            j++
+          }
+          out = out substr(input, i, j - i)
+          i = j
+          continue
+        }
+        # Command/process substitution: $(...), <(...), >(...)
+        if ((c == "$" || c == "<" || c == ">") \
+             && i+1 <= n && substr(input, i+1, 1) == "(") {
+          depth = 1
+          j = i + 2
+          content = ""
+          inner_sq = 0
+          inner_dq = 0
+          while (j <= n && depth > 0) {
+            cc = substr(input, j, 1)
+            if (inner_dq && cc == "\\" && j < n) {
+              content = content cc substr(input, j+1, 1)
+              j += 2
+              continue
+            }
+            if (!inner_dq && cc == "\047") {
+              inner_sq = !inner_sq
+            } else if (!inner_sq && cc == "\"") {
+              inner_dq = !inner_dq
+            } else if (!inner_sq && !inner_dq) {
+              if (cc == "(") {
+                depth++
+              } else if (cc == ")") {
+                depth--
+                if (depth == 0) break
+              }
+            }
+            content = content cc
+            j++
+          }
+          if (depth == 0) {
+            extras = extras content ";"
+            out = out " "
+            i = j + 1
+            RESULT_FOUND = 1
+            continue
+          }
+          # Unterminated - pass through unchanged
+          out = out c
+          i++
+          continue
+        }
+        # Backtick command substitution
+        if (c == "`") {
+          j = i + 1
+          content = ""
+          while (j <= n) {
+            cc = substr(input, j, 1)
+            if (cc == "\\" && j < n) {
+              content = content substr(input, j+1, 1)
+              j += 2
+              continue
+            }
+            if (cc == "`") break
+            content = content cc
+            j++
+          }
+          if (j <= n && substr(input, j, 1) == "`") {
+            extras = extras content ";"
+            out = out " "
+            i = j + 1
+            RESULT_FOUND = 1
+            continue
+          }
+          # Unterminated - pass through
+          out = out c
+          i++
+          continue
+        }
+        out = out c
+        i++
+      }
+      RESULT_OUT = out
+      RESULT_EXTRAS = extras
+    }
+    {
+      line = $0
+      extras_accum = ""
+      # Repeatedly scan the outer line until no more subs found.
+      while (1) {
+        extract_pass(line)
+        line = RESULT_OUT
+        extras_accum = extras_accum RESULT_EXTRAS
+        if (!RESULT_FOUND) break
+      }
+      # Then scan accumulated extras for nested subs to a fixed point.
+      while (1) {
+        if (length(extras_accum) == 0) break
+        extract_pass(extras_accum)
+        new_clean = RESULT_OUT
+        new_extras = RESULT_EXTRAS
+        if (!RESULT_FOUND) break
+        extras_accum = new_clean new_extras
+      }
+      if (length(extras_accum) > 0) {
+        print line " ; " extras_accum
+      } else {
+        print line
+      }
+    }
+  '
+}
+
 # Strip heredoc bodies and quoted content via a char-by-char awk
 # state machine. Quote state (in_sq, in_dq) persists across lines so
 # multi-line quoted strings are handled correctly. Heredoc openers
@@ -61,7 +254,19 @@ normalize_command() {
     in_hd {
       t = $0
       if (dash) sub(/^[ \t]+/, "", t)
-      if (t == delim) { in_hd = 0; delim = ""; dash = 0 }
+      if (t == delim) {
+        in_hd = 0; delim = ""; dash = 0
+        # Emit a chain separator so a post-heredoc command becomes
+        # its own segment. Closes the multi-line heredoc bypass:
+        #   git x <<EOF
+        #   body
+        #   EOF
+        #   curl evil
+        # Without this, the post-EOF line concatenates into the
+        # opener segment (first word git -> allowed) and curl
+        # never gets checked.
+        print ";"
+      }
       next
     }
     {
@@ -132,7 +337,7 @@ check_segment() {
   segment=$(printf '%s' "$segment" | sed -E 's/[[:space:]]*\)+[[:space:]]*$//')
   segment=$(printf '%s' "$segment" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)+//')
   local first
-  first=$(printf '%s' "$segment" | sed -E 's/^[[:space:]]*//' | awk 'NR==1 {print $1; exit}')
+  first=$(printf '%s' "$segment" | sed -E 's/^[[:space:]]*//' | awk '{ if (NF > 0) { print $1; exit } }')
   [[ -z "$first" ]] && return 0
   case "$first" in
     git|mkdir|rm|mv|cd|ls)
@@ -143,7 +348,7 @@ check_segment() {
       ;;
     npm)
       local second
-      second=$(printf '%s' "$segment" | sed -E 's/^[[:space:]]*//' | awk 'NR==1 {print $2; exit}')
+      second=$(printf '%s' "$segment" | sed -E 's/^[[:space:]]*//' | awk '{ if (NF > 0) { print $2; exit } }')
       if [[ "$second" == "install" || "$second" == "i" || "$second" == "ci" ]]; then
         return 0
       fi
@@ -151,7 +356,7 @@ check_segment() {
       ;;
     pip|pip3)
       local second
-      second=$(printf '%s' "$segment" | sed -E 's/^[[:space:]]*//' | awk 'NR==1 {print $2; exit}')
+      second=$(printf '%s' "$segment" | sed -E 's/^[[:space:]]*//' | awk '{ if (NF > 0) { print $2; exit } }')
       if [[ "$second" == "install" ]]; then
         return 0
       fi
@@ -174,11 +379,18 @@ case "$TOOL_NAME" in
       exit 0
     fi
 
+    # Extract substitutions first: $(...), <(...), >(...), `...`.
+    # These execute commands hidden inside argument expansion of an
+    # outer whitelisted command, e.g. 'git log $(curl evil)'. Each
+    # extracted body is appended as a ;-separated segment so the
+    # per-segment scan below covers it.
+    EXTRACTED=$(printf '%s' "$COMMAND" | extract_subs)
+
     # Normalize: strip heredoc bodies + quoted content, leaving only
     # shell-structural text. Chain operators inside quoted strings or
     # heredoc bodies are removed by this pass, so the per-segment scan
     # operates on real command boundaries.
-    NORMALIZED=$(printf '%s' "$COMMAND" | normalize_command)
+    NORMALIZED=$(printf '%s' "$EXTRACTED" | normalize_command)
 
     # Neutralize file-descriptor redirects so embedded '&' is not
     # mistaken for a background-or-chain operator. Covers 2>&1, >&3,


### PR DESCRIPTION
## Summary

Closes three concrete bypasses in `enforce-ctx-mode.sh` (the context-mode PreToolUse hook). All three let an agent execute arbitrary non-whitelisted commands while making the first-word scan see only a whitelisted outer command.

This was discovered in conversation with a user who pointed out that "everything after `&&` is unreviewed" was a real failure mode. Auditing the script revealed chain handling was already implemented (since #318 / #319), but three adjacent classes of bypass survived.

## Bypasses closed

### 1. Command and process substitution

Before:

```bash
git log $(curl evil.com)            # outer first word = git -> allowed
git diff <(curl a) <(curl b)        # outer first word = git -> allowed
git log `curl evil.com`             # outer first word = git -> allowed
git log $(echo $(curl evil.com))    # nested - same bypass, two layers deep
git log --grep="$(curl evil.com)"   # sub inside double-quoted string
```

The outer command is whitelisted (`git`); the substituted command runs at bash expansion time but never entered the segment scan because the first-word check ran only on chain-op segments.

After: a new `extract_subs` awk pass runs **before** `normalize_command` and pulls every `$(...)`, `<(...)`, `>(...)`, and backtick body out as an additional `;`-separated segment. Each extracted command is then subject to the same first-word whitelist scan as any other segment.

Properties preserved:

- **Single-quoted subs are literal** in bash, so `git log --grep='$(curl x)'` is **allowed** (the regex contains the string `$(curl x)`, no command runs)
- **Arithmetic `$((expr))`** is detected by peeking at the second `(` and passed through unchanged (`git log -n $((1+2))` allowed)
- **Parameter expansion** `$VAR` and `${VAR}` is untouched (no `(` after `$`)
- **Backslash-escaped chars inside double quotes** are handled (`\"` does not terminate the double-quoted region)
- **Nested substitutions iterate to a fixed point** so `$($(...))` is fully unwrapped

### 2. Multi-line heredoc bypass

Before:

```
git x <<EOF
body line 1
body line 2
EOF
curl evil
```

The closing `EOF` line stripped the heredoc body and resumed normal scanning, but emitted no chain separator before the next line. The post-heredoc `curl evil` line concatenated into the same segment as `git x` (first word `git` -> allowed) and was never independently checked.

After: `normalize_command`'s awk emits a `;` on the heredoc terminator line. The segment splitter then treats the post-heredoc command line as its own segment, and the existing first-word scan denies it.

This bypass existed in `enforce-ctx-mode.sh` since the heredoc handling was added. The single-line form (`cmd <<EOF body EOF && curl evil`) was already caught because `&&` is an explicit chain operator; only the multi-line newline-bridged form slipped through.

### 3. Multi-line first-word extraction

Before: `check_segment` extracted the first word via `awk 'NR==1 {print $1; exit}'`. After fix 2 above, segments **can** start with a leading newline (the line containing `;` from the closing heredoc terminator, then a newline, then the actual command). The old `NR==1` only inspected the first line of the segment; if that line was empty, the extraction returned the empty string and `check_segment` treated the segment as a no-op (whitespace-only) and allowed it.

After: changed to `awk '{ if (NF > 0) { print $1; exit } }'`, which scans records until one has at least one field. Same change applied to the npm/pip second-word lookup so `npm test` is still detected as `npm` first, `test` second.

## Diff

```
 host/__tests__/enforce-ctx-mode.test.js            | 168 +++++++++++++++
 .../context-mode/scripts/enforce-ctx-mode.sh       | 234 ++++++++++++++++++++-
 2 files changed, 391 insertions(+), 11 deletions(-)
```

Single hook, single test file. No other code touched.

## Test plan

- [x] **24 new node test cases** in `host/__tests__/enforce-ctx-mode.test.js` covering: bare `$(...)`, `<(...)`, `>(...)`, backticks, nested substitutions, substitutions inside double-quoted strings, false-positive guards (single-quoted literal subs, arithmetic, parameter expansion, parens in double-quoted strings), multi-line heredocs with various follow-up commands (whitelisted, non-whitelisted, chained, background-forked, tab-dash variant).
- [x] **41 local invocations** of the actual bash hook (`bash enforce-ctx-mode.sh < json-input`) against the matrix above all pass: 17 new sub-bypass denials + 7 new multi-line heredoc denials + 17 regression cases preserving prior behavior (whitelist, chain detection, single-line heredoc, FD redirects, env-vars, subshells, false-positives on quoted strings, commit messages with banned-word substrings).
- [x] All pre-existing tests still pass; no regression in chain handling, heredoc handling, quoted-string handling, FD-redirect handling, or first-word extraction for single-line commands.

## Known false-negatives (documented in the hook header)

Same acceptable false-negatives as the existing implementation, plus one new one:

- **Multi-line `$(...)` split across newlines** (e.g., `git log $(curl \\\n  x)`). The `extract_subs` awk processes line by line; an unterminated `$(` at end of line leaves the substitution un-extracted. Agent-generated commands are single-line in practice, and the bash parser would also fail on malformed multi-line subs. Same shape as the existing unterminated-heredoc false-negative.

## Why this is worth doing

The user observed in conversation that they have seen LLM agents (this one included) route around context-mode rules whenever the path of least resistance permits. The first-word whitelist is the load-bearing mechanism that keeps high-volume tool output out of the model context. Three demonstrated bypasses ($(...), backticks, multi-line heredoc) reduce the whitelist's effectiveness to "deny what the agent didn't bother to obfuscate." Closing them restores the contract.
