### PR TITLE
fix(vault): disable SilverBullet service worker (SW + per-session proxy incompatible)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -796,7 +796,29 @@ start_silverbullet_supervisor() {
                 sleep 5
                 continue
             fi
-            "$SB_BIN" --hostname "$SB_HOST" --port "$SB_PORT" "$VAULT_ROOT" \
+            # SB_DISABLE_SERVICE_WORKER=1: the SilverBullet service worker
+            # runs its own HttpSpacePrimitives + IndexedDB and acts as the
+            # offline-first sync layer (see SB's client/service_worker.ts).
+            # That architecture is incompatible with our per-session subpath
+            # proxy: Chrome 76+ omits credentials on
+            # navigator.serviceWorker.register() script fetches, so the
+            # cookie-auth chain on /api/vault/<sid>/service_worker.js
+            # returns 401 and registration fails permanently. The Worker
+            # already serves a static no-op SW on that selector to make the
+            # registration handshake succeed, but a no-op SW WITHOUT the
+            # real sync engine leaves SB's index in a half-broken state
+            # (writes succeed on disk via the main thread, but the SW-side
+            # post-write index/sync syscalls return undefined, producing
+            # the GET /api/vault/<sid>/undefined and .fs/undefined.md
+            # symptoms and the "files appear lost in the page list / plug
+            # install half-fails" UX). Disabling SW registration entirely
+            # is the documented escape hatch in SB's own boot.ts:
+            # bootConfig.disableServiceWorker -> SB calls
+            # flushCachesAndUnregisterServiceWorker() and skips
+            # registration. We lose offline support (acceptable: the
+            # container is the always-online source of truth here) and gain
+            # a working index + working plug install.
+            SB_DISABLE_SERVICE_WORKER=1 "$SB_BIN" --hostname "$SB_HOST" --port "$SB_PORT" "$VAULT_ROOT" \
                 >> /tmp/silverbullet.log 2>&1
             echo "[silverbullet] $(date '"'"'+%Y-%m-%d %H:%M:%S'"'"') exited (code $?), restarting in 5s..." | tee -a /tmp/silverbullet.log
             sleep 5


### PR DESCRIPTION
## Summary

Pass `SB_DISABLE_SERVICE_WORKER=1` to the SilverBullet supervisor in `entrypoint.sh`. One-line config fix for a production-breaking regression.

## Why

SilverBullet's offline-first architecture lives in its service worker (`client/service_worker.ts`), which runs its own `HttpSpacePrimitives` + `IndexedDB` and acts as the sync layer between the browser and the remote space. Our per-session subpath proxy is incompatible:

- Chrome 76+ omits credentials on `navigator.serviceWorker.register()` script fetches.
- The cookie-auth chain on `/api/vault/<sid>/service_worker.js` returns 401, registration fails permanently.
- We mitigated by serving a static no-op SW (`VAULT_NOOP_SERVICE_WORKER_JS`) so the handshake succeeds, but a no-op SW WITHOUT the real sync engine leaves SB's index half-broken: main-thread writes succeed (files land on disk via `httpSpacePrimitives`), but the SW-side post-write index/sync syscalls return undefined.

## User-visible symptoms

- 'Files appear lost in the page list' (index desynced; the files DO exist on disk, confirmed by the user)
- Plug install half-fails with `GET /api/vault/<sid>/undefined` and `.fs/undefined.md` (post-install index rescan hits undefined metadata)
- Quick Notes / Journal entries show in 'modified pages' but vanish from the page list on reload

## Fix

`SB_DISABLE_SERVICE_WORKER=1` is SilverBullet's documented escape hatch (`server/cmd/server.go:72`). When set:
- `/.config` returns `disableServiceWorker: true`
- `boot.ts:163-168` calls `flushCachesAndUnregisterServiceWorker()` and skips SW registration entirely
- Client falls back to direct HTTP for everything: no offline cache, no IndexedDB, no SW-side sync

For our deployment (always-connected container = source of truth, Worker proxy handles auth), losing offline mode is acceptable. The no-op SW handler in `src/routes/vault.ts` becomes defensive-only - SB no longer requests `service_worker.js`, so the handler never fires.

## Verification

Local before/after:

```
DEFAULT /.config:
  {... "enableClientEncryption": false}

WITH SB_DISABLE_SERVICE_WORKER=1 /.config:
  {... "enableClientEncryption": false, "disableServiceWorker": true}

Log: 'Service worker disabled via SB_DISABLE_SERVICE_WORKER'
```

## Test plan

- [x] Local SB run shows `/.config` returns `disableServiceWorker: true`
- [x] Local SB log shows the disable notice
- [ ] After merge + deploy: reproduce the user's flow (create Quick Note, install MrMugame/silverbullet-pdf plug) - expect both to succeed end-to-end with no `/undefined` URLs in Workers Observability
- [ ] Smoke: existing notes still readable; index page list reflects everything in `.user_vault/` on disk