### PR TITLE
fix(vault): exclude SB-managed index.md from vault-monitor watch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -692,7 +692,10 @@ start_sync_daemon() {
 #
 # Excluded paths: raw/sessions/ (agent-owned, written by capture hook
 # which already merges), graphify-out/ (derived), .silverbullet/ (config
-# + cache, no semantic content).
+# + cache, no semantic content), index.md at vault root (SilverBullet
+# rewrites it on every supervisor boot when its "empty space" heuristic
+# fires, so every container restart / SB crash + restart would otherwise
+# bump the marker and spawn an extract sonnet for boilerplate content).
 # ============================================================================
 start_vault_monitor_daemon() {
     local VAULT_ROOT="$HOME/.user_vault"
@@ -733,7 +736,9 @@ start_vault_monitor_daemon() {
             \( -path "$VAULT_ROOT/raw/sessions" -o \
                -path "$VAULT_ROOT/graphify-out" -o \
                -path "$VAULT_ROOT/.silverbullet" \) -prune -o \
-            -type f -newer "$LAST_MARKER" -print 2>/dev/null | head -n 50)
+            -type f \
+            -not -path "$VAULT_ROOT/index.md" \
+            -newer "$LAST_MARKER" -print 2>/dev/null | head -n 50)
 
         if [ -n "$CHANGED" ]; then
             # Write the trigger atomically (mv from tmp avoids the hook


### PR DESCRIPTION
## Summary

One-line `find` exclusion: drop \`index.md\` at vault root from the vault-monitor daemon's change detection. Fixes the noisy false-positive extract-sonnet spawns triggered by every SilverBullet supervisor restart.

## Why

SilverBullet's 'Empty space detected, creating index.md' boot heuristic rewrites \`/home/user/.user_vault/index.md\` on every supervisor start (cold boot, crash-restart, pkill-respawn). The vault-monitor daemon then sees the bumped mtime, writes \`vault-extract.vars\`, and the next \`UserPromptSubmit\` hook spawns an extract sonnet for boilerplate content. Graphify's \`source_hash\` dedup makes the \`global add\` a no-op, but the sonnet still spawns and consumes LLM tokens.

Observed: every SB restart -> ~60s later -> extract sonnet fires for index.md only.

## Fix

Add \`-not -path "\$VAULT_ROOT/index.md"\` to the daemon's \`find\` alongside the existing prune list (raw/sessions/, graphify-out/, .silverbullet/). The page is SB-managed, contains no user semantic content (template literal '_No quick notes yet!_' etc.), and the user's actual notes still live under Inbox/, Journal/, notes/ which continue to trigger the extract.

## Test plan

- [x] Local: seed marker, run find -> old version returns \`index.md\`, new version returns nothing
- [x] Local: touch Inbox/<file>.md, run find -> still returns the touched Inbox file
- [ ] After deploy: SB supervisor restart no longer triggers an extract-sonnet spawn for index.md alone
- [ ] After deploy: editing a real Inbox/<file>.md OR notes/<file>.md still triggers the extract

## Out of scope

Per-file content-hash dedup on top of mtime (catches the 'Journal autosave bumps mtime every keystroke debounce but content unchanged for this graphify pass' case). Deferred unless the index.md exclusion alone doesn't bring the spawn rate down to a reasonable level.