### PR TITLE
ci(deploy): wire BuildKit type=gha cache for both deploy paths

### DIFF
--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -232,8 +232,8 @@ jobs:
           # so the Trivy scan and the docker push that follow can
           # reference it by tag, unchanged.
           docker buildx build --platform linux/amd64 \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
+            --cache-from type=gha,scope=dockerhub \
+            --cache-to type=gha,mode=max,scope=dockerhub \
             --load \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             -t "${IMAGE_NAME}:${IMAGE_TAG}" .

--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -32,6 +32,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: write  # type=gha buildx cache writes to the Actions cache service
 
 jobs:
   deploy:
@@ -216,15 +217,24 @@ jobs:
         if: ${{ vars.CLAUDE_CODE_CACHE_BUSTER == 'active' }}
         run: echo "${{ github.sha }}" > .cache-bust
 
-      - name: Use default Docker builder
-        run: docker buildx use default
+      # The 'default' docker builder doesn't support type=gha cache. The
+      # docker-container driver (provisioned by setup-buildx-action) does
+      # and is what unlocks --cache-from / --cache-to against the
+      # built-in GitHub Actions cache service. No extra registry creds.
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build container image
         id: docker-build
         run: |
           IMAGE_TAG="${{ github.sha }}"
           IMAGE_NAME="${WORKER_NAME}-container"
-          docker build --platform linux/amd64 \
+          # --load keeps the image available to the local docker daemon
+          # so the Trivy scan and the docker push that follow can
+          # reference it by tag, unchanged.
+          docker buildx build --platform linux/amd64 \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --load \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             -t "${IMAGE_NAME}:${IMAGE_TAG}" .
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,8 +239,8 @@ jobs:
           # so the Trivy scan step and the wrangler push step that follow
           # can reference it by tag, unchanged.
           docker buildx build --platform linux/amd64 \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
+            --cache-from type=gha,scope=cloudflare \
+            --cache-to type=gha,mode=max,scope=cloudflare \
             --load \
             -t "${IMAGE_NAME}:${IMAGE_TAG}" .
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: write  # type=gha buildx cache writes to the Actions cache service
 
 jobs:
   deploy:
@@ -223,15 +224,25 @@ jobs:
         if: ${{ vars.CLAUDE_CODE_CACHE_BUSTER == 'active' }}
         run: echo "${{ github.sha }}" > .cache-bust
 
-      - name: Use default Docker builder
-        run: docker buildx use default
+      # The 'default' docker builder doesn't support type=gha cache. The
+      # docker-container driver (provisioned by setup-buildx-action) does
+      # and is what unlocks --cache-from / --cache-to against the
+      # built-in GitHub Actions cache service. No extra registry creds.
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build container image
         id: docker-build
         run: |
           IMAGE_TAG="${{ github.sha }}"
           IMAGE_NAME="${WORKER_NAME}-container"
-          docker build --platform linux/amd64 -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+          # --load keeps the image available to the local docker daemon
+          # so the Trivy scan step and the wrangler push step that follow
+          # can reference it by tag, unchanged.
+          docker buildx build --platform linux/amd64 \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --load \
+            -t "${IMAGE_NAME}:${IMAGE_TAG}" .
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
           echo "local_ref=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Wires BuildKit registry cache via `type=gha` (the built-in GitHub Actions cache service) in both `deploy.yml` and `deploy-dockerhub.yml`. Addresses the root cause of slow image pushes that motivated #357.

## Why

The previous setup did `docker buildx use default` followed by plain `docker build`. Two problems compound:

1. The **default** builder uses the docker driver, which **does not** support `type=gha` cache. Only the `docker-container` driver does.
2. The build command had no `--cache-from` / `--cache-to`, so even if the driver had supported cache, none was being imported or exported.

Result: every CI run produced fresh layer SHAs for every step, even for unchanged ones. Both deploy paths paid the full ~220 MB graphify layer upload on every run.

## What changes

In each workflow:

1. Replace `docker buildx use default` with `docker/setup-buildx-action@v3.12.0`, which provisions a `docker-container` driver builder.
2. Convert `docker build` → `docker buildx build` with:
   - `--cache-from type=gha`
   - `--cache-to type=gha,mode=max`
   - `--load` (so the built image lands in the local docker daemon, keeping the existing Trivy scan and the existing push steps unchanged).
3. Add `actions: write` to the workflow `permissions:` block — required for the GHA cache backend to export.

## Trade-offs (honest)

- **First run after this lands is slower, not faster.** The cache is cold; buildx has to upload it. Savings show up on run 2 onward.
- **GHA cache quota is 10 GB per repo.** Our compressed image is ~1-2 GB, so multi-branch caching is safe, but worth monitoring (GitHub LRU-evicts when full).
- **Layer-order in `Dockerfile` matters.** If a frequently-changing step sits above the expensive graphify install, cache invalidates from there down. A separate audit may be worthwhile later, but the current `Dockerfile` already puts apt/uv layers before app-code layers, which is the right order.

## Independence from #357

#357 raises `timeout-minutes` 20 → 30 as a band-aid until caching lands. This PR fixes the underlying cause. The two PRs touch the same files in different sections; whichever lands first, the other rebases cleanly. Once both are merged and we've confirmed cache hits are working, we can walk the timeout back down.

## Test plan

- [ ] First deploy on integration after merge: confirm `setup-buildx-action` step succeeds and build completes (even if slow — cache cold).
- [ ] Second deploy on integration: confirm GHA cache `import` reports hits in the build log and total job time drops.
- [ ] Trivy still scans the image (image is `--load`ed, tagged locally).
- [ ] `docker push` to Docker Hub / `wrangler containers push` to Cloudflare still succeed using the locally-tagged image.
