### PR TITLE
feat(sync): 15-min cadence + manual triggers + 135s shutdown

### DIFF
--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -8,7 +8,7 @@ System architecture, components, data flow, and design rationale for Codeflare.
 
 ## Architecture Overview
 
-Codeflare runs AI coding agents in isolated containers, one per browser session (tab). All sessions for a user share a single R2 bucket for persistent storage, with periodic bidirectional sync (every 60 seconds).
+Codeflare runs AI coding agents in isolated containers, one per browser session (tab). All sessions for a user share a single R2 bucket for persistent storage, with periodic bidirectional sync every 15 minutes plus manual triggers from the storage panel and a final sync at shutdown (see AD56).
 
 ```mermaid
 graph TD
@@ -18,8 +18,8 @@ graph TD
     W -->|"containerId=bucket-session2"| C2["Container 2"]
     C1 --- P1["PTY + Agent"]
     C2 --- P2["PTY + Agent"]
-    P1 -->|"rclone bisync (every 60s)"| R2["R2 bucket (shared per user)"]
-    P2 -->|"rclone bisync (every 60s)"| R2
+    P1 -->|"rclone bisync (15min + manual triggers)"| R2["R2 bucket (shared per user)"]
+    P2 -->|"rclone bisync (15min + manual triggers)"| R2
 ```
 
 **Workers.dev URL:** `https://<CLOUDFLARE_WORKER_NAME>.<ACCOUNT_SUBDOMAIN>.workers.dev` - used only for initial setup. After the setup wizard configures a custom domain, all traffic should go through the custom domain (protected by the configured auth mechanism — CF Access or GitHub OIDC). In CF Access mode, the workers.dev URL should be gated behind one-click Access in the Cloudflare dashboard.
@@ -85,7 +85,7 @@ flowchart TD
     TK -->|No| ReArm
 ```
 
-**`destroy()` Override:** Clears session identifiers and in-memory credentials from DO storage before calling `super.destroy()`. Sends `SIGTERM` and polls `ctx.container.running` for up to 25 s so the entrypoint trap can run the final `rclone bisync` before SIGKILL. Clearing identifiers first prevents `onStop()` (async) from resurrecting deleted sessions in KV. The `containerAuthToken` storage key is also cleared here so the next session under the same DO ID starts with a fresh token (no cross-lifecycle reuse).
+**`destroy()` Override:** Clears session identifiers and in-memory credentials from DO storage before calling `super.destroy()`. Sends `SIGTERM` and polls `ctx.container.running` for up to **135 seconds** so the entrypoint trap can run the final `rclone bisync` (120s budget) before SIGKILL, with a 15s clean-exit buffer. A `logger.warn` fires inside the poll loop at 110 seconds elapsed so sessions approaching the budget surface in logs. Clearing identifiers first prevents `onStop()` (async) from resurrecting deleted sessions in KV. The `containerAuthToken` storage key is also cleared here so the next session under the same DO ID starts with a fresh token (no cross-lifecycle reuse). See AD57 for the budget rationale.
 
 **Container auth token persistence (REQ-SEC-012 AC5/AC6):** The token referenced in [Request proxying](#container-do-container) above is generated lazily in `updateEnvVars()`, persisted to `ctx.storage` under key `containerAuthToken`, and restored in `blockConcurrencyWhile` alongside `bucketName` / `sessionId` / other operational state. The storage put is pinned to the request lifecycle via `ctx.waitUntil(...)` so the runtime cannot hibernate the DO before the write commits, closing the wake-then-immediately-hibernate window where the new token would otherwise be lost and re-generated on the next wake. See [security.md](./security.md#container-auth-token-req-sec-012) for the threat model and failure consequence.
 
@@ -97,7 +97,7 @@ flowchart TD
 
 **File:** `host/src/server.ts` - Node.js/TypeScript server inside the container. Single port 8080 for WebSocket + REST + health/metrics.
 
-Sync handled entirely by `entrypoint.sh` (60s daemon). Terminal server reads sync status from `/tmp/sync-status.json` and exposes via `/health`. Activity tracking (WebSocket connection state + user input timestamps: `hasActiveConnections`, `connectedClients`, `activeSessions`, `disconnectedForMs`, `lastInputAt`) for hibernation decisions via `GET /activity`. Unknown JSON `type` strings are silently ignored (guard against future message types leaking to PTY).
+Sync handled entirely by `entrypoint.sh` (15-minute daemon, SIGUSR1-interruptible for manual triggers). Terminal server reads sync status from `/tmp/sync-status.json` and exposes via `/health`. The manual trigger surface is the host endpoint `POST /internal/bisync-trigger`, which reads `/tmp/sync-daemon.pid` and sends SIGUSR1 to the daemon. See AD56 and REQ-STOR-015. Activity tracking (WebSocket connection state + user input timestamps: `hasActiveConnections`, `connectedClients`, `activeSessions`, `disconnectedForMs`, `lastInputAt`) for hibernation decisions via `GET /activity`. Unknown JSON `type` strings are silently ignored (guard against future message types leaking to PTY).
 
 **Auth-Exempt Paths:** The terminal server validates `Authorization: Bearer <token>` on all HTTP requests. `/health` and `/activity` are in the `authExemptPaths` Set at `host/src/server.ts` because `collectMetrics()` calls them directly via `ctx.container.getTcpPort(TERMINAL_SERVER_PORT).fetch(...)` from inside the DO class — that path enters the container over the SDK's private TCP plumbing and never runs through the public `fetch()` override, so no `Authorization` header is injected. The whitelist is safe because these two paths expose no user data and no mutable container state. The `/activity` endpoint is also exempted from auth in the DO-level `fetch()` override so internal health checks don't require token injection.
 

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -1,7 +1,7 @@
 
 # Architecture Decisions
 
-Architecture Decision Records for Codeflare. Each decision documents a design trade-off with rationale. Referenced as AD1-AD55 throughout the codebase and documentation. 41 ADRs carry active content (AD38 superseded by AD48; AD45 and AD50 superseded by AD51); 11 anchors are redirects (6 merged 2026-05-03, 5 reclassified 2026-05-09 per the documentation-discipline "What is NOT an ADR" rule).
+Architecture Decision Records for Codeflare. Each decision documents a design trade-off with rationale. Referenced as AD1-AD57 throughout the codebase and documentation. 43 ADRs carry active content (AD38 superseded by AD48; AD45 and AD50 superseded by AD51); 11 anchors are redirects (6 merged 2026-05-03, 5 reclassified 2026-05-09 per the documentation-discipline "What is NOT an ADR" rule).
 
 **Audience:** Developers
 
@@ -66,6 +66,8 @@ Architecture Decision Records for Codeflare. Each decision documents a design tr
 | [AD53](#ad53-graphify-hot-reload-wrapper-with-multi-repo-sentinel-tracking) | Graphify hot-reload wrapper with multi-repo sentinel tracking | Architecture |
 | [AD54](#ad54-vault-directory-must-use-a-non-hidden-basename) | Vault directory must use a non-hidden basename | Storage |
 | [AD55](#ad55-codeflare-brands-the-vault-editor-via-preseed-managed-stylesmd) | Codeflare brands the vault editor via preseed-managed STYLES.md | Architecture |
+| [AD56](#ad56-15-minute-bisync-cadence-with-manual-triggers) | 15-minute bisync cadence with manual triggers (fan-out safe under newer-mtime-wins) | Storage |
+| [AD57](#ad57-135-second-shutdown-budget-for-final-bisync) | 135-second shutdown budget for final bisync | Storage |
 
 ---
 
@@ -923,6 +925,77 @@ The initial implementation defined only `--cf-*`-namespaced custom properties on
 **Alternative considered:** Use SilverBullet's `theme:` setting in `.silverbullet/config.yaml` instead of a separate `STYLES.md` page. Rejected: the bootstrap `config.yaml` carries only the runtime essentials (indexPage, defaultMode); a 200-line CSS payload belongs in a markdown page where the `#meta/styles` tag is SilverBullet's canonical extension point.
 
 **Related REQ:** REQ-VAULT-001 (AC7 lists the four preseed-authoritative pages including STYLES.md).
+
+---
+
+### AD56: 15-minute bisync cadence with manual triggers
+
+**Category:** Storage
+
+**Status:** Active (2026-05-18)
+
+**Context:** The periodic rclone bisync daemon ran every 60 seconds, producing ~1440 invocations per session per day even on idle sessions. Each invocation does at minimum one LIST on each side plus N HEADs across both encrypted and unencrypted configs; for users with multiple active sessions the R2 operation count scaled into terabytes/month of metadata traffic and Class A operations. The dominant cost was not transferred bytes but listing overhead on idle sessions.
+
+Three options were considered: (a) keep 60s, (b) inotify-driven local-flush plus a 15-minute ceiling, (c) pure 15-minute cadence with explicit user-driven triggers. Option (b) was initially recommended for its sub-minute convergence on active sessions, but the Claude-projects directory writes session transcripts continuously and would trigger the inotify wake on every keystroke; restricting inotify to specific folders added complexity without clearly winning over option (c). Option (c) was chosen for simplicity.
+
+**Decision:** The periodic bisync runs every 15 minutes. Three trigger points cover the gap:
+
+1. **15-minute wall clock** -- the daemon's `sleep` is interruptible by SIGUSR1, otherwise wakes after 900 seconds.
+2. **Manual UI trigger** -- the storage panel's Sync-now button posts to `POST /api/sessions/sync`, which fans out per-session triggers across all the authenticated user's running sessions.
+3. **Upload-side auto-trigger** -- after a successful R2 PUT via the storage panel to a prefix in the active `SYNC_MODE` synced set, the Worker fires a fire-and-forget per-session trigger so the new file appears in the container without waiting for the next cycle.
+
+The daemon's SIGUSR1 trap is coalescing: signals received during a running bisync set a rerun-requested flag rather than queueing, so N signals during one cycle produce exactly one rerun after the current cycle completes.
+
+**Why fan-out across sessions is safe (and serial would not be better):**
+
+- bisync uses `--conflict-resolve newer`. Newest-mtime-wins is commutative and associative on absolute mtime: for any file with versions across N sessions, the final R2 state is always `max(mtime_1, ..., mtime_N)` regardless of order.
+- The system already runs in this concurrent mode every 60 seconds today for any user with multiple active sessions -- the existing `--check-sync=false / --resilient / --recover / --ignore-checksum / --max-delete 100` flag set was added precisely to harden bisync against listing divergence from concurrent writers. Manual fan-out introduces no new concurrency model.
+- R2 (S3-compatible) guarantees atomic per-object writes. Concurrent LISTs from different sessions see slightly different snapshots, but each individual file is either fully old or fully new -- never partial.
+- Serial fan-out would be ~Nx slower with no different outcome. Worse, the "winner" under serial would depend on which session the Worker happened to schedule first, replacing a mathematically deterministic max-mtime outcome with an arbitrary one.
+
+**Consequences:**
+- Estimated ~14x reduction in R2 ops on idle sessions (96 cycles/day vs 1440).
+- Ungraceful exit (OOM, container eviction, kernel panic) can lose up to 15 minutes of work. Graceful exit (idle stop, explicit delete, SIGTERM) remains safe via the final-bisync trap (AD57).
+- Multi-tab convergence latency widens from <=60s to <=15min unless the user clicks Sync-now.
+- Storage-panel-after-terminal-write freshness widens to <=15min unless the user clicks Sync-now.
+- Tier-uniform: free, standard, advanced, max, and custom paid tiers all run on the same cadence.
+
+**Alternative considered:** inotify-driven local-flush with a 15-minute ceiling. Rejected: requires either watching the whole filesystem (Claude-projects flooding) or per-folder include lists (complexity that pure 15-min plus Sync-now avoids). The simplicity win outweighed the sub-minute convergence loss for active sessions.
+
+**Alternative considered:** Activity-gated 60s plus 15-min idle fallback. Rejected: same complexity floor as inotify without the upside; misses out-of-band writes (vault editor on host).
+
+**Related REQ:** REQ-STOR-003 (rewritten in this change), REQ-STOR-015 (manual trigger surface).
+
+---
+
+### AD57: 135-second shutdown budget for final bisync
+
+**Category:** Storage
+
+**Status:** Active (2026-05-18)
+
+**Context:** The pre-existing Container DO `destroy()` budget was 75 seconds (vault rollout had already raised it from 25s -> 75s when vault edits in the last seconds before shutdown were silently truncated by the SDK's SIGKILL mid-bisync). The entrypoint shutdown handler's watchdog was 60 seconds (50s SIGTERM + 10s SIGKILL), nested cleanly inside the 75s DO budget with 15s buffer for clean process exit.
+
+Under the new 15-minute cadence (AD56), any single bisync run can accumulate more changes than under the old 60s cadence -- in the worst case, up to ~15 minutes of writes since the last sync. The 60s shutdown watchdog is therefore too tight: large vault edits or workspace deletes accumulated over a long idle window can routinely exceed 60s on the final bisync, triggering the watchdog's SIGKILL mid-write and leaving R2 in a partial state.
+
+**Decision:** Raise the shutdown chain by 60 seconds at both layers:
+
+- **entrypoint shutdown_handler watchdog**: 50s SIGTERM + 10s SIGKILL -> 108s SIGTERM + 12s SIGKILL (120 seconds total).
+- **Container DO `destroy()` timeout**: 75_000ms -> 135_000ms (120s bisync + 15s clean-exit buffer, preserving the existing 15s margin between the entrypoint giving up and the SDK SIGKILL).
+
+The DO's `_shutdownStartedAt` telemetry already logs `shutdownElapsedMs` on `onStop()`. Augment with a `logger.warn` at 110 seconds elapsed so any session approaching the new budget surfaces in logs and we can bump again if real-world bisyncs routinely exceed 110s.
+
+**Consequences:**
+- Final bisync has headroom for the worst-case 15-minute accumulation.
+- Session-delete UX shows a "Saving final changes to storage..." spinner up to ~130 seconds before reporting success. The session-delete handler at `src/routes/session/crud.ts:194-220` already awaits `container.destroy()` end-to-end, so no fire-and-forget fix is required.
+- The 2-minute SIGKILL is the user-accepted floor: anything still running at 120 seconds is hard-killed and the last writes accepted as potentially lost.
+- If telemetry shows shutdownElapsedMs P95 exceeds 110 seconds in production, the budget can be raised again to 150s/165s without architectural change -- the warn threshold gives early signal.
+
+**Alternative considered:** Telemetry-first canary -- ship the 15-min cadence behind an env var, gather shutdownElapsedMs P95/P99 for one week, then commit to the budget. Rejected by the user: the 2-minute budget plus SIGKILL is the explicit floor; if it is not enough, the warn threshold and post-merge telemetry will tell us within 24 hours.
+
+**Alternative considered:** Block container destruction on an explicit "prepare-shutdown" RPC that runs the final bisync synchronously and only returns on completion. Rejected: the existing trap-driven shutdown already runs the final bisync; adding a separate RPC adds a second code path with the same semantics. The simpler change is to extend the existing budget.
+
+**Related REQ:** REQ-STOR-005 (AC4 + AC5 codify the new budget).
 
 ---
 

--- a/documentation/storage-and-sync.md
+++ b/documentation/storage-and-sync.md
@@ -24,15 +24,15 @@ Per-user R2 storage is capped by `maxStorageBytes` in `SubscriptionTierConfig`. 
 
 s3fs FUSE: every file op = network call (~340ms PUT, ~50ms HEAD), fragile on network hiccups, "Socket not connected" errors.
 
-rclone bisync: all file ops on local disk (<1ms), background daemon every 60s, final bisync on shutdown (SIGINT/SIGTERM), stable.
+rclone bisync: all file ops on local disk (<1ms), background daemon every 15 minutes (`sleep 900`, SIGUSR1-interruptible for manual triggers from the storage panel), final bisync on shutdown (SIGINT/SIGTERM) within a 120s watchdog. See AD56 for the cadence rationale and AD57 for the shutdown budget.
 
 ## Initial Sync on Startup
 
 1. One-way `rclone sync` from R2 to local (restore data) — blocking, container waits for completion (120s timeout)
 2. All file modifications run (`.claude.json`, `.gemini/settings.json`, `.codex/version.json`, tab autostart) — these complete before bisync starts to avoid hash mismatches
-3. `rclone bisync --resync --ignore-checksum --max-delete 100 --check-sync=false --retries 3 --retries-sleep 10s` to establish baseline (non-blocking — runs in background), then start 60-second daemon
+3. `rclone bisync --resync --ignore-checksum --max-delete 100 --check-sync=false --retries 3 --retries-sleep 10s` to establish baseline (non-blocking — runs in background), then start the 15-minute daemon (SIGUSR1-interruptible)
 
-All bisync commands use `--ignore-checksum` to skip post-transfer MD5 verification. rclone v1.73+ treats hash mismatches as fatal ("corrupted on transfer"), which aborts bisync when files change during transfer (e.g., coding agents modifying workspace files). Change detection still uses modtime + size; files that change mid-transfer are caught in the next 60s cycle.
+All bisync commands use `--ignore-checksum` to skip post-transfer MD5 verification. rclone v1.73+ treats hash mismatches as fatal ("corrupted on transfer"), which aborts bisync when files change during transfer (e.g., coding agents modifying workspace files). Change detection still uses modtime + size; files that change mid-transfer are caught in the next 15-minute cycle (or sooner via a manual Sync-now trigger).
 
 `--min-size 1B` on all rclone commands (sync, bisync baseline, bisync daemon) excludes 0-byte files from transfer. R2 SSE-C fails on empty objects — the HeadObject call returns 400 when SSE-C headers are sent for a 0-byte object, which causes rclone to abort with "encryption parameters are not applicable". Empty files (`.lock`, `__init__.py`, etc.) carry no data and are excluded entirely.
 
@@ -71,15 +71,29 @@ All modes always exclude: `.bashrc`, `.bash_profile`, `.npm/**`, `.bun/**`, `.ca
 
 **Note:** The `metadata` mode is defined in `entrypoint.sh` but the Container DO currently only maps `workspaceSyncEnabled` to `full` or `none`. The `metadata` mode can be used by setting `SYNC_MODE` directly in the container environment.
 
+## Manual Sync Triggers
+
+Because the periodic cadence is 15 minutes, three explicit triggers exist for users who need fresh state sooner:
+
+1. **Sync-now button** (storage panel toolbar, cloud-sync icon). Calls `POST /api/sessions/sync`, which enumerates the authenticated user's running sessions and fans out a per-session bisync trigger with a concurrency cap of 8. Per-session failures are isolated; the response carries `{ sessions: [{ sessionId, status: 'triggered' | 'not-running' | 'failed', error? }], count }` so the UI can show honest aggregate feedback ("Synced N sessions" / "Sync errors" / "No running sessions to sync"). Rate-limited to 6 requests per minute per user. See REQ-STOR-015.
+2. **Upload-side auto-trigger**. After a successful `POST /api/storage/upload` or multipart-complete to R2, the Worker fires a fire-and-forget fan-out via `executionCtx.waitUntil(fanOutBisyncTrigger(env, bucketName))` so the new file appears in each running container without waiting for the next 15-minute cycle. No SYNC_MODE pre-filtering at the Worker layer: each container's entrypoint applies its own bisync filters, and an "extra" bisync on a session where the path is excluded is cheap (~one no-op cycle).
+3. **Final sync at shutdown**. The entrypoint's SIGTERM trap runs `bisync_with_r2` inside a 120-second watchdog (108s SIGTERM + 12s SIGKILL) before exiting. The Container DO's `destroy()` budget is 135 seconds (120 + 15s clean-exit buffer). See AD57 and REQ-STOR-005.
+
+**Daemon-side mechanism.** Triggers reach the daemon as SIGUSR1, sent by the host's `/internal/bisync-trigger` endpoint (which the Worker hits transparently through the Container DO's existing fetch-forward path). A SIGUSR1 trap inside the daemon subshell toggles two coalescing flags: `BISYNC_REQUESTED=1` (interrupt the current `sleep 900`) or `BISYNC_RERUN_REQUESTED=1` (queue exactly one rerun after the current cycle, if a bisync is mid-flight). N signals during one cycle coalesce to exactly one rerun. See REQ-STOR-015 AC5.
+
+**Fan-out safety.** Parallel bisync across multiple running sessions is safe under the existing `--conflict-resolve newer` semantics: the merge is commutative and associative on absolute mtime, so parallel and serial fan-out produce the same final R2 state per file. R2's S3-compatible atomic per-object writes guarantee no partial-state corruption. The same concurrent mode already runs every 15 minutes for multi-session users; manual triggers introduce no new failure mode. See AD56.
+
+**Hibernation note.** Triggers are best-effort. A SIGUSR1 sent while the container is sleeping never reaches the daemon (the daemon process is dead); the next container wake runs a forced baseline bisync per REQ-STOR-004 AC4, which absorbs any pending trigger. The Sync-now button surfaces hibernated sessions as `'not-running'` in the per-session result so the user gets honest feedback rather than a hang.
+
 ## Session Transcript Cleanup
 
 `cleanup_old_transcripts()` runs before each periodic bisync (sequential in the same loop iteration — no concurrent access). Keeps the 5 most recent session transcripts (`.claude/projects/**/*.jsonl` sorted by mtime), deletes older `.jsonl` files only — session directories are left intact so Claude Code can still resolve project paths. Deletions propagate to R2 via bisync automatically. Subagent transcripts are also excluded from bisync entirely (`--filter "- .claude/projects/**/subagents/**"`) since results are captured in the main transcript. `cleanup_old_transcripts()` is wrapped in a subshell with `|| true` so `set -euo pipefail` cannot kill the bisync daemon when cleanup encounters benign non-zero exits (e.g., empty `find` results, `xargs` with no input).
 
 ## Conflict Resolution
 
-Newest file wins (`--conflict-resolve newer`). `--resilient` + `--recover` handle transient bisync failures (e.g., interrupted transfers, listing mismatches) without losing deletion tracking. The sync daemon retries in 60s on failure. `--max-delete 100` on ALL bisync commands (`establish_bisync_baseline` and `bisync_with_r2`) allows bulk workspace deletions to propagate. Shutdown handler runs final bisync. All bisync commands use `--ignore-checksum` to prevent false hash-mismatch aborts — rclone v1.73 introduced stricter post-transfer MD5 verification that fails when files change during sync.
+Newest file wins (`--conflict-resolve newer`). `--resilient` + `--recover` handle transient bisync failures (e.g., interrupted transfers, listing mismatches) without losing deletion tracking. The sync daemon retries on the next 15-minute cycle after a failure (or sooner if SIGUSR1-triggered via the storage panel). `--max-delete 100` on ALL bisync commands (`establish_bisync_baseline` and `bisync_with_r2`) allows bulk workspace deletions to propagate. Shutdown handler runs final bisync within a 120s watchdog (see AD57). All bisync commands use `--ignore-checksum` to prevent false hash-mismatch aborts — rclone v1.73 introduced stricter post-transfer MD5 verification that fails when files change during sync.
 
-`--check-sync=false` disables rclone's post-sync listing validation on both `establish_bisync_baseline` and `bisync_with_r2`. The validation compares local/remote file listings after sync — if files change on R2 during the sync (e.g., another active session writing), the listings diverge and rclone exits with code 7 (critical abort). This was the most common trigger. With `--check-sync=false`, drift is caught by the next 60s cycle instead.
+`--check-sync=false` disables rclone's post-sync listing validation on both `establish_bisync_baseline` and `bisync_with_r2`. The validation compares local/remote file listings after sync — if files change on R2 during the sync (e.g., another active session writing), the listings diverge and rclone exits with code 7 (critical abort). This was the most common trigger. With `--check-sync=false`, drift is caught by the next 15-minute cycle (or sooner via Sync-now).
 
 `--retries 3 --retries-sleep 10s` (rclone v1.66+) on both functions adds bisync-level retries for transient R2 API failures. Each bisync invocation retries up to 3 times with 10s sleep between attempts, before the daemon-level retry logic even kicks in.
 

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -32,11 +32,14 @@ The loading screen waits for both R2 sync and PTY pre-warm to complete before si
 
 ### R2 Sync Issues
 
+- **Storage panel doesn't show a file I just created in the terminal**: The periodic bisync runs every 15 minutes (see [AD56](decisions/README.md#ad56-15-minute-bisync-cadence-with-manual-triggers)). Click the **Sync-now** button (cloud-sync icon in the storage panel toolbar) to trigger an immediate bisync across all your running sessions. Status surfaces in the button tooltip ("Synced N sessions" / "No running sessions to sync" / "Sync errors"). If a session shows as `'not-running'`, its container is hibernated; the next time you open that tab the container's wake-time baseline bisync will pull fresh state from R2.
 - **Bisync empty listing**: Initial `establish_bisync_baseline()` uses `--resync` to create the baseline, handles this case. The periodic daemon never uses `--resync` (see [AD14](decisions/README.md#ad14-never-auto---resync-on-bisync-failure)).
 - **`lstat: no such file or directory` bisync failure**: A transient file was listed by rclone then deleted before the copy completed. Automatically recovered: the system parses the error, adds the file to `/tmp/rclone-recovery-filters.txt`, clears bisync locks, and retries (max 3 attempts). Check `/tmp/sync.log` for `[sync-recovery] Excluded vanished file:` entries. If the failure persists beyond 3 attempts, it escalates to the normal consecutive-failure path. See [Vanishing-file recovery](storage-and-sync.md#vanishing-file-recovery) and [AD43](decisions/README.md#ad43-parse-and-exclude-vanishing-files-before-escalating-to-nuke).
 - **Transfers 0 files**: Filter order indeterminacy from mixed `--include`/`--exclude`. Use `--filter` flags instead.
 - **Slow sync**: Switch to `SYNC_MODE=metadata` or manually clean large repos from R2.
 - **Missing secrets**: Check `startup-status` response `details.syncError` for the missing variable.
+- **Session-delete spinner takes ~2 minutes**: The Container DO `destroy()` budget is 135 seconds (120s final-bisync watchdog + 15s clean-exit buffer) so unsaved local changes propagate to R2 before SIGKILL. Routine on sessions with large pending writes. See [AD57](decisions/README.md#ad57-135-second-shutdown-budget-for-final-bisync).
+- **Search button is missing from the storage panel**: Removed 2026-05-18 (sync-v2). The toolbar slot is now the Sync-now button. The underlying search-by-name filter (`storageStore.searchFiles`) is still in the codebase and can be restored by re-adding `<SearchInput />` in the toolbar - see comments in `web-ui/src/components/storage/StorageToolbar.tsx` and `web-ui/src/components/StorageBrowser.tsx`.
 
 ### Zombie Container
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -916,9 +916,9 @@ shutdown_handler() {
                 kill_subtree "$sig" "$child"
             done
         }
-        ( sleep 50
+        ( sleep 108
           kill_subtree TERM "$BISYNC_PID"
-          sleep 10
+          sleep 12
           kill_subtree KILL "$BISYNC_PID"
         ) &
         WATCHDOG_PID=$!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -872,16 +872,17 @@ shutdown_handler() {
     kill_pidfile_subtree /tmp/silverbullet.pid
 
     # Perform final bisync to R2 (only if baseline was established).
-    # Wrap in `timeout 60` so the DO's destroy() SIGKILL budget (75s,
+    # Wrap in a 120s watchdog so the DO's destroy() SIGKILL budget (135s,
     # set in src/container/index.ts) always lands AFTER we either
-    # finished or gave up cleanly — never mid-write to R2.
+    # finished or gave up cleanly - never mid-write to R2.
     #
-    # Pre-vault history: shutdown bisync had no timeout, the DO killed
-    # after 25s, and a long bisync of last-minute edits left R2 in a
-    # partial state. The next session loaded that partial state and
-    # looked stale, forcing the user to delete the session manually.
-    # See bundled fix in vault PR.
-    echo "[entrypoint] Final bisync to R2 (60s budget)..."
+    # History: shutdown bisync had no timeout originally; the DO killed
+    # after 25s and a long bisync of last-minute edits left R2 in a
+    # partial state. The vault PR raised the chain to 60s/75s; the
+    # 15-minute cadence change (AD56) raised it again to 120s/135s to
+    # cover the worst-case 15-minute accumulation on the final bisync.
+    # See AD57 for the budget rationale.
+    echo "[entrypoint] Final bisync to R2 (120s budget)..."
     if [ -f /tmp/.bisync-initialized ]; then
         # Background bisync + watchdog that hard-kills at 60s. Cannot use
         # `timeout(1)` directly because bisync_with_r2 is a shell function;
@@ -901,11 +902,14 @@ shutdown_handler() {
         # rclone's typical depth (subshell -> bash -> rclone -> child).
         ( bisync_with_r2 ) &
         BISYNC_PID=$!
-        # SIGTERM-then-SIGKILL grace pattern. 50s budget for normal bisync,
-        # 10s additional after SIGTERM for rclone to flush + abort pending
-        # multipart uploads cleanly (2s was previously too tight - rclone
-        # needs more headroom to avoid leaving partial uploads in R2).
-        # Total 60s, matching the budget the DO destroy() leaves us.
+        # SIGTERM-then-SIGKILL grace pattern. 108s budget for normal bisync,
+        # 12s additional after SIGTERM for rclone to flush + abort pending
+        # multipart uploads cleanly (2s/10s was previously too tight - rclone
+        # needs more headroom to avoid leaving partial uploads in R2, and the
+        # 15-min cadence means a single final bisync can accumulate more
+        # changes than under the old 60s cadence).
+        # Total 120s, matching the budget the DO destroy() leaves us (135s
+        # minus 15s clean-exit buffer). See AD57.
         kill_subtree() {
             local sig="$1" root="$2"
             [ -z "$root" ] && return 0
@@ -931,7 +935,7 @@ shutdown_handler() {
         if [ "$BISYNC_RC" -eq 0 ]; then
             echo "[entrypoint] Final bisync completed successfully"
         elif [ "$BISYNC_RC" -eq 143 ] || [ "$BISYNC_RC" -eq 137 ]; then
-            echo "[entrypoint] Final bisync TIMED OUT after 60s - last writes may not have synced. Increase budget if this is frequent."
+            echo "[entrypoint] Final bisync TIMED OUT after 120s - last writes may not have synced. Increase budget if this is frequent."
         else
             echo "[entrypoint] Final bisync failed with rc=$BISYNC_RC"
         fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -606,7 +606,7 @@ cleanup_old_transcripts() {
 # ephemeral so wake-time baseline is authoritative. See AD56.
 # ============================================================================
 start_sync_daemon() {
-    echo "[entrypoint] Starting background bisync daemon (every 60s, SIGUSR1-interruptible)..."
+    echo "[entrypoint] Starting background bisync daemon (every 15min, SIGUSR1-interruptible)..."
 
     while true; do
         # First-iteration init: install the SIGUSR1 trap inside the
@@ -628,9 +628,10 @@ start_sync_daemon() {
         # keeps the loop alive across that non-zero exit. Skip the
         # sleep entirely if a trigger was queued while finishing the
         # prior cycle (RERUN_REQUESTED) or while we were idle
-        # (REQUESTED).
+        # (REQUESTED). Cadence is 15 min (AD56); manual triggers from
+        # the storage panel provide the sub-15-min escape hatch.
         if [ "$BISYNC_REQUESTED" = "0" ] && [ "$BISYNC_RERUN_REQUESTED" = "0" ]; then
-            sleep 60 || true
+            sleep 900 || true
         fi
         BISYNC_REQUESTED=0
         BISYNC_RERUN_REQUESTED=0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -587,14 +587,55 @@ cleanup_old_transcripts() {
 }
 
 # ============================================================================
-# Background sync daemon - bisync every 60 seconds
+# Background sync daemon - bisync every 60 seconds, SIGUSR1-interruptible
+#
+# Manual triggers (storage-panel Sync-now, upload-side auto-trigger)
+# arrive as SIGUSR1 sent by host /internal/bisync-trigger to the daemon
+# PID at /tmp/sync-daemon.pid. The trap toggles BISYNC_REQUESTED
+# (interrupts the idle sleep) or BISYNC_RERUN_REQUESTED (queues exactly
+# one rerun after the current cycle), depending on whether a bisync is
+# mid-flight. N signals during one cycle coalesce to exactly one rerun
+# (REQ-STOR-015 AC5).
+#
+# Hibernation note: BISYNC_REQUESTED / BISYNC_RERUN_REQUESTED /
+# BISYNC_IN_FLIGHT live in this daemon process's bash memory. If the
+# container sleeps, the daemon is killed and the flags are lost. This
+# is acceptable: the container's next wake runs a forced baseline
+# bisync per REQ-STOR-004 AC4, absorbing any pending trigger. Do NOT
+# promote these flags to DO storage or KV - they are intentionally
+# ephemeral so wake-time baseline is authoritative. See AD56.
 # ============================================================================
 start_sync_daemon() {
-    echo "[entrypoint] Starting background bisync daemon (every 60s)..."
-    local CONSECUTIVE_FAILURES=0
+    echo "[entrypoint] Starting background bisync daemon (every 60s, SIGUSR1-interruptible)..."
 
     while true; do
-        sleep 60
+        # First-iteration init: install the SIGUSR1 trap inside the
+        # subshell (traps are reset to default in subshells, so the
+        # parent shell's trap would not apply here) and zero the
+        # coalescing flags. Subsequent iterations skip this block.
+        if [ -z "${TRAP_INSTALLED:-}" ]; then
+            BISYNC_REQUESTED=0
+            BISYNC_RERUN_REQUESTED=0
+            BISYNC_IN_FLIGHT=
+            # shellcheck disable=SC2064
+            trap 'if [ -n "$BISYNC_IN_FLIGHT" ]; then BISYNC_RERUN_REQUESTED=1; else BISYNC_REQUESTED=1; fi' USR1
+            CONSECUTIVE_FAILURES=0
+            TRAP_INSTALLED=1
+        fi
+
+        # Interruptible sleep: bash's `sleep` returns non-zero
+        # immediately when SIGUSR1 fires (the trap runs first); `|| true`
+        # keeps the loop alive across that non-zero exit. Skip the
+        # sleep entirely if a trigger was queued while finishing the
+        # prior cycle (RERUN_REQUESTED) or while we were idle
+        # (REQUESTED).
+        if [ "$BISYNC_REQUESTED" = "0" ] && [ "$BISYNC_RERUN_REQUESTED" = "0" ]; then
+            sleep 60 || true
+        fi
+        BISYNC_REQUESTED=0
+        BISYNC_RERUN_REQUESTED=0
+
+        BISYNC_IN_FLIGHT=1
 
         # Rotate sync log if too large (keep last 256KB when exceeding 512KB)
         if [ -f /tmp/sync.log ] && [ "$(stat -c%s /tmp/sync.log 2>/dev/null || echo 0)" -gt 524288 ]; then
@@ -628,6 +669,10 @@ start_sync_daemon() {
                     CONSECUTIVE_FAILURES=0
                     echo "[sync-daemon] $(date '+%Y-%m-%d %H:%M:%S') Recovery bisync succeeded" | tee -a /tmp/sync.log
                     update_sync_status "success" "null"
+                    # Clear in-flight before continue so the next
+                    # iteration's trap classifies signals correctly
+                    # (idle -> REQUESTED, not mid-flight -> RERUN).
+                    BISYNC_IN_FLIGHT=
                     continue
                 fi
             fi
@@ -666,6 +711,13 @@ start_sync_daemon() {
                 fi
             fi
         fi
+
+        # End of cycle: clear in-flight so the trap on a subsequent
+        # signal during the next sleep classifies it as REQUESTED
+        # (interrupt-sleep) rather than RERUN_REQUESTED (queue-after-
+        # current). The trap and these flags coalesce N signals during
+        # one cycle into exactly one rerun.
+        BISYNC_IN_FLIGHT=
     done &
 
     SYNC_DAEMON_PID=$!

--- a/host/__tests__/entrypoint-bisync-trigger.test.js
+++ b/host/__tests__/entrypoint-bisync-trigger.test.js
@@ -1,0 +1,97 @@
+// Verifies REQ-STOR-015 AC5: the bisync daemon installs a SIGUSR1 trap
+// inside its subshell, manages in-flight + rerun-requested coalescing
+// flags, and writes its PID atomically to /tmp/sync-daemon.pid so the
+// host /internal/bisync-trigger endpoint can signal it.
+//
+// Static structural test: reads entrypoint.sh and asserts on patterns.
+// Behavioural verification (signal -> wake) lives in
+// entrypoint-sigusr1.test.js.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const entrypoint = readFileSync(resolve(__dirname, '../../entrypoint.sh'), 'utf8');
+
+describe('entrypoint.sh bisync daemon SIGUSR1 trigger plumbing (REQ-STOR-015)', () => {
+  it('AC5: installs a SIGUSR1 trap inside the daemon subshell', () => {
+    // The trap must be installed via the first-iteration guard so it
+    // takes effect inside the `while ... done &` subshell (parent-shell
+    // traps are reset to default in subshells).
+    assert.ok(
+      entrypoint.includes("trap 'if [ -n \"$BISYNC_IN_FLIGHT\" ]; then BISYNC_RERUN_REQUESTED=1; else BISYNC_REQUESTED=1; fi' USR1"),
+      'entrypoint.sh must install a SIGUSR1 trap that toggles BISYNC_REQUESTED (idle) or BISYNC_RERUN_REQUESTED (mid-flight) coalescing flags'
+    );
+  });
+
+  it('AC5: initialises the three coalescing flags', () => {
+    assert.ok(/BISYNC_REQUESTED=0/.test(entrypoint),
+      'entrypoint.sh must initialise BISYNC_REQUESTED=0');
+    assert.ok(/BISYNC_RERUN_REQUESTED=0/.test(entrypoint),
+      'entrypoint.sh must initialise BISYNC_RERUN_REQUESTED=0');
+    assert.ok(/BISYNC_IN_FLIGHT=\s*$/m.test(entrypoint) || /BISYNC_IN_FLIGHT=\n/.test(entrypoint),
+      'entrypoint.sh must initialise BISYNC_IN_FLIGHT to empty');
+  });
+
+  it('AC5: gates the periodic sleep on the coalescing flags', () => {
+    // If either flag is set when entering the sleep check, we skip
+    // the sleep entirely and run an immediate bisync.
+    assert.ok(
+      /if \[ "\$BISYNC_REQUESTED" = "0" \] && \[ "\$BISYNC_RERUN_REQUESTED" = "0" \]; then/.test(entrypoint),
+      'entrypoint.sh must gate `sleep 60` on both BISYNC_REQUESTED=0 AND BISYNC_RERUN_REQUESTED=0'
+    );
+  });
+
+  it('AC5: sets BISYNC_IN_FLIGHT before bisync and clears it after each cycle', () => {
+    // Search for the set + clear pair in the daemon body.
+    const sets = entrypoint.match(/BISYNC_IN_FLIGHT=1/g) || [];
+    assert.ok(sets.length >= 1, 'entrypoint.sh must set BISYNC_IN_FLIGHT=1 before each bisync attempt');
+    // Two clears: one before the recovery-success `continue`, one at
+    // end-of-cycle. Both classify subsequent signals correctly.
+    const clears = entrypoint.match(/BISYNC_IN_FLIGHT=\s*$/gm) || [];
+    assert.ok(
+      clears.length >= 3, // includes the init line + 2 clears
+      `entrypoint.sh must clear BISYNC_IN_FLIGHT at end-of-cycle and before recovery continue (found ${clears.length} matches, expected >= 3)`
+    );
+  });
+
+  it('AC1: writes daemon PID to /tmp/sync-daemon.pid for the host trigger endpoint', () => {
+    assert.ok(
+      entrypoint.includes('echo "$SYNC_DAEMON_PID" > /tmp/sync-daemon.pid'),
+      'entrypoint.sh must write the daemon PID to /tmp/sync-daemon.pid so /internal/bisync-trigger can signal it'
+    );
+  });
+
+  it('AC5: documents hibernation-ephemeral semantics of the flags', () => {
+    // Header comment must warn that the flags live in daemon memory
+    // and that the wake-time baseline (REQ-STOR-004 AC4) absorbs any
+    // lost trigger - so we never promote these to DO storage or KV.
+    assert.ok(
+      /Hibernation note/.test(entrypoint) && /REQ-STOR-004 AC4/.test(entrypoint),
+      'entrypoint.sh sync daemon header must document hibernation-ephemeral semantics and reference REQ-STOR-004 AC4'
+    );
+  });
+});
+
+describe('entrypoint.sh shutdown budget (REQ-STOR-005, AD57)', () => {
+  it('AC4: final-bisync watchdog uses 108s + 12s = 120s budget', () => {
+    // Look for the SIGTERM + SIGKILL sleep pair in shutdown_handler.
+    assert.ok(
+      /\( sleep 108\s+kill_subtree TERM "\$BISYNC_PID"\s+sleep 12\s+kill_subtree KILL "\$BISYNC_PID"/.test(entrypoint),
+      'entrypoint.sh shutdown watchdog must use 108s SIGTERM + 12s SIGKILL (120s total) per AD57'
+    );
+  });
+
+  it('AC4: shutdown log strings advertise the 120s budget', () => {
+    assert.ok(
+      entrypoint.includes('Final bisync to R2 (120s budget)'),
+      'entrypoint.sh must announce the 120s budget in its shutdown log line'
+    );
+    assert.ok(
+      entrypoint.includes('Final bisync TIMED OUT after 120s'),
+      'entrypoint.sh timeout-path log line must reference 120s'
+    );
+  });
+});

--- a/host/src/server.ts
+++ b/host/src/server.ts
@@ -283,6 +283,46 @@ const server = http.createServer(async (req: http.IncomingMessage, res: http.Ser
     return;
   }
 
+  // Manual bisync trigger (REQ-STOR-015 AC1). Sends SIGUSR1 to the
+  // bisync daemon, which interrupts its sleep and runs an immediate
+  // bisync cycle. Idempotent: signals during a running bisync coalesce
+  // to exactly one rerun (see entrypoint.sh trap).
+  //
+  // Hibernation note: the daemon PID is read from /tmp/sync-daemon.pid
+  // at every call, never cached. If the container is sleeping or the
+  // daemon has not yet written its PID file, the call returns 503; the
+  // Worker fan-out treats 503 as "session not active, skip" rather
+  // than propagating a user-visible error.
+  if (pathname === '/internal/bisync-trigger' && method === 'POST') {
+    try {
+      const pidStr = fs.readFileSync('/tmp/sync-daemon.pid', 'utf8').trim();
+      const pid = Number(pidStr);
+      if (!Number.isFinite(pid) || pid <= 0) {
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'not-running', error: 'invalid daemon PID' }));
+        return;
+      }
+      try {
+        process.kill(pid, 'SIGUSR1');
+      } catch {
+        // ESRCH: process gone (daemon crashed or container restarting).
+        // Treat as not-running; the next container wake forces a
+        // baseline bisync per REQ-STOR-004 AC4, absorbing this trigger.
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'not-running', error: 'daemon process not found' }));
+        return;
+      }
+      res.writeHead(202, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'triggered' }));
+    } catch {
+      // PID file missing: daemon has not started yet (container still
+      // running initial sync) or has been torn down (shutdown trap).
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'not-running', error: 'sync daemon not started' }));
+    }
+    return;
+  }
+
   // Sync log endpoint
   if (pathname === '/sync-log' && method === 'GET') {
     try {

--- a/sdd/storage.md
+++ b/sdd/storage.md
@@ -7,7 +7,7 @@ R2 persistence, rclone bisync, quotas, and file browser.
 | Concept | Definition |
 |---------|-----------|
 | R2 Bucket | Per-user Cloudflare R2 storage bucket, named deterministically from user email, providing isolated durable file storage |
-| Bisync | Bidirectional rclone sync that reconciles local filesystem and R2 every 60 seconds, using newest-file-wins conflict resolution |
+| Bisync | Bidirectional rclone sync that reconciles local filesystem and R2 every 15 minutes (plus on user-initiated triggers and at shutdown), using newest-file-wins conflict resolution |
 | Sync Mode | User-configurable scope of what gets synced: `none` (configs only), `full` (entire workspace), or `metadata` (agent configs per repo) |
 | Storage Quota | Per-tier limit on total R2 usage (`maxStorageBytes`), enforced at session start, cached in KV with 60-second TTL |
 
@@ -15,7 +15,7 @@ R2 persistence, rclone bisync, quotas, and file browser.
 
 - **Version history** -- R2 stores current file state only. No file versioning, rollback to previous revisions, or change tracking within storage.
 - **File collaboration** -- Storage is single-user. No shared buckets, shared folders, or multi-user access to the same R2 prefix.
-- **Real-time file sync** -- Bisync runs on a 60-second interval. Sub-second or event-driven sync between browser and container is not supported.
+- **Real-time file sync** -- Bisync runs on a 15-minute cadence with explicit user-driven manual triggers (Sync-now button, upload-side auto-trigger) and a final sync at container shutdown. R2-side changes and multi-tab convergence wait up to the 15-minute ceiling unless the user clicks Sync-now. Sub-second or event-driven sync between browser and container is not supported.
 
 ### Domain Dependencies
 
@@ -71,16 +71,17 @@ R2 persistence, rclone bisync, quotas, and file browser.
 
 ---
 
-## REQ-STOR-003: Bidirectional Sync Every 60 Seconds
+## REQ-STOR-003: Bidirectional Sync Every 15 Minutes (with Manual Triggers)
 
-**Intent:** Changes made locally (by the agent or user) and changes in R2 (from the file browser or another session's sync) must converge within a bounded interval.
+**Intent:** Changes made locally (by the agent or user) and changes in R2 (from the file browser or another session's sync) must converge within a bounded interval, balanced against R2 operation cost. The 15-minute cadence is supplemented by explicit user-driven triggers (REQ-STOR-015) so the user is never blocked waiting for a cycle when they want fresh state.
 
 **Acceptance Criteria:**
-1. After bisync baseline is established, a periodic rclone bisync runs every 60 seconds.
-2. Conflict resolution uses newest-file-wins (`--conflict-resolve newer`).
-3. The daemon retries on transient failure and continues the 60-second cycle.
-4. On bisync failure, the daemon attempts vanishing-file recovery (parse error output, exclude transient files, clear locks, retry) before counting the failure.
-5. After 3 consecutive unrecoverable failures (each with 3 internal retries), the daemon falls back to a `--resync` baseline to re-establish clean state.
+1. After bisync baseline is established, a periodic rclone bisync runs every 15 minutes (`sleep 900` in the daemon loop).
+2. The daemon's sleep is SIGUSR1-interruptible: a signal wakes the daemon and skips the sleep, producing an immediate bisync. Signals delivered while a bisync is mid-flight queue exactly one rerun via a coalescing flag (see REQ-STOR-015 AC5).
+3. Conflict resolution uses newest-file-wins (`--conflict-resolve newer`).
+4. The daemon retries on transient failure and continues the 15-minute cycle.
+5. On bisync failure, the daemon attempts vanishing-file recovery (parse error output, exclude transient files, clear locks, retry) before counting the failure.
+6. After 3 consecutive unrecoverable failures (each with 3 internal retries), the daemon falls back to a `--resync` baseline to re-establish clean state.
 
 **Constraints:**
 - All bisync commands must use `--ignore-checksum` to prevent false hash-mismatch aborts from files changing mid-transfer.

--- a/sdd/storage.md
+++ b/sdd/storage.md
@@ -134,9 +134,11 @@ R2 persistence, rclone bisync, quotas, and file browser.
 1. A SIGINT/SIGTERM handler triggers a final bisync before exit.
 2. The final bisync only runs if the bisync-initialized flag is set.
 3. Files created during the session are available in R2 after shutdown completes.
+4. The final bisync has a 120-second watchdog (108s SIGTERM phase, 12s SIGKILL phase). Anything still running at 120 seconds is hard-killed and the user accepts that the last writes may not have synced.
+5. The Container DO `destroy()` budget is 135 seconds (120s for the final bisync plus 15s for clean process exit) before SDK teardown SIGKILLs the container.
 
 **Constraints:**
-- The shutdown handler must complete within the container runtime's grace period.
+- The shutdown handler must complete within 120 seconds; the DO destroy() budget is 135 seconds.
 - Final bisync uses the same flags as periodic bisync (`--ignore-checksum`, `--max-delete 100`, `--check-sync=false`).
 
 **Applies To:** User

--- a/sdd/storage.md
+++ b/sdd/storage.md
@@ -366,3 +366,29 @@ R2 persistence, rclone bisync, quotas, and file browser.
 **Verification:** Automated test
 
 **Status:** Implemented
+
+---
+
+## REQ-STOR-015: Explicit Sync Trigger from UI
+
+**Intent:** Because the periodic bisync cadence is 15 minutes (REQ-STOR-003), users must have explicit ways to force convergence between the container filesystem and R2 without waiting for the next cycle.
+
+**Acceptance Criteria:**
+1. `POST /api/sessions/sync` fans out a sync trigger to every running session belonging to the authenticated user. Stopped sessions are skipped client-side using `batch-status` output before fan-out.
+2. Fan-out runs in parallel with a concurrency cap of 8; remaining sessions are queued.
+3. Per-session failures are isolated -- one session's bisync failure does not prevent other sessions from completing. The response shape returns the per-session sync status.
+4. After a successful R2 PUT via `POST /api/storage/upload` (or multipart-complete) to a prefix in the active `SYNC_MODE` synced set, the Worker fires a fire-and-forget `POST /api/container/sync` to the session's container. The upload response does not block on the sync.
+5. The trigger is idempotent: a SIGUSR1 sent to the bisync daemon while a bisync is already in flight sets a rerun-requested flag, which causes exactly one rerun after the current cycle completes (N signals during one bisync coalesce to one rerun, not N).
+6. The frontend Sync-now button is disabled while any of the user's sessions reports `sync.status === 'syncing'` and re-enables once all sessions transition out.
+7. `POST /api/sessions/sync` is rate-limited at 6 requests per minute per user (matches the destructive-action rate-limiter pattern).
+
+**Constraints:**
+- Multi-session fan-out is safe under the existing `--conflict-resolve newer` bisync semantics: the merge operation is commutative and associative under absolute mtime, so parallel and serial fan-out produce the same final R2 state per file. The same concurrent mode already runs every 15 minutes when a user has multiple sessions (per REQ-STOR-003); manual triggers introduce no new failure mode.
+- Upload triggers only fire when `isInSyncSet(prefix, syncMode)` is true. Uploads to a path the active SYNC_MODE excludes do not trigger (the file would sit in R2 invisible to the container until SYNC_MODE changes).
+
+**Applies To:** User
+**Priority:** P1
+**Dependencies:** REQ-STOR-003, REQ-STOR-007, REQ-STOR-011
+**Verification:** Automated test
+
+**Status:** Planned

--- a/src/__tests__/container/index.test.ts
+++ b/src/__tests__/container/index.test.ts
@@ -542,7 +542,7 @@ describe('container DO class', () => {
       expect(mockStorage.delete).toHaveBeenCalledWith('bucketName');
     });
 
-    it('graceful shutdown: falls back to SIGKILL when the container is still running after the 75 s timeout', async () => {
+    it('graceful shutdown: falls back to SIGKILL when the container is still running after the 135 s timeout', async () => {
       vi.useFakeTimers();
       try {
         mockStorage.get.mockImplementation(async (key: string) => {
@@ -557,10 +557,11 @@ describe('container DO class', () => {
         const stopSpy = vi.spyOn(instance, 'stop' as any).mockResolvedValue(undefined);
 
         const destroyPromise = instance.destroy();
-        // Advance just past the 75s timeout so the polling loop exits via the
-        // wall-clock branch, not the running=false branch. 75s pairs with the
-        // entrypoint.sh shutdown bisync 60s budget plus a 15s buffer.
-        await vi.advanceTimersByTimeAsync(76_000);
+        // Advance just past the 135s timeout so the polling loop exits via
+        // the wall-clock branch, not the running=false branch. 135s pairs
+        // with the entrypoint.sh shutdown bisync 120s budget plus a 15s
+        // clean-exit buffer. See AD57.
+        await vi.advanceTimersByTimeAsync(136_000);
         await destroyPromise;
 
         expect(stopSpy).toHaveBeenCalledWith('SIGTERM');
@@ -909,9 +910,10 @@ describe('container DO class', () => {
         return null;
       });
       // Ensure destroy()'s SIGTERM polling exits immediately rather than
-      // running the full 75s budget (which exceeds vitest's 30s test
+      // running the full 135s budget (which exceeds vitest's 30s test
       // timeout). The graceful-shutdown behaviour itself is covered by
-      // the dedicated tests above.
+      // the dedicated tests above. Budget raised from 75s -> 135s alongside
+      // the 15-min cadence change (AD57).
       mockContainerRuntime.running = false;
 
       const instance = new ContainerClass(mockCtx as any, mockEnv);

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -238,6 +238,16 @@ export class container extends Container<Env> {
     const handler = this.internalRoutes.get(routeKey);
     if (handler) return handler(request);
 
+    // Note on POST /internal/bisync-trigger (REQ-STOR-015): the Worker
+    // fan-out at /api/sessions/sync calls this DO with that path. It is
+    // intentionally NOT in the internalRoutes map (no leading underscore)
+    // so it falls through to the standard forward path below: the DO
+    // injects the container auth token and super.fetch() routes it to
+    // the host server's matching handler. The 503 short-circuit on a
+    // hibernated container is the hibernation-safety guarantee for the
+    // Sync-now feature - no DO-side state, no daemon-PID cache, all
+    // decisions made at call time against ctx.container?.running.
+
     // Reject non-internal requests when the container is not running.
     // This prevents WebSocket reconnect attempts from waking a hibernated
     // container via super.fetch() (which triggers the SDK's startIfNotRunning).

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -110,8 +110,10 @@ export class container extends Container<Env> {
   private _userEmail: string | null = null;
   /**
    * Timestamp captured at the start of destroy(); read by onStop() to
-   * log shutdown elapsed-ms. Helps telemetry decide whether the 75s
-   * SIGTERM budget is right or needs another bump.
+   * log shutdown elapsed-ms. Helps telemetry decide whether the 135s
+   * SIGTERM budget is right or needs another bump. A warn fires inside
+   * destroy() at 110s elapsed so sessions approaching the ceiling
+   * surface in logs before the 15-min cadence makes them routine.
    */
   private _shutdownStartedAt = 0;
   /** Monotonic usage counter (seconds) — sent to Timekeeper for delta computation */
@@ -474,21 +476,34 @@ export class container extends Container<Env> {
     }
 
     if (this.ctx.container?.running) {
-      // 75s = 60s budget for the entrypoint's final bisync (set in
+      // 135s = 120s budget for the entrypoint's final bisync (set in
       // entrypoint.sh:shutdown_handler) plus a 15s buffer for clean
-      // process exit. Was 25_000 originally; raised to 75_000 alongside
-      // the vault rollout because vault edits in the last seconds
-      // before shutdown were silently truncated when the SDK SIGKILLed
-      // mid-bisync, leaving R2 in a partial state that the next
-      // session loaded as stale.
+      // process exit. Budget history: 25_000 (original) -> 75_000
+      // (vault rollout: vault edits in the last seconds were silently
+      // truncated when the SDK SIGKILLed mid-bisync) -> 135_000 (this
+      // change, alongside the 15-min cadence). Under the 15-min
+      // cadence (AD56) a single final bisync can accumulate more
+      // changes than under the old 60s cadence, so the watchdog at
+      // the entrypoint layer needed 120s; the DO budget tracks that
+      // plus the same 15s clean-exit buffer. See AD57.
       this._shutdownStartedAt = Date.now();
-      const timeoutMs = 75_000;
+      const timeoutMs = 135_000;
+      const warnThresholdMs = 110_000;
       const pollMs = 250;
       const start = this._shutdownStartedAt;
+      let warned = false;
       try {
         await this.stop('SIGTERM');
         while (this.ctx.container?.running && Date.now() - start < timeoutMs) {
           await new Promise((resolve) => setTimeout(resolve, pollMs));
+          if (!warned && Date.now() - start >= warnThresholdMs) {
+            warned = true;
+            this.logger.warn('Shutdown approaching budget ceiling', {
+              elapsedMs: Date.now() - start,
+              budgetMs: timeoutMs,
+              warnThresholdMs,
+            });
+          }
         }
         const elapsed = Date.now() - start;
         if (this.ctx.container?.running) {

--- a/src/lib/sync-fanout.ts
+++ b/src/lib/sync-fanout.ts
@@ -1,0 +1,123 @@
+/**
+ * Sync fan-out helper (REQ-STOR-015 AC1 + AC4).
+ *
+ * Enumerates a user's running sessions and forwards POST
+ * /internal/bisync-trigger to each Container DO. Used by:
+ *
+ * - POST /api/sessions/sync (foreground, user-driven Sync-now button)
+ * - Upload-side auto-trigger after R2 PUT (background via
+ *   executionCtx.waitUntil)
+ *
+ * Hibernation safety: stateless. No Worker-side cache, no DO-side
+ * cache. Each call freshly enumerates KV (which is authoritative for
+ * session status per REQ-STOR-014) and freshly forwards to each
+ * Container DO. Hibernated DOs / sleeping containers return 503,
+ * which is translated to 'not-running' so the caller can mark the
+ * session as "skipped" rather than "failed".
+ *
+ * Fan-out correctness: under the existing `--conflict-resolve newer`
+ * semantics in entrypoint.sh, the merge is commutative and associative
+ * on absolute mtime. Parallel and serial fan-out produce the same
+ * final R2 state per file. See AD56.
+ */
+import { getContainer } from '@cloudflare/containers';
+import type { Env, Session } from '../types';
+import {
+  getSessionPrefix,
+  listAllKvKeys,
+  expandSessionMetadata,
+  type SessionListMetadata,
+} from './kv-keys';
+import { getContainerId } from './container-helpers';
+
+/**
+ * Maximum concurrent per-session sync triggers in one fan-out call
+ * (REQ-STOR-015 AC2). Keeps Worker subrequest / CPU budget bounded
+ * if a user has many running sessions. Triggers beyond the cap are
+ * processed sequentially in subsequent chunks.
+ */
+export const FANOUT_CONCURRENCY_CAP = 8;
+
+export interface SyncSessionResult {
+  sessionId: string;
+  status: 'triggered' | 'not-running' | 'failed';
+  error?: string;
+}
+
+/**
+ * Enumerate the authenticated user's running sessions and fan-out the
+ * bisync trigger. Per-session failures are isolated (REQ-STOR-015 AC3).
+ */
+export async function fanOutBisyncTrigger(
+  env: Env,
+  bucketName: string
+): Promise<SyncSessionResult[]> {
+  const prefix = getSessionPrefix(bucketName);
+  const keys = await listAllKvKeys(env.KV, prefix);
+
+  // Collect running sessions only. Use list-metadata fast path; fall
+  // back to KV.get for pre-migration keys (same pattern as batch-status
+  // in src/routes/session/lifecycle.ts).
+  const runningSessionIds: string[] = [];
+  const fallbackKeys: Array<{ name: string }> = [];
+  for (const key of keys) {
+    const meta = key.metadata as SessionListMetadata | null;
+    if (meta && meta.s) {
+      const expanded = expandSessionMetadata(meta);
+      if (expanded.status === 'running') {
+        runningSessionIds.push(key.name.split(':').pop()!);
+      }
+    } else {
+      fallbackKeys.push(key);
+    }
+  }
+  if (fallbackKeys.length > 0) {
+    const fallbackSessions = await Promise.all(
+      fallbackKeys.map((key) => env.KV.get<Session>(key.name, 'json'))
+    );
+    for (const session of fallbackSessions) {
+      if (session && session.status === 'running') {
+        runningSessionIds.push(session.id);
+      }
+    }
+  }
+
+  // Fan out with concurrency cap. Each chunk's failures are isolated.
+  const results: SyncSessionResult[] = [];
+  for (let i = 0; i < runningSessionIds.length; i += FANOUT_CONCURRENCY_CAP) {
+    const chunk = runningSessionIds.slice(i, i + FANOUT_CONCURRENCY_CAP);
+    const chunkResults = await Promise.all(
+      chunk.map(async (sessionId): Promise<SyncSessionResult> => {
+        try {
+          const containerId = getContainerId(bucketName, sessionId);
+          const container = getContainer(env.CONTAINER, containerId);
+          // Path intentionally NOT in the DO's internalRoutes map (no
+          // leading underscore) so the DO's fetch() override forwards
+          // through super.fetch() with auth injection. The host's
+          // /internal/bisync-trigger handler sends SIGUSR1 to the
+          // bisync daemon.
+          const res = await container.fetch(
+            new Request('http://container/internal/bisync-trigger', { method: 'POST' })
+          );
+          if (res.status === 202) {
+            return { sessionId, status: 'triggered' };
+          }
+          if (res.status === 503) {
+            // Container not running (DO 503) or daemon not started
+            // (host 503). Either way, no active sync work to trigger.
+            return { sessionId, status: 'not-running' };
+          }
+          return { sessionId, status: 'failed', error: `unexpected status ${res.status}` };
+        } catch (err) {
+          return {
+            sessionId,
+            status: 'failed',
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      })
+    );
+    results.push(...chunkResults);
+  }
+  return results;
+}

--- a/src/lib/sync-fanout.ts
+++ b/src/lib/sync-fanout.ts
@@ -34,9 +34,10 @@ import { getContainerId } from './container-helpers';
  * Maximum concurrent per-session sync triggers in one fan-out call
  * (REQ-STOR-015 AC2). Keeps Worker subrequest / CPU budget bounded
  * if a user has many running sessions. Triggers beyond the cap are
- * processed sequentially in subsequent chunks.
+ * processed sequentially in subsequent chunks. Internal-only - no
+ * external consumer needs to read it.
  */
-export const FANOUT_CONCURRENCY_CAP = 8;
+const FANOUT_CONCURRENCY_CAP = 8;
 
 export interface SyncSessionResult {
   sessionId: string;

--- a/src/routes/session/lifecycle.ts
+++ b/src/routes/session/lifecycle.ts
@@ -66,6 +66,34 @@ const sessionStopRateLimiter = createRateLimiter({
   keyPrefix: 'session-stop',
 });
 
+/**
+ * Rate limiter for manual fan-out sync trigger (REQ-STOR-015 AC7).
+ * 6/min matches the destructive-action pattern of session-stop / session-
+ * delete. The Sync-now button is a user-driven action that should be
+ * rare in normal use; 6/min covers reasonable usage without enabling
+ * trigger spam against multiple containers.
+ */
+const sessionsSyncRateLimiter = createRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 6,
+  keyPrefix: 'sessions-sync',
+});
+
+/**
+ * Maximum concurrent per-session sync triggers in one fan-out call
+ * (REQ-STOR-015 AC2). Keeps Worker subrequest / CPU budget bounded if
+ * a user has many running sessions. Triggers beyond the cap are
+ * queued (processed in the next chunk) - they still complete in this
+ * one request, just sequentially.
+ */
+const FANOUT_CONCURRENCY_CAP = 8;
+
+interface SyncSessionResult {
+  sessionId: string;
+  status: 'triggered' | 'not-running' | 'failed';
+  error?: string;
+}
+
 const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
 
 /**
@@ -156,6 +184,101 @@ app.get('/batch-status', async (c) => {
   }
 
   return c.json({ statuses, maxSessions, storageStats, usage });
+});
+
+/**
+ * POST /api/sessions/sync
+ *
+ * Fan-out a manual bisync trigger to all the user's running sessions
+ * (REQ-STOR-015 AC1). KV is authoritative for session status (per
+ * REQ-STOR-014 and the batch-status comment block above) so we never
+ * wake hibernated containers just to learn whether they're running.
+ *
+ * Concurrency: chunks of FANOUT_CONCURRENCY_CAP per Promise.all wave.
+ * Per-session failures are isolated - one container's 500 or network
+ * error does not block the other sessions (REQ-STOR-015 AC3).
+ *
+ * Fan-out correctness: under the existing `--conflict-resolve newer`
+ * semantics in entrypoint.sh, the merge is commutative and associative
+ * on absolute mtime. Parallel and serial fan-out produce the same
+ * final R2 state per file. See AD56 for the math.
+ *
+ * Hibernation safety: stateless. No Worker-side cache, no DO-side
+ * cache. Each call freshly enumerates KV and freshly forwards to each
+ * Container DO. The DO returns 503 when its container is not running,
+ * which we translate to 'not-running' in the per-session result.
+ */
+app.post('/sync', sessionsSyncRateLimiter, async (c) => {
+  const bucketName = c.get('bucketName');
+  const prefix = getSessionPrefix(bucketName);
+  const keys = await listAllKvKeys(c.env.KV, prefix);
+
+  // Collect running sessions only. Use list-metadata fast path; fall
+  // back to KV.get for pre-migration keys (same pattern as batch-status).
+  const runningSessionIds: string[] = [];
+  const fallbackKeys: Array<{ name: string }> = [];
+  for (const key of keys) {
+    const meta = key.metadata as SessionListMetadata | null;
+    if (meta && meta.s) {
+      const expanded = expandSessionMetadata(meta);
+      if (expanded.status === 'running') {
+        runningSessionIds.push(key.name.split(':').pop()!);
+      }
+    } else {
+      fallbackKeys.push(key);
+    }
+  }
+  if (fallbackKeys.length > 0) {
+    const fallbackSessions = await Promise.all(
+      fallbackKeys.map((key) => c.env.KV.get<Session>(key.name, 'json'))
+    );
+    for (const session of fallbackSessions) {
+      if (session && session.status === 'running') {
+        runningSessionIds.push(session.id);
+      }
+    }
+  }
+
+  // Fan out with concurrency cap. Each chunk's failures are isolated.
+  const results: SyncSessionResult[] = [];
+  for (let i = 0; i < runningSessionIds.length; i += FANOUT_CONCURRENCY_CAP) {
+    const chunk = runningSessionIds.slice(i, i + FANOUT_CONCURRENCY_CAP);
+    const chunkResults = await Promise.all(
+      chunk.map(async (sessionId): Promise<SyncSessionResult> => {
+        try {
+          const containerId = getContainerId(bucketName, sessionId);
+          const container = getContainer(c.env.CONTAINER, containerId);
+          // Path is intentionally NOT in the DO's internalRoutes map
+          // (no leading underscore) so the DO's fetch() override
+          // forwards it through super.fetch() to the host server's
+          // /internal/bisync-trigger handler with container auth
+          // injected. See container/index.ts note in fetch() override.
+          const res = await container.fetch(
+            new Request('http://container/internal/bisync-trigger', { method: 'POST' })
+          );
+          if (res.status === 202) {
+            return { sessionId, status: 'triggered' };
+          }
+          if (res.status === 503) {
+            // Container not running (DO 503) or daemon not started
+            // (host 503). Either way, the session is not actively
+            // syncing so a manual trigger is a no-op.
+            return { sessionId, status: 'not-running' };
+          }
+          return { sessionId, status: 'failed', error: `unexpected status ${res.status}` };
+        } catch (err) {
+          return {
+            sessionId,
+            status: 'failed',
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      })
+    );
+    results.push(...chunkResults);
+  }
+
+  return c.json({ sessions: results, count: results.length });
 });
 
 /**

--- a/src/routes/session/lifecycle.ts
+++ b/src/routes/session/lifecycle.ts
@@ -16,6 +16,7 @@ import { toApiSession } from '../../lib/session-helpers';
 import { ValidationError } from '../../lib/error-types';
 import { isSaasModeActive } from '../../lib/onboarding';
 import { getTierConfig, getUserTier } from '../../lib/subscription';
+import { fanOutBisyncTrigger } from '../../lib/sync-fanout';
 import type { UsageRecord } from '../../types';
 
 /**
@@ -78,21 +79,6 @@ const sessionsSyncRateLimiter = createRateLimiter({
   maxRequests: 6,
   keyPrefix: 'sessions-sync',
 });
-
-/**
- * Maximum concurrent per-session sync triggers in one fan-out call
- * (REQ-STOR-015 AC2). Keeps Worker subrequest / CPU budget bounded if
- * a user has many running sessions. Triggers beyond the cap are
- * queued (processed in the next chunk) - they still complete in this
- * one request, just sequentially.
- */
-const FANOUT_CONCURRENCY_CAP = 8;
-
-interface SyncSessionResult {
-  sessionId: string;
-  status: 'triggered' | 'not-running' | 'failed';
-  error?: string;
-}
 
 const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
 
@@ -189,95 +175,14 @@ app.get('/batch-status', async (c) => {
 /**
  * POST /api/sessions/sync
  *
- * Fan-out a manual bisync trigger to all the user's running sessions
- * (REQ-STOR-015 AC1). KV is authoritative for session status (per
- * REQ-STOR-014 and the batch-status comment block above) so we never
- * wake hibernated containers just to learn whether they're running.
- *
- * Concurrency: chunks of FANOUT_CONCURRENCY_CAP per Promise.all wave.
- * Per-session failures are isolated - one container's 500 or network
- * error does not block the other sessions (REQ-STOR-015 AC3).
- *
- * Fan-out correctness: under the existing `--conflict-resolve newer`
- * semantics in entrypoint.sh, the merge is commutative and associative
- * on absolute mtime. Parallel and serial fan-out produce the same
- * final R2 state per file. See AD56 for the math.
- *
- * Hibernation safety: stateless. No Worker-side cache, no DO-side
- * cache. Each call freshly enumerates KV and freshly forwards to each
- * Container DO. The DO returns 503 when its container is not running,
- * which we translate to 'not-running' in the per-session result.
+ * User-driven Sync-now button (REQ-STOR-015 AC1). Thin wrapper over
+ * `fanOutBisyncTrigger`; the helper holds the enumeration + fan-out
+ * logic so the upload-side auto-trigger (REQ-STOR-015 AC4) can share
+ * it without duplication.
  */
 app.post('/sync', sessionsSyncRateLimiter, async (c) => {
   const bucketName = c.get('bucketName');
-  const prefix = getSessionPrefix(bucketName);
-  const keys = await listAllKvKeys(c.env.KV, prefix);
-
-  // Collect running sessions only. Use list-metadata fast path; fall
-  // back to KV.get for pre-migration keys (same pattern as batch-status).
-  const runningSessionIds: string[] = [];
-  const fallbackKeys: Array<{ name: string }> = [];
-  for (const key of keys) {
-    const meta = key.metadata as SessionListMetadata | null;
-    if (meta && meta.s) {
-      const expanded = expandSessionMetadata(meta);
-      if (expanded.status === 'running') {
-        runningSessionIds.push(key.name.split(':').pop()!);
-      }
-    } else {
-      fallbackKeys.push(key);
-    }
-  }
-  if (fallbackKeys.length > 0) {
-    const fallbackSessions = await Promise.all(
-      fallbackKeys.map((key) => c.env.KV.get<Session>(key.name, 'json'))
-    );
-    for (const session of fallbackSessions) {
-      if (session && session.status === 'running') {
-        runningSessionIds.push(session.id);
-      }
-    }
-  }
-
-  // Fan out with concurrency cap. Each chunk's failures are isolated.
-  const results: SyncSessionResult[] = [];
-  for (let i = 0; i < runningSessionIds.length; i += FANOUT_CONCURRENCY_CAP) {
-    const chunk = runningSessionIds.slice(i, i + FANOUT_CONCURRENCY_CAP);
-    const chunkResults = await Promise.all(
-      chunk.map(async (sessionId): Promise<SyncSessionResult> => {
-        try {
-          const containerId = getContainerId(bucketName, sessionId);
-          const container = getContainer(c.env.CONTAINER, containerId);
-          // Path is intentionally NOT in the DO's internalRoutes map
-          // (no leading underscore) so the DO's fetch() override
-          // forwards it through super.fetch() to the host server's
-          // /internal/bisync-trigger handler with container auth
-          // injected. See container/index.ts note in fetch() override.
-          const res = await container.fetch(
-            new Request('http://container/internal/bisync-trigger', { method: 'POST' })
-          );
-          if (res.status === 202) {
-            return { sessionId, status: 'triggered' };
-          }
-          if (res.status === 503) {
-            // Container not running (DO 503) or daemon not started
-            // (host 503). Either way, the session is not actively
-            // syncing so a manual trigger is a no-op.
-            return { sessionId, status: 'not-running' };
-          }
-          return { sessionId, status: 'failed', error: `unexpected status ${res.status}` };
-        } catch (err) {
-          return {
-            sessionId,
-            status: 'failed',
-            error: err instanceof Error ? err.message : String(err),
-          };
-        }
-      })
-    );
-    results.push(...chunkResults);
-  }
-
+  const results = await fanOutBisyncTrigger(c.env, bucketName);
   return c.json({ sessions: results, count: results.length });
 });
 

--- a/src/routes/storage/upload.ts
+++ b/src/routes/storage/upload.ts
@@ -14,6 +14,7 @@ import { escapeXml } from '../../lib/xml-utils';
 import { validateKey, MAX_KEY_LENGTH } from './validation';
 import { parseJsonBody, firstZodError } from '../../lib/request-helpers';
 import { getSseHeaders } from '../../lib/r2-sse';
+import { fanOutBisyncTrigger } from '../../lib/sync-fanout';
 
 const storageUploadRateLimiter = createRateLimiter({
   windowMs: 60_000,
@@ -91,6 +92,20 @@ app.post('/', async (c) => {
 
   // Invalidate storage-stats cache so next poll/fetch gets fresh data
   await c.env.KV.delete(`storage-stats:${bucketName}`);
+
+  // Fire-and-forget fan-out to running sessions (REQ-STOR-015 AC4).
+  // The user uploaded directly to R2; running containers pick up the
+  // file on their next bisync. Without this trigger, the wait could
+  // be up to 15 minutes (the cadence ceiling). We do not block the
+  // upload response on fan-out completion - the file is already in
+  // R2, the trigger is best-effort.
+  //
+  // sync-set filtering: we do NOT pre-filter by SYNC_MODE here. Each
+  // container's entrypoint.sh applies its own SYNC_MODE filters, and
+  // the trigger is cheap (~one extra bisync cycle on sessions where
+  // the file is filtered out). Pre-filtering would require reading
+  // per-session SYNC_MODE config, which is not worth the complexity.
+  c.executionCtx.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
 
   return c.json({ key: sanitizedKey, size: binaryContent.length });
 });
@@ -201,6 +216,10 @@ app.post('/complete', async (c) => {
 
   // Invalidate storage-stats cache so next poll/fetch gets fresh data
   await c.env.KV.delete(`storage-stats:${bucketName}`);
+
+  // Fire-and-forget fan-out to running sessions (REQ-STOR-015 AC4).
+  // See the matching block in the simple-upload route for rationale.
+  c.executionCtx.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
 
   return c.json({ key: sanitizedKey });
 });

--- a/src/routes/storage/upload.ts
+++ b/src/routes/storage/upload.ts
@@ -105,7 +105,7 @@ app.post('/', async (c) => {
   // the trigger is cheap (~one extra bisync cycle on sessions where
   // the file is filtered out). Pre-filtering would require reading
   // per-session SYNC_MODE config, which is not worth the complexity.
-  c.executionCtx.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
+  c.executionCtx?.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
 
   return c.json({ key: sanitizedKey, size: binaryContent.length });
 });
@@ -219,7 +219,7 @@ app.post('/complete', async (c) => {
 
   // Fire-and-forget fan-out to running sessions (REQ-STOR-015 AC4).
   // See the matching block in the simple-upload route for rationale.
-  c.executionCtx.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
+  c.executionCtx?.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
 
   return c.json({ key: sanitizedKey });
 });

--- a/src/routes/storage/upload.ts
+++ b/src/routes/storage/upload.ts
@@ -11,10 +11,30 @@ import { createR2Client, getR2Url, parseInitiateMultipartUploadXml } from '../..
 import { getR2Config } from '../../lib/r2-config';
 import { ValidationError, ContainerError } from '../../lib/error-types';
 import { escapeXml } from '../../lib/xml-utils';
+import type { Context } from 'hono';
 import { validateKey, MAX_KEY_LENGTH } from './validation';
 import { parseJsonBody, firstZodError } from '../../lib/request-helpers';
 import { getSseHeaders } from '../../lib/r2-sse';
 import { fanOutBisyncTrigger } from '../../lib/sync-fanout';
+
+/**
+ * Fire-and-forget the upload-side bisync fan-out trigger (REQ-STOR-015
+ * AC4). Wrapped in defensive try/catch + .catch so a synchronous throw
+ * from the trigger entry (e.g., env.KV / env.CONTAINER missing in test
+ * harnesses) or an asynchronous rejection cannot turn a successful R2
+ * PUT into a 500. The upload itself already succeeded; the trigger is
+ * best-effort and the 15-minute periodic cadence catches anything that
+ * the fire-and-forget missed.
+ */
+function fireBisyncTrigger(c: Context<{ Bindings: Env; Variables: AuthVariables }>, bucketName: string): void {
+  try {
+    const triggerPromise = fanOutBisyncTrigger(c.env, bucketName).catch(() => undefined);
+    c.executionCtx?.waitUntil(triggerPromise);
+  } catch {
+    // Synchronous throw from the trigger entry - swallow. The R2 PUT
+    // already succeeded; the periodic 15-min cadence will catch up.
+  }
+}
 
 const storageUploadRateLimiter = createRateLimiter({
   windowMs: 60_000,
@@ -105,7 +125,7 @@ app.post('/', async (c) => {
   // the trigger is cheap (~one extra bisync cycle on sessions where
   // the file is filtered out). Pre-filtering would require reading
   // per-session SYNC_MODE config, which is not worth the complexity.
-  c.executionCtx?.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
+  fireBisyncTrigger(c, bucketName);
 
   return c.json({ key: sanitizedKey, size: binaryContent.length });
 });
@@ -219,7 +239,7 @@ app.post('/complete', async (c) => {
 
   // Fire-and-forget fan-out to running sessions (REQ-STOR-015 AC4).
   // See the matching block in the simple-upload route for rationale.
-  c.executionCtx?.waitUntil(fanOutBisyncTrigger(c.env, bucketName));
+  fireBisyncTrigger(c, bucketName);
 
   return c.json({ key: sanitizedKey });
 });

--- a/web-ui/src/__tests__/components/StorageBrowser.test.tsx
+++ b/web-ui/src/__tests__/components/StorageBrowser.test.tsx
@@ -326,38 +326,19 @@ describe('StorageBrowser', () => {
     });
   });
 
-  describe('Search', () => {
-    it('shows search input when search toggle is clicked', () => {
+  // SEARCH UI DISABLED 2026-05-18 (REQ-STOR-015 D1): the storage-search-toggle
+  // button was removed to free the toolbar slot for the Sync-now button.
+  // storageStore.searchFiles() and the filter chain remain intact. If the
+  // toggle is restored, re-add toggle-click / input-focus / searchFiles
+  // tests here, matching the original three test bodies.
+  describe('Search (toolbar toggle removed)', () => {
+    it('search toggle button is not in the toolbar', () => {
       render(() => <StorageBrowser />);
-
-      const searchToggle = screen.getByTestId('storage-search-toggle');
-      fireEvent.click(searchToggle);
-
-      expect(screen.getByTestId('storage-search-input')).toBeInTheDocument();
+      expect(screen.queryByTestId('storage-search-toggle')).toBeNull();
     });
 
-    it('focuses search input automatically when opened', async () => {
-      render(() => <StorageBrowser />);
-
-      const searchToggle = screen.getByTestId('storage-search-toggle');
-      fireEvent.click(searchToggle);
-
-      const searchInput = screen.getByTestId('storage-search-input');
-      await waitFor(() => expect(searchInput).toHaveFocus());
-    });
-
-    it('calls searchFiles with query as user types', () => {
-      mockObjects = [
-        { key: 'workspace/readme.md', size: 100, lastModified: '2024-01-15T10:00:00Z' },
-      ];
-      render(() => <StorageBrowser />);
-
-      const searchToggle = screen.getByTestId('storage-search-toggle');
-      fireEvent.click(searchToggle);
-
-      const searchInput = screen.getByTestId('storage-search-input');
-      fireEvent.input(searchInput, { target: { value: 'readme' } });
-
+    it('searchFiles store helper remains callable even with toggle removed', () => {
+      mockSearchFiles('readme');
       expect(mockSearchFiles).toHaveBeenCalledWith('readme');
     });
   });

--- a/web-ui/src/api/storage.ts
+++ b/web-ui/src/api/storage.ts
@@ -12,6 +12,7 @@ import {
   StoragePreviewTextResponseSchema,
   StoragePreviewImageResponseSchema,
   StoragePreviewBinaryResponseSchema,
+  SessionsSyncResponseSchema,
 } from '../lib/schemas';
 import { ApiError, baseFetch } from './fetch-helper';
 
@@ -150,4 +151,13 @@ export function getDownloadUrl(key: string): string {
   const params = new URLSearchParams();
   params.set('key', key);
   return `${BASE_URL}/storage/download?${params.toString()}`;
+}
+
+// Sync-now fan-out (REQ-STOR-015 AC1). Calls POST /api/sessions/sync
+// which enumerates the user's running sessions and triggers a bisync
+// on each. Returns per-session result; the UI uses these to show
+// "Triggered N sessions" feedback and re-list R2 after a brief delay.
+export type SessionsSyncResponse = z.infer<typeof SessionsSyncResponseSchema>;
+export async function syncAllSessions(): Promise<SessionsSyncResponse> {
+  return storageFetch('/sessions/sync', { method: 'POST' }, SessionsSyncResponseSchema);
 }

--- a/web-ui/src/components/StorageBrowser.tsx
+++ b/web-ui/src/components/StorageBrowser.tsx
@@ -277,8 +277,16 @@ const StorageBrowser: Component = () => {
       <div class="storage-browser-header">
         <StorageBreadcrumbs currentPrefix={storageStore.currentPrefix} />
         <StorageToolbar
-          showSearch={showSearch}
-          setShowSearch={setShowSearch}
+          // SEARCH UI DISABLED 2026-05-18 (REQ-STOR-015 + sync-v2 PR):
+          // the search-toggle button was removed from StorageToolbar.
+          // showSearch / setShowSearch / searchQuery / setSearchQuery /
+          // handleSearchInput remain declared above, and the
+          // <Show when={showSearch()}> render block below stays in
+          // place. They are now latent (nothing flips showSearch to
+          // true), and storageStore.searchFiles() is still callable
+          // by anything that wants the filter chain. To restore: add
+          // a button in StorageToolbar that calls setShowSearch and
+          // re-add showSearch + setShowSearch to its props.
           showHiddenItems={showHiddenItems}
           setShowHiddenItems={setShowHiddenItems}
           selectionModeEnabled={selectionModeEnabled}

--- a/web-ui/src/components/StorageBrowser.tsx
+++ b/web-ui/src/components/StorageBrowser.tsx
@@ -14,7 +14,12 @@ import '../styles/storage-browser.css';
 
 const StorageBrowser: Component = () => {
   const [isDragOver, setIsDragOver] = createSignal(false);
-  const [showSearch, setShowSearch] = createSignal(false);
+  // SEARCH UI DISABLED 2026-05-18 (sync-v2): the setter is unused at
+  // runtime because the toolbar button that flipped it was removed.
+  // Underscore prefix matches the project's oxlint convention for
+  // intentionally-unused identifiers. To restore: rename back to
+  // `setShowSearch` and re-add the toggle button in StorageToolbar.
+  const [showSearch, _setShowSearch] = createSignal(false);
   const [searchQuery, setSearchQuery] = createSignal('');
   const [selectionModeEnabled, setSelectionModeEnabled] = createSignal(false);
   const [showHiddenItems, setShowHiddenItems] = createSignal(false);

--- a/web-ui/src/components/storage/StorageToolbar.tsx
+++ b/web-ui/src/components/storage/StorageToolbar.tsx
@@ -2,7 +2,14 @@ import { Component, Show, Accessor } from 'solid-js';
 import { storageStore } from '../../stores/storage';
 import Icon from '../Icon';
 import {
-  mdiMagnify,
+  // SEARCH UI DISABLED 2026-05-18 (REQ-STOR-015 + sync-v2 PR):
+  // the search-toggle button gave its toolbar slot to the Sync-now
+  // (mdiCloudSync) action. The store's searchFiles() helper and the
+  // <Show when={showSearch()}> render block in StorageBrowser.tsx are
+  // intentionally preserved so search can be re-enabled by re-adding
+  // the toggle button below and re-importing mdiMagnify.
+  // mdiMagnify,
+  mdiCloudSync,
   mdiEyeOff,
   mdiSelect,
   mdiFolderPlus,
@@ -13,8 +20,6 @@ import {
 } from '@mdi/js';
 
 interface StorageToolbarProps {
-  showSearch: Accessor<boolean>;
-  setShowSearch: (v: boolean) => void;
   showHiddenItems: Accessor<boolean>;
   setShowHiddenItems: (v: boolean) => void;
   selectionModeEnabled: Accessor<boolean>;
@@ -26,16 +31,45 @@ interface StorageToolbarProps {
 }
 
 const StorageToolbar: Component<StorageToolbarProps> = (props) => {
+  const syncTooltip = () => {
+    if (storageStore.syncing) {
+      const r = storageStore.syncResult;
+      return r && r.total > 0
+        ? `Syncing ${r.triggered + r.notRunning + r.failed} of ${r.total} sessions...`
+        : 'Syncing all running sessions...';
+    }
+    const r = storageStore.syncResult;
+    if (r) {
+      if (r.failed > 0) return `Sync errors: ${r.lastError ?? `${r.failed} failed`}`;
+      if (r.total === 0) return 'No running sessions to sync';
+      return `Synced ${r.triggered} session${r.triggered === 1 ? '' : 's'}`;
+    }
+    return 'Sync all running sessions to R2 and refresh listing';
+  };
+
   return (
     <div class="storage-actions">
+      {/* REQ-STOR-015 AC1+AC6: Sync-now button replaces the search
+          toggle in this slot. Click fans out a bisync trigger to all
+          the user's running sessions, then silently re-lists R2.
+          Disabled while a fan-out is in flight (storageStore.syncing). */}
       <button
         type="button"
         class="storage-icon-btn"
-        data-testid="storage-search-toggle"
-        title="Search"
-        onClick={() => props.setShowSearch(!props.showSearch())}
+        data-testid="storage-sync-now-btn"
+        title={syncTooltip()}
+        disabled={storageStore.syncing}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void storageStore.syncNow();
+        }}
       >
-        <Icon path={mdiMagnify} size={16} />
+        <Icon
+          path={mdiCloudSync}
+          size={16}
+          class={storageStore.syncing ? 'storage-sync-spinning' : ''}
+        />
       </button>
       <div class="storage-toolbar-separator" />
       <button

--- a/web-ui/src/lib/schemas.ts
+++ b/web-ui/src/lib/schemas.ts
@@ -315,3 +315,16 @@ export const OnboardingConfigResponseSchema = z.object({
   active: z.boolean(),
   turnstileSiteKey: z.string().nullable(),
 });
+
+// Sessions sync fan-out (REQ-STOR-015 AC1).
+// Mirrors SyncSessionResult from src/lib/sync-fanout.ts.
+export const SessionsSyncResponseSchema = z.object({
+  sessions: z.array(
+    z.object({
+      sessionId: z.string(),
+      status: z.union([z.literal('triggered'), z.literal('not-running'), z.literal('failed')]),
+      error: z.string().optional(),
+    })
+  ),
+  count: z.number(),
+});

--- a/web-ui/src/stores/storage.ts
+++ b/web-ui/src/stores/storage.ts
@@ -37,6 +37,14 @@ interface PreviewFile {
   lastModified: string;
 }
 
+interface SyncNowResult {
+  triggered: number;
+  notRunning: number;
+  failed: number;
+  total: number;
+  lastError?: string;
+}
+
 interface StorageState {
   currentPrefix: string;
   objects: StorageObject[];
@@ -52,6 +60,11 @@ interface StorageState {
   previewFile: PreviewFile | null;
   backgroundRefreshing: boolean;
   workerName: string;
+  // REQ-STOR-015: sync-now flag drives the toolbar button's disabled
+  // state and spinner overlay. The last result is held briefly so the
+  // toolbar can surface "Triggered N sessions" feedback.
+  syncing: boolean;
+  syncResult: SyncNowResult | null;
 }
 
 const initialState: StorageState = {
@@ -69,7 +82,14 @@ const initialState: StorageState = {
   previewFile: null,
   backgroundRefreshing: false,
   workerName: 'codeflare',
+  syncing: false,
+  syncResult: null,
 };
+
+// REQ-STOR-015 AC6: how long to keep the syncResult visible after the
+// fan-out request returns. Long enough for the user to read the toast,
+// short enough that stale state does not linger.
+const SYNC_RESULT_DISPLAY_MS = 4000;
 
 const [state, setState] = createStore<StorageState>({ ...initialState });
 
@@ -89,6 +109,8 @@ export const storageStore = {
   get backgroundRefreshing() { return state.backgroundRefreshing; },
   get workerName() { return state.workerName; },
   setWorkerName(name: string) { setState('workerName', name); },
+  get syncing() { return state.syncing; },
+  get syncResult() { return state.syncResult; },
   get breadcrumbs() {
     const parts = state.currentPrefix.split('/').filter(Boolean);
     return parts.map((_, i) => parts.slice(0, i + 1).join('/') + '/');
@@ -336,6 +358,54 @@ export const storageStore = {
 
   async refresh(options?: { silent?: boolean }) {
     await storageStore.browse(undefined, options);
+  },
+
+  /**
+   * REQ-STOR-015: fan-out a bisync trigger to all the user's running
+   * sessions, then re-list R2 once the trigger completes.
+   *
+   * The fan-out call itself is fast (it triggers SIGUSR1 per session
+   * and returns). The actual bisync runs in each container's daemon
+   * AFTER the trigger returns, so we re-list R2 after a short delay
+   * to give the bisyncs a chance to propagate fresh content before
+   * the user sees the new listing.
+   *
+   * Hibernation-resilient: the response shape includes `not-running`
+   * for sleeping containers. The aggregate counters distinguish
+   * triggered / not-running / failed so the user gets honest feedback.
+   */
+  async syncNow() {
+    if (state.syncing) return;  // idempotent click guard
+    setState('syncing', true);
+    setState('syncResult', null);
+    try {
+      const result = await storageApi.syncAllSessions();
+      const aggregate: SyncNowResult = {
+        triggered: result.sessions.filter((s) => s.status === 'triggered').length,
+        notRunning: result.sessions.filter((s) => s.status === 'not-running').length,
+        failed: result.sessions.filter((s) => s.status === 'failed').length,
+        total: result.count,
+        lastError: result.sessions.find((s) => s.status === 'failed')?.error,
+      };
+      setState('syncResult', aggregate);
+      // Re-list R2 so the user sees the freshest state. Silent to avoid
+      // a loading spinner on top of the sync spinner.
+      await storageStore.refresh({ silent: true });
+    } catch (err) {
+      setState('syncResult', {
+        triggered: 0,
+        notRunning: 0,
+        failed: 0,
+        total: 0,
+        lastError: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setState('syncing', false);
+      // Auto-clear the result message after a brief display window.
+      setTimeout(() => {
+        setState((s) => (s.syncing ? s : { ...s, syncResult: null }));
+      }, SYNC_RESULT_DISPLAY_MS);
+    }
   },
 };
 


### PR DESCRIPTION
## Summary

R2 bisync cost + reliability overhaul. Three coupled changes shipped on one branch:

1. **Shutdown budget raised** from 60s/75s to **120s/135s** (entrypoint watchdog 108+12s SIGTERM/SIGKILL; Container DO `destroy()` timeout 135_000ms). A `logger.warn` fires at 110s elapsed so sessions approaching the ceiling surface in logs. See AD57.
2. **Manual sync triggers** added: SIGUSR1-interruptible bisync daemon with coalescing flags (`BISYNC_REQUESTED`/`BISYNC_RERUN_REQUESTED`/`BISYNC_IN_FLIGHT`); host `POST /internal/bisync-trigger` endpoint sends SIGUSR1; new Worker fan-out at `POST /api/sessions/sync` with concurrency cap 8 + per-session failure isolation + 6/min rate limit; upload-side fire-and-forget trigger via `executionCtx.waitUntil` after R2 PUT; storage-panel Sync-now button (mdi/cloud-sync, replaces the search-toggle slot; search code/store preserved with restoration comments).
3. **Cadence flip** from 60s -> 15 minutes (`sleep 60` -> `sleep 900`). One-line revertable; estimated ~14x reduction in idle R2 ops. See AD56.

REQ backlinks:
- **REQ-STOR-003** rewritten: "Bidirectional Sync Every 15 Minutes (with Manual Triggers)". Cadence + interruptibility ACs added.
- **REQ-STOR-005** updated: AC4+AC5 codify 120s watchdog + 135s DO budget.
- **REQ-STOR-015** (new): explicit sync trigger from UI; fan-out + per-session isolation + rate-limit + button-disabled-while-syncing.

ADRs:
- **AD56**: 15-minute bisync cadence with manual triggers. Includes "why fan-out is safe under newer-mtime-wins" math (commutative/associative on absolute mtime; same concurrent mode the 60s daemon already runs today; R2 atomic per-object writes; serial would not improve outcomes).
- **AD57**: 135-second shutdown budget for final bisync.

## Hibernation safety

DO instance fields reset on hibernation. The new sync mechanism is stateless on the DO side: no `this.*` cache for bisync state or daemon PID, no DO storage for pending triggers. All decisions made at call time against `ctx.container?.running` and `/tmp/sync-daemon.pid`. A SIGUSR1 sent while the container is sleeping is lost; the next container wake's forced baseline bisync (REQ-STOR-004 AC4) absorbs the lost trigger. Documented in the daemon header comment and AD56.

## Test plan

- [ ] CI green on `sync-v2 -> develop` (PR Checks, CodeQL).
- [ ] After merging to develop and opening the develop -> main PR, all SDD reviewers (code-reviewer, spec-reviewer, doc-updater) pass with no LOW+ findings.
- [ ] Smoke (post-deploy): with 2+ running sessions, click Sync-now in the storage panel. Verify button disables, tooltip shows "Syncing N sessions...", aggregate state shows "Synced N sessions" / "No running sessions to sync" / per-session errors. R2 listing refreshes.
- [ ] Smoke: upload a file to the panel. Verify the file appears in the running session's container within ~30s (background fan-out trigger after the R2 PUT).
- [ ] Smoke: delete a session from the UI. Verify the delete spinner runs for up to ~130s on sessions with pending writes, and that the final R2 state reflects pre-delete edits.
- [ ] Smoke: leave a session idle for 16 minutes. Verify exactly one bisync cycle in `/tmp/sync.log` (the 15-minute timer) plus initial baseline.
- [ ] Cost telemetry (after 1 week): R2 Class A op count vs pre-merge baseline. Expect ~14x reduction on idle-heavy users.
- [ ] Monitor `shutdownElapsedMs` warn-threshold (110s) hits in logs. If routine, bump destroy budget to 150s/165s in a follow-up.