### PR TITLE
fix(container): bind port 8080 before R2 sync to avoid cold-start crash

### DIFF
--- a/documentation/api-reference.md
+++ b/documentation/api-reference.md
@@ -456,7 +456,33 @@ GET `/public/onboarding-config`, POST `/public/waitlist` (rate limited)
 
 ### Health
 
-GET `/health`, GET `/api/health`
+| Method | Endpoint | Auth | Implements | Description |
+|--------|----------|------|------------|-------------|
+| GET | `/health` | None (auth-exempt — no `CONTAINER_AUTH_TOKEN` required) | TBD | Direct host health check; available before CONTAINER_AUTH_TOKEN is wired up |
+| GET | `/api/health` | Session cookie | TBD | Worker-proxied alias for `/health` |
+
+Both endpoints return the same JSON body:
+
+```json
+{
+  "status": "healthy",
+  "sessions": 0,
+  "uptime": 42,
+  "syncStatus": "idle",
+  "syncError": null,
+  "userPath": "/root",
+  "prewarmReady": false,
+  "initFlagObserved": false,
+  "cpu": 12.5,
+  "mem": 45.2,
+  "hdd": 30.1,
+  "timestamp": "2026-05-15T10:00:00.000Z"
+}
+```
+
+**`initFlagObserved`** — `true` once the server has seen `/tmp/codeflare-init-complete` written by `entrypoint.sh` at the end of R2 sync. A session where `prewarmReady: false` and `initFlagObserved: false` indicates the init-complete flag was never written (sync hung, `jq` merge failed, etc.). See [Container Startup](container.md#startup-sequence) and [Troubleshooting](troubleshooting.md#container-stuck-at-waiting-for-services).
+
+**`prewarmReady`** — `true` once the tab-1 PTY session has produced its first output (pre-warm complete).
 
 ---
 

--- a/documentation/container.md
+++ b/documentation/container.md
@@ -58,14 +58,19 @@ Port: 8080 (single port architecture).
 
 Uses polling with safety timeouts: poll until success OR background process exits OR safety timeout expires. Exit immediately on success. Safety timeout `SYNC_TIMEOUT=120` (2 min) prevents infinite blocking.
 
-### Parallel Startup
+### Startup Sequence
+
+Port 8080 must bind before Cloudflare's container port-wait timeout (~10-15s) elapses. The entrypoint therefore starts the terminal server immediately — before R2 sync — then gates PTY pre-warm behind a flag file written only after sync and configuration complete.
 
 ```mermaid
 flowchart TD
-    A[Container Start] --> B["initial_sync_from_r2()"]
-    B -->|"Blocking — waits for sync to complete"| C["configure_tab_autostart()"]
-    C --> D["Start terminal server (:8080)"]
+    A[Container Start] --> B["Start terminal server (:8080)\n— port binds, PTY pre-warm blocked"]
+    B --> C["initial_sync_from_r2()"]
+    C -->|"Blocking — waits for sync to complete"| D["configure_tab_autostart()"]
+    D --> E["touch /tmp/codeflare-init-complete\n— releases PTY pre-warm"]
 ```
+
+**Init-complete flag:** `CODEFLARE_INIT_FLAG_FILE=/tmp/codeflare-init-complete`. The terminal server polls for this file (every 250ms, up to 90s) before spawning the tab-1 PTY session. This ensures pre-warm reads the fully-restored `.claude.json`, `.bashrc`, and MCP server registrations rather than pre-sync state. If the flag does not appear within 90s, pre-warm proceeds anyway. The flag is deleted and recreated on every container start.
 
 Auto-start uses `claude --dangerously-skip-permissions` for fast boot. Auto-updates are disabled by default via `FAST_CLI_START=true` (see [Fast Start](#fast-start) below). Users can enable auto-updates via Settings.
 

--- a/documentation/security.md
+++ b/documentation/security.md
@@ -295,9 +295,11 @@ File download responses use `Content-Disposition: attachment` with sanitized fil
 
 Base64-encoded inputs are validated with try/catch around `atob()`. Invalid base64 returns 400 immediately rather than propagating decode errors.
 
-### WebSocket Rate Limit
+### WebSocket Rate Limit (REQ-SEC-007)
 
 30 connections per 60-second window per user (`WS_RATE_LIMIT_WINDOW_MS = 60000`, `WS_RATE_LIMIT_MAX_CONNECTIONS = 30`). Defined in `src/lib/constants.ts`.
+
+**Check order in `handleWebSocketUpgrade`:** session-stopped rejection runs first, rate-limit check runs second. WebSocket upgrade requests for sessions whose KV status is `stopped` are rejected immediately with close code 4503 (`container-stopped`) before the rate-limit counter is consulted. This means a browser reconnect storm against a hibernated or crashed container does not consume the user's 30-connection budget. When the container comes back up, the user can reconnect without hitting a self-imposed 429. Implements [REQ-SEC-007 AC10](../sdd/security.md#req-sec-007-rate-limiting-on-all-mutation-endpoints).
 
 ### Session Limits
 

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -24,7 +24,11 @@ Browser retained stale Access session. Test in incognito. Clear CF Access cookie
 
 ### Container Stuck at "Waiting for Services"
 
-Terminal server not starting (sync blocking). Check: `GET /api/container/startup-status?sessionId=xxx` (inspect `details.syncError` field). Common causes: missing R2 credentials, bucket doesn't exist, network timeout.
+The loading screen waits for both R2 sync and PTY pre-warm to complete before signalling ready. Check `GET /api/container/startup-status?sessionId=xxx` and inspect the `details.syncError` field.
+
+**Port-wait timeout (container killed before reaching the loading screen):** Cloudflare kills a container that does not bind port 8080 within ~10-15s. Since PR #364 the terminal server binds port 8080 at the very start of `entrypoint.sh` — before R2 sync — so this should no longer occur. If it does, check that `node dist/server.js` in `/app/host` exits cleanly: `cat /tmp/terminal.pid` then `kill -0 $(cat /tmp/terminal.pid)`.
+
+**Loading screen hangs after port binds:** PTY pre-warm is gated on `/tmp/codeflare-init-complete`. If sync never finishes, the flag is never written and pre-warm waits up to 90s before proceeding anyway. Common causes: missing R2 credentials, bucket does not exist, network timeout. Check `/tmp/sync.log` for errors.
 
 ### R2 Sync Issues
 
@@ -71,7 +75,8 @@ sudo apt-get install -yqq --no-install-recommends \
 |---------|-------|-----|
 | Container won't start | Missing R2 credentials | `wrangler secret list` then `wrangler secret put` |
 | `403 Forbidden` on R2 | Expired credentials | Regenerate in CF dashboard |
-| Container stuck "starting" | Port 8080 not responding | Check sync log |
+| Container killed before loading screen | Port 8080 did not bind in time | Check `/tmp/terminal.pid`; verify `node dist/server.js` started |
+| Loading screen hangs indefinitely | `/tmp/codeflare-init-complete` never written (sync stalled) | Check `/tmp/sync.log`; verify R2 credentials |
 | WebSocket fails | Container not running | Verify startup-status |
 | Zombie restarts | Stale DO state | Self-terminates via missing-identifiers guard |
 | Deleted session reappears | `onStop()` resurrects KV entry | Verify `destroy()` clears `SESSION_ID_KEY` before `super.destroy()` |

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -77,7 +77,7 @@ sudo apt-get install -yqq --no-install-recommends \
 | `403 Forbidden` on R2 | Expired credentials | Regenerate in CF dashboard |
 | Container killed before loading screen | Port 8080 did not bind in time | Check `/tmp/terminal.pid`; verify `node dist/server.js` started |
 | Loading screen hangs indefinitely | `/tmp/codeflare-init-complete` never written (sync stalled) | Check `/tmp/sync.log`; verify R2 credentials |
-| WebSocket fails | Container not running | Verify startup-status |
+| WebSocket fails | Container not running | Verify startup-status. Reconnects while container is stopped use close code 4503 and do NOT count against the WS rate-limit budget (see [WebSocket Rate Limit](security.md#websocket-rate-limit-req-sec-007)). |
 | Zombie restarts | Stale DO state | Self-terminates via missing-identifiers guard |
 | Deleted session reappears | `onStop()` resurrects KV entry | Verify `destroy()` clears `SESSION_ID_KEY` before `super.destroy()` |
 | Container dies during active use | Auth issue on internal paths | Verify `/activity` in `authExemptPaths` in `host/src/server.ts` |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -981,19 +981,33 @@ export CODEFLARE_INIT_FLAG_FILE=/tmp/codeflare-init-complete
 rm -f "$CODEFLARE_INIT_FLAG_FILE"
 
 echo "[entrypoint] Starting terminal server on port 8080..."
-cd /app/host && HOME="$USER_HOME" TERMINAL_PORT=8080 \
+# Subshell-scope the cd so the rest of the entrypoint's cwd is unchanged.
+(cd /app/host && HOME="$USER_HOME" TERMINAL_PORT=8080 \
     CODEFLARE_INIT_FLAG_FILE="$CODEFLARE_INIT_FLAG_FILE" \
-    node dist/server.js &
+    node dist/server.js) &
 TERMINAL_PID=$!
 echo "$TERMINAL_PID" > /tmp/terminal.pid
 echo "[entrypoint] Terminal server started with PID $TERMINAL_PID (prewarm gated on $CODEFLARE_INIT_FLAG_FILE)"
 
-sleep 0.5
-
-if kill -0 "$TERMINAL_PID" 2>/dev/null; then
-    echo "[entrypoint] Terminal server is running"
+# Probe port 8080 (not just kill -0): a live node process that hasn't reached
+# server.listen() yet would pass the old check but fail Cloudflare's port-wait.
+# /health is auth-exempt (host/src/server.ts authExemptPaths), so this works
+# before CONTAINER_AUTH_TOKEN is wired up. Poll up to 5s; fail-open if not
+# bound (host server may still come up while the rest of init runs).
+PORT_BOUND=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -fsS -o /dev/null --max-time 1 http://127.0.0.1:8080/health 2>/dev/null; then
+        PORT_BOUND=1
+        break
+    fi
+    sleep 0.5
+done
+if [ "$PORT_BOUND" = "1" ]; then
+    echo "[entrypoint] Terminal server is listening on port 8080"
+elif kill -0 "$TERMINAL_PID" 2>/dev/null; then
+    echo "[entrypoint] WARNING: Terminal server alive (PID $TERMINAL_PID) but port 8080 not bound after 5s"
 else
-    echo "[entrypoint] WARNING: Terminal server failed to start!"
+    echo "[entrypoint] WARNING: Terminal server process died before binding port 8080!"
 fi
 
 # ============================================================================

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -971,6 +971,32 @@ fi
 init_sync_log
 
 # ============================================================================
+# Start terminal server EARLY so port 8080 binds before Cloudflare's container
+# port-wait timeout (~10-15s) elapses. The server will not begin PTY pre-warm
+# until /tmp/codeflare-init-complete is written at the end of this script —
+# this preserves the existing readiness contract (loading screen still waits
+# for sync + prewarm) while moving the slow init work off the port-wait path.
+# ============================================================================
+export CODEFLARE_INIT_FLAG_FILE=/tmp/codeflare-init-complete
+rm -f "$CODEFLARE_INIT_FLAG_FILE"
+
+echo "[entrypoint] Starting terminal server on port 8080..."
+cd /app/host && HOME="$USER_HOME" TERMINAL_PORT=8080 \
+    CODEFLARE_INIT_FLAG_FILE="$CODEFLARE_INIT_FLAG_FILE" \
+    node dist/server.js &
+TERMINAL_PID=$!
+echo "$TERMINAL_PID" > /tmp/terminal.pid
+echo "[entrypoint] Terminal server started with PID $TERMINAL_PID (prewarm gated on $CODEFLARE_INIT_FLAG_FILE)"
+
+sleep 0.5
+
+if kill -0 "$TERMINAL_PID" 2>/dev/null; then
+    echo "[entrypoint] Terminal server is running"
+else
+    echo "[entrypoint] WARNING: Terminal server failed to start!"
+fi
+
+# ============================================================================
 # R2 SYNC STARTUP
 # ============================================================================
 # Note: Claude Code consent is pre-accepted via bypassPermissionsModeAccepted in .claude.json.
@@ -1453,24 +1479,15 @@ if [ $RCLONE_CONFIG_RESULT -eq 0 ] && [ "${STEP1_RESULT:-1}" -eq 0 ]; then
 fi
 
 # ============================================================================
-# Start servers AFTER initial sync completes
+# Init complete — release the terminal server's PTY pre-warm.
+# The server has been listening on port 8080 since the top of MAIN EXECUTION;
+# it has been polling for this flag file before spawning the tab-1 PTY so
+# that pre-warm reads the final .claude.json / .bashrc rather than pre-sync
+# state.
 # ============================================================================
+touch "$CODEFLARE_INIT_FLAG_FILE"
+echo "[entrypoint] Init complete — wrote $CODEFLARE_INIT_FLAG_FILE (releasing PTY pre-warm)"
 
-echo "[entrypoint] Starting terminal server on port 8080..."
-cd /app/host && HOME="$USER_HOME" TERMINAL_PORT=8080 node dist/server.js &
-TERMINAL_PID=$!
-echo "$TERMINAL_PID" > /tmp/terminal.pid
-echo "[entrypoint] Terminal server started with PID $TERMINAL_PID"
-
-sleep 0.5
-
-if kill -0 "$TERMINAL_PID" 2>/dev/null; then
-    echo "[entrypoint] Terminal server is running"
-else
-    echo "[entrypoint] WARNING: Terminal server failed to start!"
-fi
-
-# Terminal server now handles all endpoints (health metrics consolidated)
 echo "[entrypoint] Startup complete. Servers running:"
 echo "[entrypoint]   - Terminal server (port 8080): PID $TERMINAL_PID"
 SYNC_PID=$(cat /tmp/sync-daemon.pid 2>/dev/null || echo '')

--- a/host/src/server.ts
+++ b/host/src/server.ts
@@ -188,6 +188,7 @@ const server = http.createServer(async (req: http.IncomingMessage, res: http.Ser
         syncError: syncInfo.error,
         userPath: syncInfo.userPath,
         prewarmReady,
+        initFlagObserved,
         cpu: sysMetrics.cpu,
         mem: sysMetrics.mem,
         hdd: sysMetrics.hdd,
@@ -427,6 +428,12 @@ wss.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
 // Pre-warm state (module-level so /health endpoint can read prewarmReady)
 let prewarmReady = false;
 let prewarmStartTime = 0;
+// True after waitForInitFlag observes the flag file; false if it timed out
+// or no flag was configured. Exposed via /health for production debugging:
+// a session stuck at `prewarmReady=false` with `initFlagObserved=false` means
+// the entrypoint never wrote the init-complete flag (sync hung, jq merge
+// failed, etc.).
+let initFlagObserved = false;
 
 const parsedTabConfig: TabConfigEntry[] = (() => {
   try { return JSON.parse(process.env.TAB_CONFIG ?? '[]') as TabConfigEntry[]; } catch { return []; }
@@ -434,13 +441,20 @@ const parsedTabConfig: TabConfigEntry[] = (() => {
 const prewarmConfig = getPrewarmConfig(parsedTabConfig);
 const PREWARM_TIMEOUT_MS = 20000;     // Hard cap: consider ready after 20s regardless
 const PREWARM_ORPHAN_MS = 120000;     // Kill pre-warmed session if not adopted within 2min
-const PREWARM_INIT_WAIT_MS = 90000;   // Max wait for entrypoint init-complete flag before starting prewarm anyway
+// Init-flag wait must exceed entrypoint's SYNC_TIMEOUT (120s in initial_sync_from_r2)
+// + slack, so a legitimately-slow R2 sync never trips the fallback. If the
+// entrypoint dies before writing the flag, the fallback releases pre-warm against
+// image-default state (intentional — fail-open keeps the terminal reachable).
+const PREWARM_INIT_WAIT_MS = 130000;
 const PREWARM_INIT_POLL_MS = 250;
 
 // Wait for the entrypoint to write its init-complete flag file before pre-warming.
 // Allows the entrypoint to start the HTTP server early (so port 8080 binds inside
-// Cloudflare's container port-wait window) without spawning the tab-1 PTY against
-// half-restored state (.claude.json, .bashrc, MCP server registrations).
+// Cloudflare's container port-wait window) without spawning the tab-1 PTY before
+// the user's R2-restored state (.claude.json, .bashrc, MCP server registrations)
+// is in place. On R2-sync failure or no-R2-credentials the entrypoint still writes
+// the flag — pre-warm then runs against image-default state, which is intentional
+// (a half-restored terminal is more useful than no terminal).
 // No-ops in tests and dev mode where CODEFLARE_INIT_FLAG_FILE is unset.
 function waitForInitFlag(): Promise<void> {
   const flagPath = process.env.CODEFLARE_INIT_FLAG_FILE;
@@ -449,6 +463,7 @@ function waitForInitFlag(): Promise<void> {
   return new Promise((resolve) => {
     const tick = (): void => {
       if (fs.existsSync(flagPath)) {
+        initFlagObserved = true;
         log('info', 'Init-complete flag observed, starting pre-warm', { flagPath, waitedMs: Date.now() - start });
         resolve();
         return;

--- a/host/src/server.ts
+++ b/host/src/server.ts
@@ -434,14 +434,45 @@ const parsedTabConfig: TabConfigEntry[] = (() => {
 const prewarmConfig = getPrewarmConfig(parsedTabConfig);
 const PREWARM_TIMEOUT_MS = 20000;     // Hard cap: consider ready after 20s regardless
 const PREWARM_ORPHAN_MS = 120000;     // Kill pre-warmed session if not adopted within 2min
+const PREWARM_INIT_WAIT_MS = 90000;   // Max wait for entrypoint init-complete flag before starting prewarm anyway
+const PREWARM_INIT_POLL_MS = 250;
+
+// Wait for the entrypoint to write its init-complete flag file before pre-warming.
+// Allows the entrypoint to start the HTTP server early (so port 8080 binds inside
+// Cloudflare's container port-wait window) without spawning the tab-1 PTY against
+// half-restored state (.claude.json, .bashrc, MCP server registrations).
+// No-ops in tests and dev mode where CODEFLARE_INIT_FLAG_FILE is unset.
+function waitForInitFlag(): Promise<void> {
+  const flagPath = process.env.CODEFLARE_INIT_FLAG_FILE;
+  if (!flagPath) return Promise.resolve();
+  const start = Date.now();
+  return new Promise((resolve) => {
+    const tick = (): void => {
+      if (fs.existsSync(flagPath)) {
+        log('info', 'Init-complete flag observed, starting pre-warm', { flagPath, waitedMs: Date.now() - start });
+        resolve();
+        return;
+      }
+      if (Date.now() - start >= PREWARM_INIT_WAIT_MS) {
+        log('warn', 'Init-complete flag not seen within timeout, starting pre-warm anyway', { flagPath, timeoutMs: PREWARM_INIT_WAIT_MS });
+        resolve();
+        return;
+      }
+      setTimeout(tick, PREWARM_INIT_POLL_MS);
+    };
+    tick();
+  });
+}
 
 // Start server
-server.listen(PORT, '0.0.0.0', () => {
+server.listen(PORT, '0.0.0.0', async () => {
   log('info', 'Terminal server listening', { port: PORT });
   log('info', 'Workspace config', { workspace: WORKSPACE_DEFAULT, workingDir: getWorkingDirectory(), keepAliveSec: PTY_KEEPALIVE_MS / 1000 });
 
   // Start periodic cleanup of dead sessions
   sessionManager.startCleanup();
+
+  await waitForInitFlag();
 
   // Pre-warm tab 1 PTY so the first client connect is instant
   const prewarmSession = new Session(PREWARM_SESSION_ID, 'Terminal', false, sessionOptions);

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -2,6 +2,9 @@
 
 Semantic changes to the specification. Git history captures diffs; this file captures intent.
 
+## 2026-05-15
+- REQ-STOR-004 reordered: terminal server binds port 8080 before R2 sync runs (AC1 reworded; AC8 added for the `/tmp/codeflare-init-complete` flag that gates PTY pre-warm). Cloudflare's container port-wait timeout (~10-15s) was killing the container on cold resume when initial R2 sync was slow. The readiness contract is preserved: loading screen still waits for sync + pre-warm; only the port bind moves earlier.
+
 ## 2026-05-14
 - REQ-AGENT-023 expanded with AC4 (hot-reload tolerance: MCP wrapper presents an empty `LazyGraph` to `graphify.serve` so the server stays up across an empty workspace and rebinds within `GRAPHIFY_POLL_SECONDS` of a `graph.json` appearing) and AC5 (advanced-only active-repo PostToolUse hook on `Bash | Edit | Write | Read | NotebookEdit | mcp__context-mode__ctx_execute | mcp__context-mode__ctx_execute_file | mcp__context-mode__ctx_batch_execute` writing a sentinel that the wrapper reads to bind G to the agent's current repo; fallback is freshest-mtime across `CODEFLARE_WORKSPACE/*/graphify-out/graph.json`). Constraint added: per-branch graphs not supported, `.git/HEAD` read only for log identification. Recorded as AD53.
 - Added REQ-AGENT-023 through REQ-AGENT-027 (graphify knowledge-graph integration). Containers ship `graphifyy[mcp,sql,pdf]` globally via `uv tool install`; the graphify MCP server is registered in `~/.claude.json` for both default and advanced session modes (capability is ambient). In advanced session mode only, three hooks (SessionStart context-injection, PostToolUse-on-clone triage, PreToolUse graph-first soft-nudge) plus `rules/graph-first.md` and `skills/graphify/SKILL.md` teach the agent to prefer focused MCP queries over Grep for architecture, dependency, and call-flow questions.

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -4,6 +4,7 @@ Semantic changes to the specification. Git history captures diffs; this file cap
 
 ## 2026-05-15
 - REQ-STOR-004 reordered: terminal server binds port 8080 before R2 sync runs (AC1 reworded; AC8 added for the `/tmp/codeflare-init-complete` flag that gates PTY pre-warm). Cloudflare's container port-wait timeout (~10-15s) was killing the container on cold resume when initial R2 sync was slow. The readiness contract is preserved: loading screen still waits for sync + pre-warm; only the port bind moves earlier.
+- REQ-SEC-007 AC10 added: session-stopped WebSocket rejection (4503) runs before the WS rate-limit check, so a browser reconnect-storm against a hibernated container does not consume the user's 30/60s budget and self-lock them out.
 
 ## 2026-05-14
 - REQ-AGENT-023 expanded with AC4 (hot-reload tolerance: MCP wrapper presents an empty `LazyGraph` to `graphify.serve` so the server stays up across an empty workspace and rebinds within `GRAPHIFY_POLL_SECONDS` of a `graph.json` appearing) and AC5 (advanced-only active-repo PostToolUse hook on `Bash | Edit | Write | Read | NotebookEdit | mcp__context-mode__ctx_execute | mcp__context-mode__ctx_execute_file | mcp__context-mode__ctx_batch_execute` writing a sentinel that the wrapper reads to bind G to the agent's current repo; fallback is freshest-mtime across `CODEFLARE_WORKSPACE/*/graphify-out/graph.json`). Constraint added: per-branch graphs not supported, `.git/HEAD` read only for log identification. Recorded as AD53.

--- a/sdd/security.md
+++ b/sdd/security.md
@@ -193,6 +193,7 @@ Security requirements for authentication enforcement, credential isolation, encr
 7. Security-critical endpoints (`request-access`, Turnstile verification) use fail-closed rate limiting (KV failure returns 503 instead of allowing the request).
 8. General resource-protection endpoints use fail-open rate limiting (per AD6).
 9. When `STRESS_TEST_MODE=active`, all rate limits are bypassed with a one-time warning per isolate.
+10. WebSocket upgrade requests for sessions with KV status `stopped` are rejected via close code 4503 BEFORE the WS rate-limit check runs, so a reconnect storm against a hibernated container does not consume the user's 30/60s budget.
 
 **Constraints:**
 - KV key prefixes must not collide with application cache keys (use `rl-` prefix where collision exists).

--- a/sdd/storage.md
+++ b/sdd/storage.md
@@ -102,16 +102,18 @@ R2 persistence, rclone bisync, quotas, and file browser.
 **Intent:** When a container boots, it must restore the user's persisted files from R2 before the agent or terminal becomes usable.
 
 **Acceptance Criteria:**
-1. A one-way `rclone sync` from R2 to local runs as the first startup step (blocking).
+1. A one-way `rclone sync` from R2 to local runs as the first initialization step after the terminal server starts listening on port 8080 (blocking).
 2. The sync completes or times out within 120 seconds (`SYNC_TIMEOUT`).
 3. All file modifications (`.claude.json`, `.gemini/settings.json`, `.codex/version.json`, tab autostart) complete after the initial sync but before bisync baseline, to avoid hash mismatches.
 4. A bisync baseline (`--resync`) is established after file modifications complete.
 5. If the initial baseline fails due to a vanishing file (file listed but deleted before copy), the system parses the error output, adds the file to a session-scoped recovery filter (`/tmp/rclone-recovery-filters.txt`), and retries (max 3 attempts). Only non-workspace files are auto-excluded; workspace files trigger a plain retry.
 6. Known ephemeral files (`.claude/mcp-*.json`) are statically excluded from all sync operations.
 7. The bisync daemon starts unconditionally after baseline — even if all baseline attempts fail. A dead daemon means zero sync for the entire session; the daemon has its own recovery (vanishing-file recovery + consecutive failure → resync fallback).
+8. The terminal server's tab-1 PTY pre-warm is gated on an init-complete flag file (`/tmp/codeflare-init-complete`) written by the entrypoint after initial sync, file modifications, and tab autostart configuration complete; this preserves the readiness contract while letting port 8080 bind before Cloudflare's container port-wait timeout.
 
 **Constraints:**
-- Container must not serve terminal connections until the initial sync either succeeds or times out.
+- The terminal server must bind port 8080 within Cloudflare's container port-wait window; slow initialization (R2 sync, MCP config merges) must not block the port bind.
+- Container must not signal readiness (PTY pre-warm complete) until the initial sync either succeeds or times out.
 - The bisync-initialized flag (`/tmp/.bisync-initialized`) must be set even on the timeout path to prevent the shutdown trap from skipping the final sync.
 
 **Applies To:** User

--- a/src/__tests__/routes/terminal-ws.test.ts
+++ b/src/__tests__/routes/terminal-ws.test.ts
@@ -352,5 +352,44 @@ describe('handleWebSocketUpgrade', () => {
       // Should return 101 (WebSocket upgrade accepted then closed with 4503)
       expect(result.status).toBe(101);
     });
+
+    it('does NOT burn WebSocket rate-limit budget when session is stopped (reconnect-storm protection)', async () => {
+      // Reconnect storms during container outages were self-locking users for ~2min:
+      // browser auto-reconnect would hit /api/terminal/:id/ws 30+ times in 60s while
+      // the container was down, the rate-limit incremented on each, and even after
+      // the container came back the user was throttled. Stopped-session rejection
+      // must short-circuit before the rate-limit check.
+      const sessionId = 'abcdef1234567890';
+      mockKV._set(`session:test-bucket:${sessionId}`, {
+        id: sessionId,
+        name: 'Test',
+        userId: 'test-bucket',
+        createdAt: '2026-01-01T00:00:00Z',
+        lastAccessedAt: '2026-01-01T00:00:00Z',
+        status: 'stopped',
+      });
+
+      const request = new Request(`http://localhost/api/terminal/${sessionId}-1/ws`, {
+        headers: { 'Upgrade': 'websocket', 'Origin': 'http://localhost' },
+      });
+      const env = {
+        KV: mockKV as unknown as KVNamespace,
+        CONTAINER: {},
+      } as unknown as Env;
+      const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
+      const routeResult = validateWebSocketRoute(request);
+
+      const result = await handleWebSocketUpgrade(request, env, ctx, routeResult as any);
+
+      expect(result.status).toBe(101); // 4503-close path still returns successful upgrade
+      const wsConnectGetCalls = mockKV.get.mock.calls.filter(
+        (call: any[]) => typeof call[0] === 'string' && call[0].startsWith('ws-connect:')
+      );
+      const wsConnectPutCalls = mockKV.put.mock.calls.filter(
+        (call: any[]) => typeof call[0] === 'string' && call[0].startsWith('ws-connect:')
+      );
+      expect(wsConnectGetCalls).toHaveLength(0);
+      expect(wsConnectPutCalls).toHaveLength(0);
+    });
   });
 });

--- a/src/routes/terminal.ts
+++ b/src/routes/terminal.ts
@@ -178,32 +178,6 @@ export async function handleWebSocketUpgrade(
       return new Response(JSON.stringify({ error: 'Access denied', code }), { status: 403, headers: jsonHeaders });
     }
 
-    if (env.STRESS_TEST_MODE === 'active') {
-      if (!wsStressTestWarningLogged) {
-        logger.warn('STRESS_TEST_MODE is active — WebSocket rate limits bypassed');
-        wsStressTestWarningLogged = true;
-      }
-    } else {
-      // WebSocket connection rate limiting: 30 connections/min per user (FIX-21)
-      // Fail-open on KV errors via shared rate-limit-core (AD35)
-      const wsRateResult = await checkRateLimit({
-        kv: env.KV,
-        key: `ws-connect:${user.email}`,
-        limit: WS_RATE_LIMIT_MAX_CONNECTIONS,
-        windowMs: WS_RATE_LIMIT_WINDOW_MS,
-        ttlSeconds: WS_RATE_LIMIT_TTL_SECONDS,
-      });
-
-      if (!wsRateResult.allowed) {
-        logger.warn('WebSocket rate limit exceeded', { email: user.email, count: wsRateResult.count });
-        return new Response(null, {
-          status: 429,
-          headers: { ...jsonHeaders, 'Retry-After': String(wsRateResult.retryAfterSec) },
-          webSocket: undefined,
-        });
-      }
-    }
-
     const containerId = getContainerId(bucketName, baseSessionId);
 
     logger.info('User authenticated for WebSocket', { email: user.email, containerId, terminalId });
@@ -222,11 +196,42 @@ export async function handleWebSocketUpgrade(
     // Reject WebSocket connections to stopped/hibernated sessions.
     // Uses custom close code 4503 so the client can distinguish
     // "container stopped" from network errors (1006).
+    // Done BEFORE rate-limit check so a browser reconnect-storm against
+    // a stopped container does not burn the user's WS rate-limit budget
+    // and self-lock them out for ~2 minutes.
     if (session.status === 'stopped') {
       const pair = new WebSocketPair();
       pair[1].accept();
       pair[1].close(4503, 'container-stopped');
       return new Response(null, { status: 101, webSocket: pair[0] });
+    }
+
+    if (env.STRESS_TEST_MODE === 'active') {
+      if (!wsStressTestWarningLogged) {
+        logger.warn('STRESS_TEST_MODE is active — WebSocket rate limits bypassed');
+        wsStressTestWarningLogged = true;
+      }
+    } else {
+      // WebSocket connection rate limiting: 30 connections/min per user (FIX-21)
+      // Runs AFTER session-stopped rejection (see comment above) so failed
+      // reconnects to a hibernated container do not count against the limit.
+      // Fail-open on KV errors via shared rate-limit-core (AD35).
+      const wsRateResult = await checkRateLimit({
+        kv: env.KV,
+        key: `ws-connect:${user.email}`,
+        limit: WS_RATE_LIMIT_MAX_CONNECTIONS,
+        windowMs: WS_RATE_LIMIT_WINDOW_MS,
+        ttlSeconds: WS_RATE_LIMIT_TTL_SECONDS,
+      });
+
+      if (!wsRateResult.allowed) {
+        logger.warn('WebSocket rate limit exceeded', { email: user.email, count: wsRateResult.count });
+        return new Response(null, {
+          status: 429,
+          headers: { ...jsonHeaders, 'Retry-After': String(wsRateResult.retryAfterSec) },
+          webSocket: undefined,
+        });
+      }
     }
 
     // Update last accessed timestamp (don't await)


### PR DESCRIPTION
## Summary

- Entrypoint reordered: terminal server binds port 8080 **before** the slow R2 restore + config writes, so cold-resume no longer trips Cloudflare's container port-wait timeout (~10-15s) and crashes with `Container crashed while checking for ports`.
- Host server's PTY pre-warm now waits for `/tmp/codeflare-init-complete` (written by the entrypoint at end of init) before spawning the tab-1 PTY, preserving today's readiness contract — loading screen still waits for `syncStatus=success` and `prewarmReady=true`.
- Backward-compatible in tests / dev: the wait is a no-op when `CODEFLARE_INIT_FLAG_FILE` env var is unset.

Implements `REQ-STOR-004` (AC1 reworded, AC8 added for the init-complete flag).

## Root cause

Production logs at 2026-05-15T17:20:45Z showed `Container crashed while checking for ports` while the same `scriptVersion` (no deploy) had been working an hour earlier. Worker logs ruled out a code regression; the entrypoint was previously doing the full R2 sync + MCP server config merges + bashrc autostart writes **before** starting the terminal server on 8080. On a cold resume that exceeded Cloudflare's port-wait budget. Once the container was marked crashed, the browser auto-reconnect hit the 30-per-minute WebSocket rate limit and self-locked for ~2 minutes.

## Test plan

- [ ] CI green on develop
- [ ] Manually stop the production container, observe the loading screen progresses ``starting -> syncing -> verifying -> mounting -> ready`` (unchanged) and Open only shows at true ready
- [ ] Cold-resume from hibernation: confirm port 8080 binds within ~2s (no ``Container crashed while checking for ports`` in worker logs)
- [ ] Verify pre-warm PTY still reads correctly-restored ``.claude.json`` (configured agent launches normally, not onboarding)
- [ ] Verify the existing ``/api/container/startup-status`` polling still gates Open on ``prewarmReady``