### PR TITLE
ci(deploy): raise deploy job timeout from 20 to 30 minutes

### DIFF
--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -47,7 +47,7 @@ jobs:
     # would still be satisfied - the gate must be on the job that
     # actually performs the deploy.
     environment: ${{ github.ref == 'refs/heads/main' && (inputs.environment || 'production') || 'integration' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME || 'codeflare' }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     environment: ${{ github.ref == 'refs/heads/main' && (inputs.environment || 'production') || 'integration' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME || 'codeflare' }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Raises `timeout-minutes` on the deploy job from **20** to **30** in both `deploy.yml` (Cloudflare registry path) and `deploy-dockerhub.yml` (Docker Hub bypass path).

## Why

The AD52 graphify integration added ~220 MB to the container image (Python 3 + uv + `graphifyy[mcp,sql,pdf]`). Recent runs show the deploy job consuming nearly the full 20-minute budget on the image-push step alone:

| Step | Duration (last cancelled run) |
|---|---|
| Push image to Docker Hub | **924 s (15m 24s)** |
| Scan container image for vulnerabilities | 108 s |
| Build container image | 46 s |
| Backend tests | 41 s |
| Everything else | ~30 s |

The deploy itself completes — wrangler reports `Success`, all secrets upload, the worker is live — but GitHub Actions enforces the `timeout-minutes: 20` job cap and cancels the workflow during post-step cleanup. Result: a green deploy is marked `cancelled` and the next workflow's status check fails.

## Why both files

`deploy.yml` and `deploy-dockerhub.yml` push the same image. The Cloudflare registry path (`wrangler containers push`) currently fits inside 20 minutes because the registry sits on the Cloudflare backbone, but the same ~220 MB layer is now in flight there too. Bumping both keeps them in lockstep and avoids a follow-up PR the first time the CF push slows down.

## Follow-up (not in this PR)

The underlying issue is that neither workflow uses BuildKit registry cache. `docker buildx use default` + plain `docker build` with no `--cache-from` / `--cache-to` produces fresh layer SHAs every run, so registry-side blob dedup can't kick in. A separate PR should wire:

```
docker buildx build \
  --cache-from type=registry,ref=${IMAGE}-buildcache \
  --cache-to   type=registry,ref=${IMAGE}-buildcache,mode=max \
  ...
```

That removes the underlying slowness for both deploy paths and lets us walk the timeout back down.

## Test plan

- [x] Local: `yamllint` parses cleanly (manual diff inspection — single-character change in each file).
- [ ] Next deploy on integration runs under 30m and completes without cancellation.
