### PR TITLE
fix(hooks): close $((...)) arithmetic-nested command-substitution bypass in enforce-ctx-mode

### DIFF
--- a/host/__tests__/enforce-ctx-mode.test.js
+++ b/host/__tests__/enforce-ctx-mode.test.js
@@ -492,6 +492,67 @@ describe('enforce-ctx-mode hook', () => {
       }));
     });
 
+    it('allows nested arithmetic-only $(($((1+2)) + 3)) with no inner command sub', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log -n $(($((1+2)) + 3))' },
+      }));
+    });
+
+    it('allows arithmetic with parens-grouped operator: $(( (1+2) * 3 ))', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log -n $(( (1+2) * 3 ))' },
+      }));
+    });
+
+    it('CLOSES arithmetic-nested $(...) bypass: $(($(curl evil) + 1))', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log -n $(($(curl evil.com) + 1))' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES arithmetic-nested backtick bypass: $((`curl evil` + 1))', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log -n $((`curl evil` + 1))' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES arithmetic-nested non-network sub: $(($(head /etc/passwd) + 1))', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log -n $(($(head /etc/passwd) + 1))' },
+      }));
+      assert.match(reason, /head violates/);
+    });
+
+    it('CLOSES deeply-nested arithmetic+sub: $(($((1+$(curl x))) + 2))', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log -n $(($((1+$(curl x))) + 2))' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('CLOSES arithmetic-nested sub inside double-quoted string', () => {
+      const reason = deniedReason(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'git log --grep="$(($(curl evil) + 1))"' },
+      }));
+      assert.match(reason, /curl violates/);
+    });
+
+    it('allows arithmetic-nested sub inside single-quoted string (literal)', () => {
+      assertAllowed(runHook({
+        tool_name: 'Bash',
+        tool_input: { command: "git log --grep='$(($(curl x) + 1))'" },
+      }));
+    });
+
     it('allows parameter expansion $VAR and ${VAR}', () => {
       assertAllowed(runHook({
         tool_name: 'Bash',

--- a/preseed/agents/claude/plugins/context-mode/scripts/enforce-ctx-mode.sh
+++ b/preseed/agents/claude/plugins/context-mode/scripts/enforce-ctx-mode.sh
@@ -24,6 +24,8 @@
 #   - 'git diff <(curl a) <(curl b)' (process substitution bypass)
 #   - 'git log `curl evil`' (backtick command substitution bypass)
 #   - 'git log $(echo $(curl evil))' (nested substitution)
+#   - 'git log -n $(($(curl evil) + 1))' (sub inside arithmetic)
+#   - 'git log -n $((`curl evil` + 1))' (backtick inside arithmetic)
 # And these false-positives:
 #   - 'git log --grep="tail x ;"' (chain op inside quoted string)
 #   - "git log --grep='$(curl x)'" (sub inside single-quoted literal)
@@ -68,8 +70,12 @@ emit_deny() {
 #     literal string in bash so '$(...)' is not a command sub.
 #   - Double quotes ("...") do NOT suppress extraction; "$(...)" is
 #     executed at runtime.
-#   - $((arith)) is arithmetic, not command substitution; it is
-#     skipped (passed through unchanged) by peeking at the second '('.
+#   - $((arith)) is arithmetic, not command substitution, but its
+#     body IS recursively scanned for inner $(...) / backticks since
+#     bash executes those at arithmetic-evaluation time and treats
+#     their stdout as a numeric operand. Arithmetic-only bodies like
+#     $((1+2)) stay allowed; $(($(curl x) + 1)) emits 'curl x' as a
+#     separate segment that the first-word whitelist then denies.
 #   - Backslash inside double quotes escapes the next character so
 #     '\"' inside "..." is not a quote terminator.
 #   - Iterates to a fixed point so nested $($(...)) and `` `$(...)` ``
@@ -86,7 +92,8 @@ extract_subs() {
   awk '
     function extract_pass(input,   out, extras, n, i, c, depth, j,
                                    content, in_sq, in_dq, inner_sq,
-                                   inner_dq, cc) {
+                                   inner_dq, cc, arith_body,
+                                   saved_found) {
       out = ""
       extras = ""
       n = length(input)
@@ -122,8 +129,13 @@ extract_subs() {
           i++
           continue
         }
-        # Arithmetic expansion $((...)) - pass through unchanged.
-        # Detection: $ followed by ( followed by (.
+        # Arithmetic expansion $((...)) - keep the arithmetic shell
+        # in place, but recursively scan its body for inner command
+        # substitutions. Bash DOES execute $(cmd) and `cmd` inside
+        # $((...)) - the inner stdout is parsed as numeric and used
+        # as an operand. Without this recursion the body would be
+        # opaque pass-through and an inner $(curl evil) would bypass
+        # the first-word whitelist. Detection: $ followed by ( ( .
         if (c == "$" && i+2 <= n \
                      && substr(input, i+1, 1) == "(" \
                      && substr(input, i+2, 1) == "(") {
@@ -135,6 +147,19 @@ extract_subs() {
             else if (cc == ")") depth--
             j++
           }
+          if (depth == 0) {
+            arith_body = substr(input, i+3, j - i - 5)
+            saved_found = RESULT_FOUND
+            extract_pass(arith_body)
+            out = out "$((" RESULT_OUT "))"
+            extras = extras RESULT_EXTRAS
+            if (RESULT_FOUND) saved_found = 1
+            RESULT_FOUND = saved_found
+            i = j
+            continue
+          }
+          # Unterminated arithmetic - pass through unchanged (fail-open,
+          # same shape as the existing unterminated $(...) handling).
           out = out substr(input, i, j - i)
           i = j
           continue


### PR DESCRIPTION
## Summary

Closes a fourth bypass class in `enforce-ctx-mode.sh` that was left open by #323/#324: command substitution nested inside arithmetic expansion.

The arithmetic guard previously treated `$((...))` as opaque pass-through, scanning only for balanced parens. But bash **does execute** `$(cmd)` and backticks inside arithmetic — the inner stdout is parsed as numeric and used as the arithmetic operand. The outer command's first word stays `git`, the substitution is never extracted, and `curl` runs without entering the segment scan.

## Bypass closed

Before:

```bash
git log -n $(($(curl evil.com) + 1))   # outer first word = git -> allowed
git log -n $((`curl evil` + 1))         # same - backtick variant
git log -n $(($(head /etc/passwd) + 1)) # same - non-network variant
```

After: when arithmetic is detected, `extract_pass` recurses on the body. Inner `$(...)` and backticks emit as separate segments that the first-word whitelist then checks. The arithmetic shell (`$((...))`) stays intact in the cleaned outer command, so arithmetic-only expressions remain allowed.

## Properties preserved

- `$((1+2))` allowed (no inner sub)
- `$(($((1+2)) + 3))` allowed (nested arithmetic-only)
- `$(())` allowed (empty arithmetic)
- `$(( (1+2) * 3 ))` allowed (grouped operators)
- `'$(($(curl x) + 1))'` allowed (single-quoted literal)
- Unterminated arithmetic falls through unchanged (fail-open, same shape as existing unterminated-`$(...)` behavior)

## Diff

```
 host/__tests__/enforce-ctx-mode.test.js            | 61 ++++++++++++++++++++++
 .../context-mode/scripts/enforce-ctx-mode.sh       | 35 +++++++++++--
 2 files changed, 91 insertions(+), 5 deletions(-)
```

## Test plan

- [x] 8 new node test cases covering arithmetic-nested `$(...)`, arithmetic-nested backticks, deep nesting, double-quoted host, single-quoted literal guard, and the false-positive guards for arithmetic-only nesting and grouped operators
- [x] 18 local hook invocations pass: 5 new bypass denials, 6 false-positive guards, 7 regression cases for prior closures
- [x] Deny reasons correctly name the inner command (`curl`, `head`) — verified with three trace cases

## Why this is worth doing

#324's PR description frames itself as closing the "outer-first-word-only" class of bypasses. Shipping with `$((...))` still opaque leaves the same class open one level deeper — exactly the failure mode the PR cites ("everything inside X is unreviewed"). Closing this completes the bypass-class closure.
