### PR TITLE
chore(trivy): suppress 3 new HIGH CVEs (curl, libexpat, lazygit)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -284,3 +284,25 @@ CVE-2026-42499
 # invoked and no SMB URLs are ever constructed. No fix available in Debian
 # bookworm.
 CVE-2026-5773
+
+# curl / libcurl3-gnutls / libcurl4 7.88.1-10+deb12u14: information disclosure
+# via cookie leak when reusing connections with different credentials. Same
+# exposure profile as CVE-2026-5773 above: container uses curl exclusively for
+# outbound HTTPS to fixed, trusted endpoints (GitHub raw, PyPI, deb mirrors).
+# No multi-tenant cookie state, no untrusted-host reuse. No fix in bookworm.
+CVE-2026-6276
+
+# libexpat1 2.5.0-1+deb12u2: computational complexity on crafted XML attribute
+# names (DoS). Transitive dep of git, python3, etc. Container parses no
+# untrusted XML at runtime - same exposure profile as the existing
+# CVE-2026-25210 entry above. No fixed version in Debian bookworm.
+CVE-2026-45186
+
+# go-git/go-billy/v5 v5.6.2 embedded in lazygit v0.60.0 binary: path traversal
+# in symlink-followed file operations. Fixed in v5.9.0; lazygit upstream has
+# not yet rebuilt with the patched go-billy. lazygit runs only against the
+# user's own git working trees (trusted local repos cloned via HTTPS); it
+# never operates on attacker-controlled bundles or remote-driven symlinks.
+# Exposure profile is identical to the other "Go stdlib / module in
+# rclone/lazygit binaries" entries above.
+CVE-2026-44973


### PR DESCRIPTION
## Summary

Trivy scan on `main@9a1b3c6` flagged 4 new HIGH findings (3 distinct CVEs across 4 package surfaces; one CVE covers three curl variants). All three were assessed against the container's actual exposure profile and ignored with explicit justification, matching the established `.trivyignore` convention. Unblocks the Deploy workflow.

- **CVE-2026-6276** (curl / libcurl3-gnutls / libcurl4 `7.88.1-10+deb12u14`): cookie leak via connection reuse with different credentials. Container uses curl exclusively for outbound HTTPS to fixed trusted endpoints (GitHub raw, PyPI, deb mirrors). No multi-tenant cookie state, no untrusted-host reuse. No fix in Debian bookworm.
- **CVE-2026-45186** (libexpat1 `2.5.0-1+deb12u2`): computational complexity DoS on crafted XML attribute names. Transitive dep of git/python3. Container parses no untrusted XML at runtime - same exposure profile as the existing CVE-2026-25210 libexpat entry. No fix in bookworm.
- **CVE-2026-44973** (go-git/go-billy/v5 `v5.6.2` in lazygit `v0.60.0` binary): path traversal via symlink-followed file ops. Fixed in `v5.9.0`; lazygit upstream has not rebuilt yet. lazygit runs only against the user's own trusted local repos cloned via HTTPS; never operates on attacker-controlled bundles or remote-driven symlinks.

## REQ backlink

No new REQ. `.trivyignore` is operational hygiene under the established Trivy gate in the deploy workflow; existing exception entries follow the same justification-per-CVE pattern.

## Test plan

- [x] `.trivyignore` syntax preserved (one CVE per line, header comments untouched, monthly-review reminder retained).
- [x] Each new entry includes the same justification structure used by all 60+ pre-existing entries (package + version, exposure profile, fix availability).
- [ ] Deploy workflow re-runs green on the next push to main (the previous run failed at the Trivy scan step on `main@9a1b3c6`).