### PR TITLE
fix(entrypoint): dedup vault + graphify hooks in MANAGED_HOOKS_REGEX (production hook accumulation fix)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1645,14 +1645,14 @@ if [ -f "$SETTINGS_FILE" ]; then
     # Implements REQ-AGENT-008
     # Merge non-hooks settings with *, rebuild hooks separately to avoid
     # jq array-replace destroying user-added hooks or leaving stale managed hooks.
-    # "Managed" = command path contains codeflare-(hooks|memory)/scripts/,
-    # references enforce-ctx-mode.sh (both the legacy ~/.claude/hooks/ path
-    # and the current ~/.claude/plugins/context-mode/scripts/ path), OR is
-    # a context-mode hook invocation (any of: bare `context-mode`,
-    # `bunx context-mode@*`, or `npx -y context-mode@*` for legacy compat
-    # with sessions that still have stale settings.json from before the
-    # build-time install landed). Adding to MANAGED_HOOKS_REGEX must
-    # happen here AND in any other place that prunes managed hooks.
+    # "Managed" = command path contains codeflare-(hooks|memory|vault)/scripts/
+    # OR graphify/scripts/, references enforce-ctx-mode.sh (both the legacy
+    # ~/.claude/hooks/ path and the current ~/.claude/plugins/context-mode/
+    # scripts/ path), OR is a context-mode hook invocation (any of: bare
+    # `context-mode`, `bunx context-mode@*`, or `npx -y context-mode@*` for
+    # legacy compat with sessions that still have stale settings.json from
+    # before the build-time install landed). Adding to MANAGED_HOOKS_REGEX
+    # must happen here AND in any other place that prunes managed hooks.
     if jq --argjson cfg "$SETTINGS_CONFIG" '
       . as $orig |
       (del(.hooks) * ($cfg | del(.hooks))) +
@@ -1665,7 +1665,7 @@ if [ -f "$SETTINGS_FILE" ]; then
             [($existArr[] | .matcher // ""), ($cfgArr[] | .matcher // "")] | unique |
             map(. as $m |
               [$existArr[] | select((.matcher // "") == $m) | (.hooks // [])[] |
-                select((.command // "") | test("codeflare-(hooks|memory)/scripts/|enforce-ctx-mode\\.sh|(^context-mode |(bunx|npx) (-y )?context-mode@.* hook claude-code)") | not)
+                select((.command // "") | test("codeflare-(hooks|memory|vault)/scripts/|graphify/scripts/|enforce-ctx-mode\\.sh|(^context-mode |(bunx|npx) (-y )?context-mode@.* hook claude-code)") | not)
               ] as $user |
               [$cfgArr[] | select((.matcher // "") == $m) | (.hooks // [])[]] as $mgr |
               {matcher: $m, hooks: ($user + $mgr)}

--- a/host/__tests__/entrypoint-enforce-ctx-mode-dedup.test.js
+++ b/host/__tests__/entrypoint-enforce-ctx-mode-dedup.test.js
@@ -196,3 +196,163 @@ describe('entrypoint settings.json hook merge - enforce-ctx-mode.sh dedup', () =
     );
   });
 });
+
+// Reproduces the prod accumulation observed in production verification of
+// PR #367: vault-monitor-hook.sh registered 2x on UserPromptSubmit and the
+// graphify hooks (graphify-clone-prompt.sh, graphify-session-start.sh)
+// registered 10x each. Without the extended MANAGED_HOOKS_REGEX, the merge
+// preserves every prior copy because the prune regex only knew about
+// codeflare-(hooks|memory)/scripts/ + enforce-ctx-mode.sh + context-mode
+// invocations.
+function accumulatedVaultGraphifySettingsFixture() {
+  const vaultHook = 'bash /home/user/.claude/plugins/codeflare-vault/scripts/vault-monitor-hook.sh';
+  const memoryHook = 'bash /home/user/.claude/plugins/codeflare-memory/scripts/memory-capture.sh';
+  const graphifyClone = 'bash /home/user/.claude/plugins/graphify/scripts/graphify-clone-prompt.sh';
+  const graphifyStart = 'bash /home/user/.claude/plugins/graphify/scripts/graphify-session-start.sh';
+  return JSON.stringify({
+    skipDangerousModePermissionPrompt: true,
+    hooks: {
+      UserPromptSubmit: [
+        {
+          matcher: '',
+          hooks: [
+            { type: 'command', command: vaultHook },
+            { type: 'command', command: memoryHook },
+            { type: 'command', command: vaultHook },
+          ],
+        },
+      ],
+      PostToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+            { type: 'command', command: graphifyClone },
+          ],
+        },
+      ],
+      SessionStart: [
+        {
+          matcher: 'startup',
+          hooks: Array.from({ length: 10 }, () => ({ type: 'command', command: graphifyStart })),
+        },
+        {
+          // User-added SessionStart hook on the default matcher — must survive.
+          matcher: '',
+          hooks: [
+            { type: 'command', command: 'bash /home/user/custom/my-session-start.sh' },
+          ],
+        },
+      ],
+    },
+  });
+}
+
+// Canonical advanced-mode config with one copy of each managed hook on its
+// canonical matcher (mirrors what entrypoint.sh assembles into SETTINGS_CONFIG).
+function advancedVaultGraphifySettingsConfig() {
+  const vaultHook = 'bash /home/user/.claude/plugins/codeflare-vault/scripts/vault-monitor-hook.sh';
+  const memoryHook = 'bash /home/user/.claude/plugins/codeflare-memory/scripts/memory-capture.sh';
+  const graphifyClone = 'bash /home/user/.claude/plugins/graphify/scripts/graphify-clone-prompt.sh';
+  const graphifyStart = 'bash /home/user/.claude/plugins/graphify/scripts/graphify-session-start.sh';
+  return {
+    skipDangerousModePermissionPrompt: true,
+    hooks: {
+      UserPromptSubmit: [
+        {
+          matcher: '',
+          hooks: [
+            { type: 'command', command: memoryHook },
+            { type: 'command', command: vaultHook },
+          ],
+        },
+      ],
+      PostToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [{ type: 'command', command: graphifyClone }],
+        },
+      ],
+      SessionStart: [
+        {
+          matcher: 'startup',
+          hooks: [{ type: 'command', command: graphifyStart }],
+        },
+      ],
+    },
+  };
+}
+
+describe('entrypoint settings.json hook merge - vault + graphify dedup', () => {
+  it('vault-monitor-hook.sh duplicated 2x collapses to exactly 1 on UserPromptSubmit', () => {
+    const merged = runJqMerge(accumulatedVaultGraphifySettingsFixture(), advancedVaultGraphifySettingsConfig());
+    const ups = merged?.hooks?.UserPromptSubmit ?? [];
+    const defaultMatcher = ups.find((e) => e.matcher === '');
+    assert.ok(defaultMatcher, 'UserPromptSubmit default matcher must exist after merge');
+    const vaultCount = defaultMatcher.hooks.filter((h) => h.command.includes('vault-monitor-hook.sh')).length;
+    assert.equal(
+      vaultCount,
+      1,
+      `expected exactly 1 vault-monitor-hook.sh entry, got ${vaultCount}: ${JSON.stringify(defaultMatcher.hooks)}`,
+    );
+  });
+
+  it('memory-capture.sh stays exactly 1 (was already managed by codeflare-memory regex)', () => {
+    const merged = runJqMerge(accumulatedVaultGraphifySettingsFixture(), advancedVaultGraphifySettingsConfig());
+    const ups = merged?.hooks?.UserPromptSubmit ?? [];
+    const defaultMatcher = ups.find((e) => e.matcher === '');
+    const memCount = defaultMatcher.hooks.filter((h) => h.command.includes('memory-capture.sh')).length;
+    assert.equal(memCount, 1, 'memory-capture.sh should remain exactly 1 after dedup');
+  });
+
+  it('graphify-clone-prompt.sh duplicated 10x collapses to exactly 1 on PostToolUse[Bash]', () => {
+    const merged = runJqMerge(accumulatedVaultGraphifySettingsFixture(), advancedVaultGraphifySettingsConfig());
+    const post = merged?.hooks?.PostToolUse ?? [];
+    const bashMatcher = post.find((e) => e.matcher === 'Bash');
+    assert.ok(bashMatcher, 'PostToolUse Bash matcher must exist after merge');
+    const cloneCount = bashMatcher.hooks.filter((h) => h.command.includes('graphify-clone-prompt.sh')).length;
+    assert.equal(
+      cloneCount,
+      1,
+      `expected exactly 1 graphify-clone-prompt.sh entry, got ${cloneCount}`,
+    );
+  });
+
+  it('graphify-session-start.sh duplicated 10x collapses to exactly 1 on SessionStart[startup]', () => {
+    const merged = runJqMerge(accumulatedVaultGraphifySettingsFixture(), advancedVaultGraphifySettingsConfig());
+    const ss = merged?.hooks?.SessionStart ?? [];
+    const startupMatcher = ss.find((e) => e.matcher === 'startup');
+    assert.ok(startupMatcher, 'SessionStart startup matcher must exist after merge');
+    const startCount = startupMatcher.hooks.filter((h) => h.command.includes('graphify-session-start.sh')).length;
+    assert.equal(
+      startCount,
+      1,
+      `expected exactly 1 graphify-session-start.sh entry, got ${startCount}`,
+    );
+  });
+
+  it('user-added SessionStart hook on default matcher survives the prune', () => {
+    const merged = runJqMerge(accumulatedVaultGraphifySettingsFixture(), advancedVaultGraphifySettingsConfig());
+    const ss = merged?.hooks?.SessionStart ?? [];
+    const userMatcher = ss.find((e) => e.matcher === '');
+    assert.ok(userMatcher, 'user-added SessionStart default-matcher entry must survive');
+    assert.equal(userMatcher.hooks[0].command, 'bash /home/user/custom/my-session-start.sh');
+  });
+
+  it('downgrade to default mode: vault and graphify managed hooks are pruned', () => {
+    const merged = runJqMerge(accumulatedVaultGraphifySettingsFixture(), defaultModeSettingsConfig());
+    const allCommands = JSON.stringify(merged?.hooks ?? {});
+    assert.ok(!allCommands.includes('vault-monitor-hook.sh'), 'vault-monitor-hook.sh must be pruned on downgrade');
+    assert.ok(!allCommands.includes('graphify-clone-prompt.sh'), 'graphify-clone-prompt.sh must be pruned on downgrade');
+    assert.ok(!allCommands.includes('graphify-session-start.sh'), 'graphify-session-start.sh must be pruned on downgrade');
+    assert.ok(!allCommands.includes('memory-capture.sh'), 'memory-capture.sh must be pruned on downgrade');
+  });
+});


### PR DESCRIPTION
## Summary

Single-regex fix for runaway hook duplication observed in production verification of PR #367.

The REQ-AGENT-008 settings-merge filter at `entrypoint.sh:1668` was added to dedup managed hooks across boots, but its `MANAGED_HOOKS_REGEX` only knew about three command-path patterns:

- `codeflare-(hooks|memory)/scripts/`
- `enforce-ctx-mode.sh`
- `context-mode hook claude-code ...` (and `bunx`/`npx` variants for legacy compat)

Hooks added later under `codeflare-vault/scripts/` and `graphify/scripts/` fell through the prune, so every container boot appended a fresh copy without removing prior ones. Production accumulation after ~10 boots:

| Hook | Matcher | Copies |
|---|---|---|
| `vault-monitor-hook.sh` | `UserPromptSubmit[""]` | 2 |
| `graphify-clone-prompt.sh` | `PostToolUse[Bash]` | 10 |
| `graphify-clone-prompt.sh` | `PostToolUse[mcp__context-mode__*]` | 10 |
| `graphify-active-repo.sh` | `PostToolUse[Bash|Edit|Write|Read|NotebookEdit]` | 10 |
| `graphify-active-repo.sh` | `PostToolUse[mcp__context-mode__*]` | 10 |
| `graphify-session-start.sh` | `SessionStart[startup]` | 10 |
| `graph-first-nudge.sh`, `enforce-graphify.sh` | `PreToolUse[*]` | 2 each |

## The fix

One-line regex extension at `entrypoint.sh:1668`:

```diff
-test("codeflare-(hooks|memory)/scripts/|enforce-ctx-mode\\.sh|(^context-mode |(bunx|npx) (-y )?context-mode@.* hook claude-code)")
+test("codeflare-(hooks|memory|vault)/scripts/|graphify/scripts/|enforce-ctx-mode\\.sh|(^context-mode |(bunx|npx) (-y )?context-mode@.* hook claude-code)")
```

`~/.claude/hooks/context-mode-cache-heal.mjs` deliberately stays UNMANAGED — it is self-installed by the context-mode CLI (not by entrypoint.sh), so adding it to the regex would silently delete it on every boot.

Comment block at `entrypoint.sh:1648` updated to reflect the wider scope.

## Tests

Extends `host/__tests__/entrypoint-enforce-ctx-mode-dedup.test.js` with 6 new cases, mirroring the existing enforce-ctx-mode dedup suite. The test extracts the actual jq filter from entrypoint.sh and runs jq against fixtures that reproduce the exact accumulated patterns observed in production (10x graphify hooks, 2x vault hook). A regression in the regex fails the suite immediately.

Coverage:
- vault-monitor-hook.sh 2x → 1
- memory-capture.sh stays exactly 1 (regression guard on existing codeflare-memory pattern)
- graphify-clone-prompt.sh 10x → 1
- graphify-session-start.sh 10x → 1
- user-added unmanaged hook survives the prune
- downgrade to default mode prunes all managed (vault + graphify + memory) hooks

## Test plan

- [ ] CI green on all three jobs
- [ ] After merge + container rebuild: `python3 -c "import json; c=json.load(open('/home/user/.claude/settings.json')); ..."` shows exactly 1 copy of each managed hook in production
- [ ] User-added hooks (if any) still survive
