### PR TITLE
fix(trivy): suppress unfixed curl CVE-2026-5773

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -277,3 +277,10 @@ CVE-2026-33814
 CVE-2026-39820
 CVE-2026-39836
 CVE-2026-42499
+
+# curl / libcurl3-gnutls / libcurl4 7.88.1-10+deb12u14: wrong file transfer
+# due to incorrect SMB connection reuse. Container uses curl exclusively for
+# outbound HTTPS (git-over-HTTPS, package fetches); the SMB protocol is not
+# invoked and no SMB URLs are ever constructed. No fix available in Debian
+# bookworm.
+CVE-2026-5773


### PR DESCRIPTION
## Summary
- Trivy scan on the deploy workflow (run 25832116341) failed with 3 HIGH findings, all from `CVE-2026-5773` against curl / libcurl3-gnutls / libcurl4 7.88.1-10+deb12u14.
- Debian bookworm has no fix yet (status `affected`, empty Fixed Version).
- Container only uses curl for outbound HTTPS (git-over-HTTPS, package fetches); SMB protocol is never invoked, so the SMB connection-reuse exposure does not apply.
- Added the CVE to `.trivyignore` with justification matching the existing entry style.

## Test plan
- [ ] Deploy workflow on this PR's merge commit reaches the "Scan container image for vulnerabilities" step and exits 0.
- [ ] No new CVEs surface beyond the suppressed one.