### PR TITLE
ci(deploy): raise timeout + wire BuildKit type=gha cache

### DIFF
--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -232,8 +232,8 @@ jobs:
           # so the Trivy scan and the docker push that follow can
           # reference it by tag, unchanged.
           docker buildx build --platform linux/amd64 \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
+            --cache-from type=gha,scope=dockerhub \
+            --cache-to type=gha,mode=max,scope=dockerhub \
             --load \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             -t "${IMAGE_NAME}:${IMAGE_TAG}" .

--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -32,6 +32,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: write  # type=gha buildx cache writes to the Actions cache service
 
 jobs:
   deploy:
@@ -216,15 +217,24 @@ jobs:
         if: ${{ vars.CLAUDE_CODE_CACHE_BUSTER == 'active' }}
         run: echo "${{ github.sha }}" > .cache-bust
 
-      - name: Use default Docker builder
-        run: docker buildx use default
+      # The 'default' docker builder doesn't support type=gha cache. The
+      # docker-container driver (provisioned by setup-buildx-action) does
+      # and is what unlocks --cache-from / --cache-to against the
+      # built-in GitHub Actions cache service. No extra registry creds.
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build container image
         id: docker-build
         run: |
           IMAGE_TAG="${{ github.sha }}"
           IMAGE_NAME="${WORKER_NAME}-container"
-          docker build --platform linux/amd64 \
+          # --load keeps the image available to the local docker daemon
+          # so the Trivy scan and the docker push that follow can
+          # reference it by tag, unchanged.
+          docker buildx build --platform linux/amd64 \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --load \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             -t "${IMAGE_NAME}:${IMAGE_TAG}" .
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -47,7 +47,7 @@ jobs:
     # would still be satisfied - the gate must be on the job that
     # actually performs the deploy.
     environment: ${{ github.ref == 'refs/heads/main' && (inputs.environment || 'production') || 'integration' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME || 'codeflare' }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,8 +239,8 @@ jobs:
           # so the Trivy scan step and the wrangler push step that follow
           # can reference it by tag, unchanged.
           docker buildx build --platform linux/amd64 \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
+            --cache-from type=gha,scope=cloudflare \
+            --cache-to type=gha,mode=max,scope=cloudflare \
             --load \
             -t "${IMAGE_NAME}:${IMAGE_TAG}" .
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     environment: ${{ github.ref == 'refs/heads/main' && (inputs.environment || 'production') || 'integration' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME || 'codeflare' }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: write  # type=gha buildx cache writes to the Actions cache service
 
 jobs:
   deploy:
@@ -223,15 +224,25 @@ jobs:
         if: ${{ vars.CLAUDE_CODE_CACHE_BUSTER == 'active' }}
         run: echo "${{ github.sha }}" > .cache-bust
 
-      - name: Use default Docker builder
-        run: docker buildx use default
+      # The 'default' docker builder doesn't support type=gha cache. The
+      # docker-container driver (provisioned by setup-buildx-action) does
+      # and is what unlocks --cache-from / --cache-to against the
+      # built-in GitHub Actions cache service. No extra registry creds.
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build container image
         id: docker-build
         run: |
           IMAGE_TAG="${{ github.sha }}"
           IMAGE_NAME="${WORKER_NAME}-container"
-          docker build --platform linux/amd64 -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+          # --load keeps the image available to the local docker daemon
+          # so the Trivy scan step and the wrangler push step that follow
+          # can reference it by tag, unchanged.
+          docker buildx build --platform linux/amd64 \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --load \
+            -t "${IMAGE_NAME}:${IMAGE_TAG}" .
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
           echo "local_ref=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

CI hygiene for the deploy workflows. Rolls up #357 + #358 + scope-isolation follow-up into a single integration PR.

## What's in here

1. **`timeout-minutes: 20 → 30`** on both `deploy.yml` and `deploy-dockerhub.yml`. AD52's graphify addition pushed the deploy job past the old 20-minute cap; runs were succeeding substantively but getting cancelled during post-step cleanup.
2. **BuildKit `type=gha` cache** wired into both workflows:
   - `docker/setup-buildx-action@v3.12.0` (SHA-pinned) provisions a `docker-container` driver builder that supports the GHA cache backend.
   - `docker build` → `docker buildx build --cache-from type=gha --cache-to type=gha,mode=max --load`.
   - `--load` keeps the image in the local docker daemon so Trivy + wrangler push + docker push steps work unchanged.
   - `actions: write` permission added (required for `type=gha` cache export).
3. **Per-workflow cache scopes** (`scope=cloudflare` / `scope=dockerhub`) so the two workflows can never race on a shared cache key.

## Why three commits' worth instead of one

#357 was the band-aid (raise timeout); #358 was the root-cause fix (cache); the scope-isolation came out of code review on #358. Folded into a single develop-to-main PR per the integration-branch workflow.

## Trade-offs

- First deploy after merge is still cold (no cache yet). Savings show up from run 2.
- GHA cache quota is 10 GB per repo; two scopes × ~1-2 GB image keeps us well under.
- Once cache hits are confirmed in production, the 30m timeout can be walked back down in a follow-up.

## Test plan

- [x] Code review run on both PRs - clean, 1 MEDIUM addressed (scope isolation).
- [ ] Integration deploy from develop completes under 30m.
- [ ] Second integration deploy shows GHA cache hits in build log.
- [ ] Production deploy from main after merge.
