### PR TITLE
test(req-backfill): coverage for STOR-003 / STOR-005 / STOR-015 / MEM-001 / MEM-004 / MEM-006

### DIFF
--- a/host/__tests__/entrypoint-bisync-cadence.test.js
+++ b/host/__tests__/entrypoint-bisync-cadence.test.js
@@ -1,0 +1,126 @@
+// REQ-STOR-003 backfill: bidirectional sync every 15 minutes + manual triggers.
+//
+// Static structural test. Reads entrypoint.sh and pattern-matches on the
+// daemon body. Behavioural verification of SIGUSR1 wake lives in
+// entrypoint-sigusr1.test.js; this file covers the cadence + recovery +
+// fallback semantics that nothing else asserts on.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const entrypoint = readFileSync(resolve(__dirname, '../../entrypoint.sh'), 'utf8');
+
+describe('entrypoint.sh bisync daemon cadence (REQ-STOR-003)', () => {
+  it('AC1: periodic bisync uses a 15-minute sleep', () => {
+    // 900 seconds = 15 minutes. The daemon body must contain the cadence
+    // sleep wrapped in the bash backgrounded-sleep + wait pattern so the
+    // trap can interrupt it (see AC2).
+    assert.ok(
+      /sleep 900 &/.test(entrypoint),
+      'entrypoint.sh must call `sleep 900 &` (15-min cadence backgrounded so the SIGUSR1 trap can wake it)'
+    );
+  });
+
+  it('AC2: periodic sleep is signal-interruptible via wait builtin', () => {
+    // bash trap semantics: a foreground `sleep` blocks until it returns,
+    // so the trap queues until then. The `wait` builtin IS interruptible
+    // and is the correct pattern. We must see all three pieces inside
+    // the cadence block: backgrounded sleep, wait on PID, kill leftover.
+    assert.ok(
+      /SYNC_SLEEP_PID=\$!/.test(entrypoint),
+      'entrypoint.sh must capture the backgrounded sleep PID into SYNC_SLEEP_PID'
+    );
+    assert.ok(
+      /wait "\$SYNC_SLEEP_PID" 2>\/dev\/null \|\| true/.test(entrypoint),
+      'entrypoint.sh must use `wait $SYNC_SLEEP_PID` (the builtin -- foreground sleeps do not return on trap)'
+    );
+    assert.ok(
+      /kill "\$SYNC_SLEEP_PID" 2>\/dev\/null \|\| true/.test(entrypoint),
+      'entrypoint.sh must kill the still-running sleep after wait returns (otherwise one sleep child leaks per trigger)'
+    );
+  });
+
+  it('AC3: bisync uses --conflict-resolve newer', () => {
+    // The newest-file-wins flag must be present on the periodic bisync
+    // command line, not just the initial --resync baseline. Look for at
+    // least two occurrences (--resync baseline + periodic bisync).
+    const matches = entrypoint.match(/--conflict-resolve newer/g) || [];
+    assert.ok(
+      matches.length >= 2,
+      `entrypoint.sh must pass --conflict-resolve newer to BOTH the --resync baseline and the periodic bisync (found ${matches.length})`
+    );
+  });
+
+  it('AC3 constraints: required rclone flags are all present', () => {
+    // The constraint block on REQ-STOR-003 mandates these flags. Each
+    // must appear on the periodic bisync command line.
+    const required = [
+      '--ignore-checksum',
+      '--max-delete 100',
+      '--check-sync=false',
+      '--min-size 1B',
+    ];
+    for (const flag of required) {
+      // At least 2 occurrences -- baseline + periodic bisync.
+      const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(escaped, 'g');
+      const count = (entrypoint.match(re) || []).length;
+      assert.ok(
+        count >= 2,
+        `entrypoint.sh must pass ${flag} (found ${count} occurrences, expected >= 2 across baseline + periodic)`
+      );
+    }
+  });
+
+  it('AC5: vanishing-file recovery is invoked on bisync failure', () => {
+    // On failure we must (a) parse error output via recover_vanished_files,
+    // (b) clear the rclone lock files (.lck) before retry, (c) attempt one
+    // immediate retry, (d) only count the failure if recovery doesn't help.
+    assert.ok(
+      /recover_vanished_files "\$\(cat \/tmp\/last-bisync-output\.txt 2>\/dev\/null\)"/.test(entrypoint),
+      'entrypoint.sh must call recover_vanished_files with the captured last-bisync-output before counting a failure'
+    );
+    assert.ok(
+      /rm -f "\$HOME\/.cache\/rclone\/bisync"\/\*\.lck/.test(entrypoint),
+      'entrypoint.sh must clear rclone .lck lock files before the recovery retry'
+    );
+  });
+
+  it('AC4 + AC6: failure counter tracks consecutive failures and resync fallback at 3', () => {
+    // AC4: transient retry continues the cycle. AC6: after 3 consecutive
+    // unrecoverable failures the daemon falls back to --resync.
+    assert.ok(
+      /CONSECUTIVE_FAILURES=0/.test(entrypoint),
+      'entrypoint.sh must initialise CONSECUTIVE_FAILURES=0'
+    );
+    assert.ok(
+      /CONSECUTIVE_FAILURES=\$\(\(CONSECUTIVE_FAILURES \+ 1\)\)/.test(entrypoint),
+      'entrypoint.sh must increment CONSECUTIVE_FAILURES on each unrecoverable failure'
+    );
+    assert.ok(
+      /if \[ \$CONSECUTIVE_FAILURES -ge 3 \]; then/.test(entrypoint),
+      'entrypoint.sh must guard the --resync fallback on CONSECUTIVE_FAILURES >= 3'
+    );
+    assert.ok(
+      /establish_bisync_baseline/.test(entrypoint),
+      'entrypoint.sh must call establish_bisync_baseline (the --resync path) as the fallback recovery'
+    );
+  });
+
+  it('AC6 fast-path: missing listing files trigger immediate --resync without waiting for 3 failures', () => {
+    // Exit code 7 + no listing files = no prior bisync state. The daemon
+    // must short-circuit to the --resync fallback by setting the failure
+    // counter to 3 directly.
+    assert.ok(
+      /if \[ "\$HAS_LISTINGS" = "false" \] && \[ \$SYNC_RESULT -eq 7 \]; then/.test(entrypoint),
+      'entrypoint.sh must short-circuit to --resync when exit code 7 + no listing files (no prior bisync state)'
+    );
+    assert.ok(
+      /CONSECUTIVE_FAILURES=3\s*#\s*force resync path below/i.test(entrypoint),
+      'entrypoint.sh must set CONSECUTIVE_FAILURES=3 in the no-listings fast-path to force the resync fallback'
+    );
+  });
+});

--- a/host/__tests__/entrypoint-shutdown-budget.test.js
+++ b/host/__tests__/entrypoint-shutdown-budget.test.js
@@ -1,0 +1,80 @@
+// REQ-STOR-005 backfill: graceful shutdown performs final sync.
+//
+// AC1 (SIGINT/SIGTERM handler -> final bisync) and AC4 (120s watchdog,
+// 135s DO budget) are already covered in entrypoint-bisync-trigger.test.js.
+// This file covers the AC2 (bisync-initialized flag gate) and AC3 (final
+// bisync runs synchronously before exit) gaps. AC5 (DO destroy budget) is
+// asserted in src/__tests__/container/index.test.ts where the destroy
+// timeout constant lives.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const entrypoint = readFileSync(resolve(__dirname, '../../entrypoint.sh'), 'utf8');
+
+describe('entrypoint.sh shutdown handler (REQ-STOR-005 backfill)', () => {
+  it('AC2: final bisync is gated on the /tmp/.bisync-initialized flag', () => {
+    // Without this gate, a container that died before establishing the
+    // bisync baseline would still attempt a final bisync — which fails
+    // with no listing files and wastes the entire 120s budget on a
+    // doomed --resync.
+    assert.ok(
+      /if \[ -f \/tmp\/\.bisync-initialized \]; then/.test(entrypoint),
+      'shutdown_handler must gate the final bisync on -f /tmp/.bisync-initialized so it does not run before the baseline exists'
+    );
+  });
+
+  it('AC2: the bisync-initialized flag is touched on baseline establishment', () => {
+    // Counterpart of the gate above: if nothing ever touches the flag,
+    // the gate would always be false and the final bisync would never
+    // run, defeating the entire purpose of the shutdown handler.
+    const touches = entrypoint.match(/touch \/tmp\/\.bisync-initialized/g) || [];
+    assert.ok(
+      touches.length >= 2,
+      `entrypoint.sh must touch /tmp/.bisync-initialized after successful baseline (found ${touches.length} occurrences, expected >= 2 for both the success and timeout-but-baseline-ran paths)`
+    );
+  });
+
+  it('AC3: shutdown_handler is registered via trap on SIGTERM, SIGINT, and EXIT', () => {
+    // Without the trap registration the handler would never run and R2
+    // would be missing the last 0-15 minutes of edits on every shutdown.
+    // EXIT catches the normal-exit path too (e.g., main process returns).
+    assert.ok(
+      /trap shutdown_handler SIGTERM SIGINT EXIT/.test(entrypoint),
+      'entrypoint.sh must trap SIGTERM + SIGINT + EXIT into shutdown_handler so all exit paths drain to R2'
+    );
+  });
+
+  it('AC3: shutdown_handler waits on the bisync subshell PID synchronously', () => {
+    // The bisync runs in a background subshell so the watchdog can kill
+    // it on timeout, but the handler must block on its exit. Otherwise
+    // the script falls through to the cleanup/exit lines while the
+    // bisync child is still uploading — which is the bug AD57 fixed.
+    assert.ok(
+      /BISYNC_PID=\$!/.test(entrypoint),
+      'shutdown_handler must capture the bisync subshell PID for the watchdog + wait pair'
+    );
+    // The wait must be on BISYNC_PID specifically (not just any pid).
+    assert.ok(
+      /wait "?\$BISYNC_PID"?/.test(entrypoint) || /wait \$BISYNC_PID/.test(entrypoint),
+      'shutdown_handler must `wait` on $BISYNC_PID before exit so the final sync actually completes synchronously'
+    );
+  });
+
+  it('AC3: the watchdog kills the rclone subtree, not just the wrapping subshell', () => {
+    // History note in the entrypoint comment block makes this explicit:
+    // killing only the wrapping bash subshell leaves rclone running and
+    // half-uploaded files land in R2 anyway. The fix is kill_subtree.
+    assert.ok(
+      /kill_subtree\(\)/.test(entrypoint),
+      'shutdown_handler must define kill_subtree to walk descendant PIDs (otherwise rclone outlives its parent and lands partial uploads)'
+    );
+    assert.ok(
+      /pgrep -P "\$root"/.test(entrypoint),
+      'kill_subtree must use pgrep -P to walk the descendant tree (parent-to-child traversal)'
+    );
+  });
+});

--- a/host/__tests__/memory-capture-pipeline.test.js
+++ b/host/__tests__/memory-capture-pipeline.test.js
@@ -1,0 +1,207 @@
+// REQ-MEM-001 backfill: covers the AC3 / AC4 / AC5 gaps left by
+// memory-capture-hook.test.js (which covers the hook entry path:
+// transcript counting, counter file semantics, additionalContext
+// emission). This file exercises the post-hook pipeline:
+//
+//   AC3 - prefilter-transcript.sh strips tool I/O and chunks the
+//         remainder into ~20-entry files.
+//   AC4 - the memory-agent prompt declares the YAML frontmatter
+//         template (session_id, captured_at, captured_from_range).
+//   AC5 - the prompt runs graphify extract + global add under
+//         flock /tmp/graphify-global.lock.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PREFILTER = resolve(
+  __dirname,
+  '../../preseed/agents/claude/plugins/codeflare-memory/scripts/prefilter-transcript.sh',
+);
+const PROMPT = resolve(
+  __dirname,
+  '../../preseed/agents/claude/plugins/codeflare-memory/scripts/memory-agent-prompt.md',
+);
+
+function realUserLine(content) {
+  return JSON.stringify({ type: 'user', message: { role: 'user', content } });
+}
+function assistantTextLine(text) {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'text', text }] },
+  });
+}
+function toolResultLine() {
+  return JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'tool_result', content: 'x' }] },
+  });
+}
+function toolUseLine() {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'tool_use', name: 'Read', input: { file_path: '/x' } }],
+    },
+  });
+}
+function syntheticUserLine(prefix) {
+  return JSON.stringify({ type: 'user', message: { role: 'user', content: prefix + ' continued' } });
+}
+function metaLine() {
+  // isMeta records are agent-internal control records - prefilter must skip
+  return JSON.stringify({ type: 'user', isMeta: true, message: { role: 'user', content: 'meta' } });
+}
+
+describe('prefilter-transcript.sh (REQ-MEM-001 AC3)', () => {
+  it('AC3: strips tool_use, tool_result, and synthetic markers; keeps real prompts + assistant text', () => {
+    const out = mkdtempSync(join(tmpdir(), 'prefilter-strip-'));
+    const transcript = join(out, 'transcript.jsonl');
+    writeFileSync(
+      transcript,
+      [
+        realUserLine('first real prompt'),
+        toolResultLine(),
+        toolUseLine(),
+        assistantTextLine('assistant reply one'),
+        syntheticUserLine('<command-name>'),
+        syntheticUserLine('Stop hook executed'),
+        syntheticUserLine('This session is being continued'),
+        syntheticUserLine('[Request interrupted by user]'),
+        metaLine(),
+        realUserLine('second real prompt'),
+        assistantTextLine('assistant reply two'),
+      ].join('\n') + '\n',
+    );
+
+    const result = spawnSync('bash', [PREFILTER, transcript, '1', '999', out, '20'], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `prefilter exit code: ${result.status}, stderr: ${result.stderr}`);
+
+    const clean = readFileSync(join(out, 'clean.ndjson'), 'utf8').trim().split('\n').filter(Boolean);
+    // Expect 4 surviving entries: 2 user prompts + 2 assistant replies.
+    assert.equal(clean.length, 4, `prefilter kept ${clean.length} entries, expected 4`);
+
+    const parsed = clean.map((line) => JSON.parse(line));
+    const userTexts = parsed.filter((p) => p.role === 'user').map((p) => p.text);
+    const assistantTexts = parsed.filter((p) => p.role === 'assistant').map((p) => p.text);
+
+    assert.deepEqual(userTexts.sort(), ['first real prompt', 'second real prompt']);
+    assert.deepEqual(assistantTexts.sort(), ['assistant reply one', 'assistant reply two']);
+  });
+
+  it('AC3: produces multiple chunks when input exceeds chunk size', () => {
+    const out = mkdtempSync(join(tmpdir(), 'prefilter-chunk-'));
+    const transcript = join(out, 'transcript.jsonl');
+    // 50 real entries -> at chunk size 20 -> 3 chunks (aa: 20, ab: 20, ac: 10)
+    const lines = [];
+    for (let i = 0; i < 25; i++) {
+      lines.push(realUserLine(`prompt ${i}`));
+      lines.push(assistantTextLine(`reply ${i}`));
+    }
+    writeFileSync(transcript, lines.join('\n') + '\n');
+
+    const result = spawnSync('bash', [PREFILTER, transcript, '1', '999', out, '20'], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `prefilter exit code: ${result.status}, stderr: ${result.stderr}`);
+
+    const chunkMd = readdirSync(out).filter((f) => f.startsWith('chunk-') && f.endsWith('.md'));
+    assert.ok(
+      chunkMd.length >= 2,
+      `expected >=2 .md chunks for 50 entries at chunk_size 20, got ${chunkMd.length}: ${chunkMd.join(',')}`,
+    );
+    // Default 20-per-chunk should produce 3 markdown files.
+    assert.equal(chunkMd.length, 3, `expected exactly 3 chunks (20+20+10), got ${chunkMd.length}`);
+  });
+
+  it('AC3: significantly reduces byte count vs raw transcript', () => {
+    // The whole point of the prefilter (per AD58) is that the raw
+    // transcript is ~99% tool noise. Verify the strip ratio empirically:
+    // a transcript dominated by tool I/O must shrink dramatically.
+    const out = mkdtempSync(join(tmpdir(), 'prefilter-bytes-'));
+    const transcript = join(out, 'transcript.jsonl');
+    const lines = [];
+    // 2 real entries vs 200 tool I/O entries = ~99% noise
+    lines.push(realUserLine('keep me 1'));
+    lines.push(assistantTextLine('keep this 1'));
+    for (let i = 0; i < 200; i++) {
+      lines.push(toolResultLine());
+      lines.push(toolUseLine());
+    }
+    writeFileSync(transcript, lines.join('\n') + '\n');
+
+    const result = spawnSync('bash', [PREFILTER, transcript, '1', '99999', out, '20'], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `prefilter exit code: ${result.status}, stderr: ${result.stderr}`);
+
+    const rawBytes = statSync(transcript).size;
+    const cleanBytes = statSync(join(out, 'clean.ndjson')).size;
+    const ratio = rawBytes / cleanBytes;
+    // Demand at least 10x reduction (in practice AD58 measured ~76x).
+    assert.ok(
+      ratio >= 10,
+      `prefilter reduction ratio ${ratio.toFixed(1)}x is below the 10x floor (raw=${rawBytes} clean=${cleanBytes})`,
+    );
+  });
+});
+
+describe('memory-agent-prompt.md frontmatter + flock (REQ-MEM-001 AC4 + AC5)', () => {
+  const prompt = readFileSync(PROMPT, 'utf8');
+
+  it('AC4: declares the YAML frontmatter template with session_id, captured_at, captured_from_range', () => {
+    // The template is a fenced code block in the prompt. The fields
+    // must be present together so the produced capture files are
+    // queryable by graphify and round-trippable.
+    assert.ok(/session_id:\s*\{SESSION_ID\}/.test(prompt),
+      'memory-agent-prompt.md must declare session_id: {SESSION_ID} in the frontmatter template');
+    assert.ok(/captured_at:\s*\{ISO_TS\}/.test(prompt),
+      'memory-agent-prompt.md must declare captured_at: {ISO_TS} in the frontmatter template');
+    assert.ok(/captured_from_range:\s*\[\{LAST_LINE\},\s*\{TOTAL_LINES\}\]/.test(prompt),
+      'memory-agent-prompt.md must declare captured_from_range: [{LAST_LINE}, {TOTAL_LINES}] in the frontmatter template');
+  });
+
+  it('AC4: frontmatter is delimited by triple-dash lines', () => {
+    // YAML frontmatter requires `---` open/close fences. Missing them
+    // and the SilverBullet front-matter parser will silently treat the
+    // block as body text.
+    const openFenceCount = (prompt.match(/^---$/gm) || []).length;
+    assert.ok(
+      openFenceCount >= 2,
+      `memory-agent-prompt.md must include the YAML frontmatter --- open + close fences (found ${openFenceCount})`,
+    );
+  });
+
+  it('AC5: graphify extract and global add run under flock /tmp/graphify-global.lock', () => {
+    // The capture pipeline shares the global graph lock with the
+    // vault-monitor pipeline and the active-repo hook. Without flock,
+    // concurrent writers would corrupt the JSON-on-disk merge.
+    assert.ok(
+      /flock\s+\/tmp\/graphify-global\.lock\s+.*graphify\s+global\s+add/.test(prompt) ||
+        /flock\s+\/tmp\/graphify-global\.lock[\s\S]*?graphify\s+global\s+add/.test(prompt),
+      'memory-agent-prompt.md must call `graphify global add` under flock /tmp/graphify-global.lock',
+    );
+    // The build step (extract -> graph.json) should be lock-protected
+    // too because it writes to the shared vault graphify-out tree.
+    assert.ok(
+      /flock\s+\/tmp\/graphify-global\.lock/.test(prompt),
+      'memory-agent-prompt.md must serialize graphify writes behind flock /tmp/graphify-global.lock',
+    );
+  });
+
+  it('AC5: tags the merged repo as user_vault so subsequent queries can filter by tag', () => {
+    assert.ok(
+      /graphify\s+global\s+add\s+\S+\s+--as\s+user_vault/.test(prompt),
+      'memory-agent-prompt.md must pass --as user_vault to `graphify global add` for repo-tag filtering',
+    );
+  });
+});

--- a/host/__tests__/pro-mode-gating-static.test.js
+++ b/host/__tests__/pro-mode-gating-static.test.js
@@ -1,0 +1,86 @@
+// REQ-MEM-006 backfill (static source-level checks).
+//
+// Manifest assertions for AC3 live in src/__tests__/lib/pro-mode-gating.test.ts
+// (vitest, uses the generated AGENTS_SEEDED_CONFIGS). This file covers
+// AC5 (entrypoint.sh hook-merge mode gating) and AC8 (reconcileAgentConfigs
+// guarded against bulk deletion of user files) because those require
+// readFileSync on source files which the Workers vitest pool does not
+// allow.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../');
+
+describe('REQ-MEM-006 AC5: entrypoint.sh merges hook registrations only in advanced mode', () => {
+  const entrypoint = readFileSync(resolve(repoRoot, 'entrypoint.sh'), 'utf8');
+
+  it('default-mode SETTINGS_CONFIG contains only skipDangerousModePermissionPrompt', () => {
+    // The default-mode branch in entrypoint.sh writes a minimal config.
+    // Any drift (e.g. accidentally including a hooks block) would
+    // silently turn on capture/memory hooks for Standard users.
+    assert.ok(
+      entrypoint.includes(`SETTINGS_CONFIG='{"skipDangerousModePermissionPrompt":true}'`),
+      'default-mode SETTINGS_CONFIG block must be exactly {"skipDangerousModePermissionPrompt":true}'
+    );
+  });
+
+  it('advanced-mode SETTINGS_CONFIG includes UserPromptSubmit hook for memory-capture.sh', () => {
+    // The advanced-mode branch builds a larger hooks block.
+    // memory-capture.sh and vault-monitor-hook.sh must both register
+    // on UserPromptSubmit.
+    assert.ok(/codeflare-memory\/scripts\/memory-capture\.sh/.test(entrypoint),
+      'entrypoint.sh advanced-mode SETTINGS_CONFIG must reference codeflare-memory/scripts/memory-capture.sh');
+    assert.ok(/codeflare-vault\/scripts\/vault-monitor-hook\.sh/.test(entrypoint),
+      'entrypoint.sh advanced-mode SETTINGS_CONFIG must reference codeflare-vault/scripts/vault-monitor-hook.sh');
+  });
+
+  it('advanced-mode and default-mode are separate, ordered log sentinels', () => {
+    // The two SETTINGS_CONFIG assignments must live in separate
+    // mode-gated branches identified by their log lines.
+    const advIdx = entrypoint.indexOf('Advanced mode: configuring settings.json with hooks');
+    const defIdx = entrypoint.indexOf('Default mode: configuring settings.json without hooks');
+    assert.ok(advIdx > 0, 'entrypoint.sh must log "Advanced mode: configuring settings.json with hooks"');
+    assert.ok(defIdx > 0, 'entrypoint.sh must log "Default mode: configuring settings.json without hooks"');
+    assert.ok(defIdx > advIdx,
+      'default-mode log must follow advanced-mode log (else-branch ordering)');
+  });
+});
+
+describe('REQ-MEM-006 AC8: reconcileAgentConfigs preserves user-created files', () => {
+  const r2seed = readFileSync(resolve(repoRoot, 'src/lib/r2-seed.ts'), 'utf8');
+
+  it('reconcileAgentConfigs is exported from r2-seed.ts', () => {
+    assert.ok(
+      /export\s+(async\s+)?function\s+reconcileAgentConfigs/.test(r2seed),
+      'src/lib/r2-seed.ts must export a reconcileAgentConfigs function'
+    );
+  });
+
+  it('reconcile is manifest-driven (uses AGENTS_SEEDED_CONFIGS / managed key set)', () => {
+    // The function must NOT call deleteObjects with arbitrary key
+    // patterns; deletes are filtered through the manifest. The exact
+    // identifier may evolve - accept several known shapes.
+    assert.ok(
+      /AGENTS_SEEDED_CONFIGS|AGENT_SEEDED_KEYS|agentSeedKeys|seededKeys/.test(r2seed),
+      'r2-seed.ts reconcile must filter through a manifest-driven key set so user files are never collateral'
+    );
+  });
+
+  it('reconcile does NOT issue a bulk wildcard delete of .claude/**', () => {
+    // A wildcard delete of '.claude/**' would obliterate user files.
+    // The function must iterate explicit keys from the manifest.
+    assert.ok(
+      !/deleteAll\s*\(/.test(r2seed),
+      'r2-seed.ts must not call deleteAll() (would risk wiping user-created files)'
+    );
+    assert.ok(
+      !/deleteObjects\s*\(\s*['"]\.claude\/\*\*['"]/.test(r2seed),
+      "r2-seed.ts must not deleteObjects('.claude/**') (would risk wiping user-created files)"
+    );
+  });
+});

--- a/host/__tests__/sync-fanout-static.test.js
+++ b/host/__tests__/sync-fanout-static.test.js
@@ -1,0 +1,80 @@
+// REQ-STOR-015 backfill (static source-level checks).
+//
+// Runtime/mock tests for fanOutBisyncTrigger live in
+// src/__tests__/lib/sync-fanout.test.ts (vitest Workers pool, with
+// mocked KV + CONTAINER). The Workers pool does NOT support
+// readFileSync of source files; the static structural assertions for
+// AC4 (upload-side wiring) and AC7 (rate-limiter shape) live here in
+// the Node test runner.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../');
+
+describe('REQ-STOR-015 AC4 (static): upload-side fire-and-forget trigger wiring', () => {
+  const upload = readFileSync(resolve(repoRoot, 'src/routes/storage/upload.ts'), 'utf8');
+
+  it('upload.ts imports fanOutBisyncTrigger from sync-fanout', () => {
+    assert.ok(
+      upload.includes("from '../../lib/sync-fanout'"),
+      "upload.ts must import fanOutBisyncTrigger from '../../lib/sync-fanout'"
+    );
+    assert.ok(
+      /fanOutBisyncTrigger/.test(upload),
+      'upload.ts must reference fanOutBisyncTrigger somewhere'
+    );
+  });
+
+  it('fan-out fires through executionCtx.waitUntil so the response is not blocked', () => {
+    assert.ok(
+      /c\.executionCtx\?\.waitUntil\(/.test(upload),
+      'upload.ts must wire the trigger through c.executionCtx?.waitUntil(...) so successful PUTs return immediately'
+    );
+  });
+
+  it('trigger rejection is swallowed via .catch(() => undefined)', () => {
+    // Defensive: a trigger failure must not poison a successful R2 PUT
+    // (a failed trigger is acceptable; the 15-min cadence will catch up).
+    assert.ok(
+      /\.catch\(\(\) => undefined\)/.test(upload),
+      'upload.ts must wrap fanOutBisyncTrigger with .catch(() => undefined) to swallow trigger failures'
+    );
+  });
+});
+
+describe('REQ-STOR-015 AC7 (static): sessions-sync rate limiter shape', () => {
+  const lifecycle = readFileSync(resolve(repoRoot, 'src/routes/session/lifecycle.ts'), 'utf8');
+
+  it('declares sessionsSyncRateLimiter with windowMs=60_000', () => {
+    assert.ok(
+      /sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?windowMs:\s*60_?000[\s\S]*?\}\s*\)/.test(lifecycle),
+      'sessionsSyncRateLimiter must set windowMs to 60_000 (or 60000)'
+    );
+  });
+
+  it('declares sessionsSyncRateLimiter with maxRequests=6', () => {
+    assert.ok(
+      /sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?maxRequests:\s*6[\s\S]*?\}\s*\)/.test(lifecycle),
+      'sessionsSyncRateLimiter must set maxRequests to 6 (matches destructive-action rate-limit pattern)'
+    );
+  });
+
+  it('declares sessionsSyncRateLimiter with keyPrefix=sessions-sync', () => {
+    assert.ok(
+      /sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?keyPrefix:\s*['"]sessions-sync['"][\s\S]*?\}\s*\)/.test(lifecycle),
+      "sessionsSyncRateLimiter must set keyPrefix to 'sessions-sync'"
+    );
+  });
+
+  it('attaches sessionsSyncRateLimiter to POST /sync', () => {
+    assert.ok(
+      /app\.post\(\s*['"]\/sync['"]\s*,\s*sessionsSyncRateLimiter/.test(lifecycle),
+      'POST /sync must be guarded by sessionsSyncRateLimiter (otherwise the rate limit is dead code)'
+    );
+  });
+});

--- a/host/__tests__/vault-r2-sync.test.js
+++ b/host/__tests__/vault-r2-sync.test.js
@@ -1,0 +1,159 @@
+// REQ-MEM-004 backfill: vault contents synced to R2 across sessions.
+//
+// All assertions are static structural checks against entrypoint.sh
+// (rclone filter ordering, idempotent init, lifecycle hooks).
+// Behavioral E2E of round-trip persistence lives in the integration
+// suite; this file covers the filter-shape correctness that nothing
+// else asserts on.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const entrypoint = readFileSync(resolve(__dirname, '../../entrypoint.sh'), 'utf8');
+
+describe('Vault R2 sync filter shape (REQ-MEM-004)', () => {
+  it('AC1: Vault/ + Uploads/ + Temporary/ are included in the common rclone filter', () => {
+    // These three folders are user-persistent and must round-trip to
+    // R2 in every SYNC_MODE.
+    assert.ok(
+      /--filter\s+"\+ Vault\/\*\*"/.test(entrypoint),
+      'entrypoint.sh RCLONE_FILTERS_COMMON must include `+ Vault/**`'
+    );
+    assert.ok(
+      /--filter\s+"\+ Uploads\/\*\*"/.test(entrypoint),
+      'entrypoint.sh RCLONE_FILTERS_COMMON must include `+ Uploads/**`'
+    );
+    assert.ok(
+      /--filter\s+"\+ Temporary\/\*\*"/.test(entrypoint),
+      'entrypoint.sh RCLONE_FILTERS_COMMON must include `+ Temporary/**`'
+    );
+  });
+
+  it('AC1: `+ Vault/**` precedes `- **/graphify-out/**` in the filter list', () => {
+    // rclone applies filters in first-match order. The Vault include
+    // MUST come BEFORE the graphify-out exclude, otherwise the vault's
+    // own graphify-out/ subtree (which holds the vault knowledge
+    // graph) would be silently skipped and the vault-extract pipeline
+    // would never persist its output across sessions.
+    const vaultIdx = entrypoint.indexOf('--filter "+ Vault/**"');
+    const graphifyOutIdx = entrypoint.indexOf('--filter "- **/graphify-out/**"');
+    assert.ok(vaultIdx > 0, 'entrypoint.sh must declare `+ Vault/**`');
+    assert.ok(graphifyOutIdx > 0, 'entrypoint.sh must declare `- **/graphify-out/**`');
+    assert.ok(
+      vaultIdx < graphifyOutIdx,
+      `Vault include must appear BEFORE the graphify-out exclude (Vault at ${vaultIdx}, graphify-out at ${graphifyOutIdx}). If reversed, rclone first-match would silently drop the vault's own graphify-out/.`
+    );
+  });
+
+  it('AC2: initial_sync_from_r2 runs early and is called before vault init', () => {
+    // The R2 pull must complete (or time out) before init_user_vault
+    // runs, otherwise the vault skeleton would overwrite any preseed
+    // pages the user had customised in R2.
+    assert.ok(
+      /^initial_sync_from_r2\(\)/m.test(entrypoint),
+      'entrypoint.sh must define initial_sync_from_r2()'
+    );
+    const initialSyncDef = entrypoint.indexOf('initial_sync_from_r2() {');
+    const initUserVaultDef = entrypoint.indexOf('init_user_vault() {');
+    assert.ok(initialSyncDef > 0, 'entrypoint.sh must define initial_sync_from_r2');
+    assert.ok(initUserVaultDef > 0, 'entrypoint.sh must define init_user_vault');
+    // Both must be invoked in main body. Find their call sites.
+    const initialSyncCall = entrypoint.indexOf('initial_sync_from_r2 &');
+    const initUserVaultCall = entrypoint.indexOf('(init_user_vault)');
+    assert.ok(initialSyncCall > 0, 'entrypoint.sh must invoke initial_sync_from_r2');
+    assert.ok(initUserVaultCall > 0, 'entrypoint.sh must invoke (init_user_vault)');
+    assert.ok(
+      initialSyncCall < initUserVaultCall,
+      'initial_sync_from_r2 invocation must occur BEFORE init_user_vault invocation'
+    );
+  });
+
+  it('AC3: init_user_vault uses mkdir -p (idempotent) for required subdirectories', () => {
+    // Every boot must be safe to re-run. mkdir -p means a returning
+    // session with the vault already populated does not lose anything;
+    // a fresh container creates the skeleton from scratch.
+    const block = entrypoint.match(/init_user_vault\(\) \{[\s\S]+?\n\}/);
+    assert.ok(block, 'entrypoint.sh must contain init_user_vault block');
+    const body = block[0];
+    // Required idempotent mkdirs.
+    assert.ok(/mkdir -p "\$VAULT\/Raw\/Sessions"/.test(body),
+      'init_user_vault must mkdir -p $VAULT/Raw/Sessions');
+    assert.ok(/mkdir -p "\$VAULT\/Raw\/Sessions" "\$VAULT\/Raw\/Pasted" "\$VAULT\/Notes"/.test(body),
+      'init_user_vault must mkdir -p the canonical user folders (Raw/Sessions, Raw/Pasted, Notes)');
+  });
+
+  it('AC3: preseed pages only overwrite when they differ from disk (cmp -s gate)', () => {
+    // The four preseed pages (Index, CONFIG, README, STYLES) are
+    // codeflare-authoritative. They must overwrite on each boot when
+    // the preseed source has changed BUT must not bloat sync logs by
+    // rewriting identical files every boot. The cmp -s guard handles
+    // both requirements.
+    assert.ok(
+      /cmp -s "\$PRESEED_DIR\/\$PAGE" "\$VAULT\/\$PAGE"/.test(entrypoint),
+      'init_user_vault must use cmp -s to skip identical preseed pages'
+    );
+  });
+
+  it('AC4: bisync daemon triggers include 15-min cadence + SIGUSR1 + shutdown', () => {
+    // The vault rides on the same bisync daemon as the rest of the
+    // synced tree (the filter is shared). Confirm all three triggers
+    // exist; the per-trigger details live in REQ-STOR-003 (cadence +
+    // SIGUSR1) and REQ-STOR-005 (shutdown).
+    assert.ok(/sleep 900 &/.test(entrypoint), 'AC4 (15-min cadence): entrypoint.sh must `sleep 900 &` in the daemon body');
+    assert.ok(/trap.*USR1/.test(entrypoint), 'AC4 (SIGUSR1 trigger): entrypoint.sh must install a USR1 trap');
+    assert.ok(/trap shutdown_handler SIGTERM SIGINT EXIT/.test(entrypoint),
+      'AC4 (shutdown trigger): entrypoint.sh must trap shutdown_handler on SIGTERM/SIGINT/EXIT');
+  });
+
+  it('AC5: ~/.graphify/ is excluded from bisync (rebuilt per boot)', () => {
+    // The global graph layer is a deterministic merge of per-source
+    // graphs. R2 sync of it would race against on-boot rebuild and
+    // produce stale state; the cleanest fix is no round-trip at all.
+    assert.ok(
+      /--filter\s+"- \.graphify\/\*\*"/.test(entrypoint),
+      'entrypoint.sh RCLONE_FILTERS_COMMON must exclude `~/.graphify/**` (the unified global graph layer)'
+    );
+  });
+
+  it('AC6: shutdown_handler watchdog is 120s for the final bisync', () => {
+    // Final bisync gets the same 108s SIGTERM + 12s SIGKILL grace
+    // pattern as REQ-STOR-005 AC4 — the vault inherits the budget
+    // because it shares the same daemon and bisync invocation.
+    assert.ok(
+      /\(\s*sleep 108\s+kill_subtree TERM "\$BISYNC_PID"\s+sleep 12\s+kill_subtree KILL "\$BISYNC_PID"/.test(entrypoint),
+      'shutdown_handler must run a 108s SIGTERM + 12s SIGKILL watchdog (120s total) so vault writes have time to flush'
+    );
+  });
+
+  it('constraint: rclone S3 multipart settings prevent BadDigest TOCTOU races', () => {
+    // disable_checksum = true skips X-Amz-Meta-Md5chksum metadata on
+    // multipart uploads. --s3-upload-cutoff 0 forces ALL uploads
+    // through the multipart path. Together they avoid the TOCTOU race
+    // where rclone computes an md5 then the file mutates before
+    // upload and R2 rejects the request with BadDigest.
+    assert.ok(
+      /disable_checksum\s*=\s*true/.test(entrypoint),
+      'entrypoint.sh rclone config must set disable_checksum = true'
+    );
+    const cutoffMatches = entrypoint.match(/--s3-upload-cutoff 0/g) || [];
+    assert.ok(
+      cutoffMatches.length >= 2,
+      `entrypoint.sh must pass --s3-upload-cutoff 0 to both --resync baseline AND periodic bisync (found ${cutoffMatches.length})`
+    );
+  });
+
+  it('constraint: counter files are excluded from bisync', () => {
+    // Per-session counter files at ~/.memory/counter/{session_id}.vars
+    // are ephemeral. Syncing them would (a) waste R2 ops and (b)
+    // leak counters between sessions on R2 pull, corrupting the next
+    // session's hook gating logic.
+    assert.ok(
+      /--filter\s+"- \.memory\/counter\/\*\*"/.test(entrypoint),
+      'entrypoint.sh must exclude `.memory/counter/**` from rclone bisync (per-session ephemeral state)'
+    );
+  });
+});

--- a/src/__tests__/lib/pro-mode-gating.test.ts
+++ b/src/__tests__/lib/pro-mode-gating.test.ts
@@ -1,0 +1,148 @@
+// REQ-MEM-006 backfill: memory/vault features gated behind advanced mode.
+//
+// AC1 (vault NOT preserved across recreations in default mode) and AC2
+// (default-mode capture hook runs counter but no vault write) are
+// behavioral and require integration / E2E setup that this unit suite
+// cannot host; they remain in the integration suite per the spec's
+// Verification field.
+//
+// AC3 (memory + vault rules + plugins are advanced-only) -- this file.
+// AC4 (Pro is a strict superset of Standard) -- already covered in
+// agent-seed-manifest.test.ts (`"advanced" is a superset of "default"`).
+// AC5 (entrypoint.sh merges hook registrations only in advanced) -- this file.
+// AC6 (resolveSessionMode default) -- covered in session-mode.test.ts.
+// AC7 (mode changes only via recreate or new bucket) -- behavioral; integration.
+// AC8 (reconcileAgentConfigs never touches user files) -- this file.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AGENTS_SEEDED_CONFIGS } from '../../lib/agent-seed.generated';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('REQ-MEM-006 AC3: memory + vault rules and plugins are advanced-only', () => {
+  const advancedOnly = (key: string) =>
+    AGENTS_SEEDED_CONFIGS.filter((d) => d.key === key).every(
+      (d) => d.modes.length === 1 && d.modes[0] === 'advanced'
+    );
+
+  const has = (key: string) => AGENTS_SEEDED_CONFIGS.some((d) => d.key === key);
+
+  it('rules/memory.md is advanced-only', () => {
+    expect(has('.claude/rules/memory.md'), '.claude/rules/memory.md must be present in the seed').toBe(true);
+    expect(advancedOnly('.claude/rules/memory.md'),
+      'rules/memory.md must be tagged advanced-only -- it documents vault capture which is Pro-only').toBe(true);
+  });
+
+  it('rules/vault.md is advanced-only', () => {
+    expect(has('.claude/rules/vault.md'), '.claude/rules/vault.md must be present in the seed').toBe(true);
+    expect(advancedOnly('.claude/rules/vault.md'),
+      'rules/vault.md must be tagged advanced-only -- vault is a Pro feature').toBe(true);
+  });
+
+  it('rules/vault-note-capture.md is advanced-only', () => {
+    expect(has('.claude/rules/vault-note-capture.md'), '.claude/rules/vault-note-capture.md must be present in the seed').toBe(true);
+    expect(advancedOnly('.claude/rules/vault-note-capture.md'),
+      'rules/vault-note-capture.md drives the vault-note-capture skill; must be Pro-only').toBe(true);
+  });
+
+  it('all codeflare-memory plugin files are advanced-only', () => {
+    const memory = AGENTS_SEEDED_CONFIGS.filter((d) =>
+      d.key.startsWith('.claude/plugins/codeflare-memory/')
+    );
+    expect(memory.length, 'codeflare-memory plugin must have at least one file in the seed').toBeGreaterThan(0);
+    for (const doc of memory) {
+      expect(doc.modes, `${doc.key} must be tagged advanced-only`).toEqual(['advanced']);
+    }
+  });
+
+  it('all codeflare-vault plugin files are advanced-only', () => {
+    const vault = AGENTS_SEEDED_CONFIGS.filter((d) =>
+      d.key.startsWith('.claude/plugins/codeflare-vault/')
+    );
+    expect(vault.length, 'codeflare-vault plugin must have at least one file in the seed').toBeGreaterThan(0);
+    for (const doc of vault) {
+      expect(doc.modes, `${doc.key} must be tagged advanced-only`).toEqual(['advanced']);
+    }
+  });
+
+  it('non-Claude agents do not receive memory or vault plugins', () => {
+    // The memory and vault subsystems depend on Claude-specific MCP and
+    // hook systems; shipping them to Codex/Gemini/Copilot/OpenCode would
+    // produce empty/broken plugs.
+    const nonClaude = AGENTS_SEEDED_CONFIGS.filter((d) => !d.key.startsWith('.claude/'));
+    for (const doc of nonClaude) {
+      expect(doc.key).not.toContain('codeflare-memory');
+      expect(doc.key).not.toContain('codeflare-vault');
+    }
+  });
+});
+
+describe('REQ-MEM-006 AC5: entrypoint.sh merges hook registrations only in advanced mode', () => {
+  const entrypoint = readFileSync(resolve(__dirname, '../../../entrypoint.sh'), 'utf8');
+
+  it('default-mode SETTINGS_CONFIG contains only skipDangerousModePermissionPrompt', () => {
+    // The default-mode branch in entrypoint.sh writes a minimal config.
+    // Any drift (e.g. accidentally including a hooks block) would
+    // silently turn on capture/memory hooks for Standard users.
+    assert_contains(
+      entrypoint,
+      `SETTINGS_CONFIG='{"skipDangerousModePermissionPrompt":true}'`,
+      'default-mode SETTINGS_CONFIG block must be exactly {"skipDangerousModePermissionPrompt":true}'
+    );
+  });
+
+  it('advanced-mode SETTINGS_CONFIG includes UserPromptSubmit hook for memory-capture.sh', () => {
+    // The advanced-mode branch builds a larger hooks block. memory-capture.sh
+    // and vault-monitor-hook.sh must both register on UserPromptSubmit.
+    expect(entrypoint).toMatch(/codeflare-memory\/scripts\/memory-capture\.sh/);
+    expect(entrypoint).toMatch(/codeflare-vault\/scripts\/vault-monitor-hook\.sh/);
+  });
+
+  it('advanced-mode hook block is gated on the session mode branch', () => {
+    // The two SETTINGS_CONFIG assignments must be in separate
+    // branches: one in the advanced path, one in the default fallback.
+    // Find the `Advanced mode: configuring` and `Default mode: configuring`
+    // log lines as sentinels.
+    expect(entrypoint).toMatch(/Advanced mode: configuring settings\.json with hooks/);
+    expect(entrypoint).toMatch(/Default mode: configuring settings\.json without hooks/);
+    // Default mode log must come AFTER advanced (else branch).
+    const advIdx = entrypoint.indexOf('Advanced mode: configuring settings.json with hooks');
+    const defIdx = entrypoint.indexOf('Default mode: configuring settings.json without hooks');
+    expect(advIdx).toBeGreaterThan(0);
+    expect(defIdx).toBeGreaterThan(advIdx);
+  });
+});
+
+describe('REQ-MEM-006 AC8: reconcileAgentConfigs never touches user-created files', () => {
+  // Static structural check on the reconcile function: it must only
+  // act on keys whose source is a preseed-managed entry, never on
+  // user-written files. The function lives in src/lib/r2-seed.ts.
+  const r2seed = readFileSync(resolve(__dirname, '../../lib/r2-seed.ts'), 'utf8');
+
+  it('reconcileAgentConfigs is defined in r2-seed.ts', () => {
+    expect(r2seed).toMatch(/export\s+(async\s+)?function\s+reconcileAgentConfigs/);
+  });
+
+  it('reconcile only deletes keys that match an AGENTS_SEEDED_CONFIGS entry', () => {
+    // The function must NOT call deleteObjects with arbitrary key
+    // patterns; deletes are filtered through the manifest. Look for
+    // the manifest-driven key set used by the delete pass.
+    expect(r2seed).toMatch(/AGENTS_SEEDED_CONFIGS|AGENT_SEEDED_KEYS|agentSeedKeys/);
+  });
+
+  it('reconcile guards delete with a managed-keys allowlist (no bulk wildcard delete)', () => {
+    // A wildcard delete of '.claude/**' would obliterate user files.
+    // The function must iterate explicit keys from the manifest.
+    expect(r2seed).not.toMatch(/deleteAll\s*\(/);
+    expect(r2seed).not.toMatch(/deleteObjects\s*\(\s*['"]\.claude\/\*\*['"]/);
+  });
+});
+
+// Local helper -- supports the AC5 SETTINGS_CONFIG assertion that
+// would otherwise need a substring escape gymnastics for the JSON
+// literal containing single quotes and curlies.
+function assert_contains(haystack: string, needle: string, msg: string): void {
+  expect(haystack.includes(needle), msg).toBe(true);
+}

--- a/src/__tests__/lib/pro-mode-gating.test.ts
+++ b/src/__tests__/lib/pro-mode-gating.test.ts
@@ -6,20 +6,16 @@
 // cannot host; they remain in the integration suite per the spec's
 // Verification field.
 //
-// AC3 (memory + vault rules + plugins are advanced-only) -- this file.
+// AC3 (memory + vault rules + plugins are advanced-only) -- THIS FILE.
 // AC4 (Pro is a strict superset of Standard) -- already covered in
 // agent-seed-manifest.test.ts (`"advanced" is a superset of "default"`).
-// AC5 (entrypoint.sh merges hook registrations only in advanced) -- this file.
+// AC5 (entrypoint.sh hook-merge mode gating) -- host/__tests__/pro-mode-gating-static.test.js
+//      (Workers vitest pool cannot readFileSync entrypoint.sh).
 // AC6 (resolveSessionMode default) -- covered in session-mode.test.ts.
 // AC7 (mode changes only via recreate or new bucket) -- behavioral; integration.
-// AC8 (reconcileAgentConfigs never touches user files) -- this file.
+// AC8 (reconcileAgentConfigs never touches user files) -- host/__tests__/pro-mode-gating-static.test.js.
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { AGENTS_SEEDED_CONFIGS } from '../../lib/agent-seed.generated';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('REQ-MEM-006 AC3: memory + vault rules and plugins are advanced-only', () => {
   const advancedOnly = (key: string) =>
@@ -78,71 +74,3 @@ describe('REQ-MEM-006 AC3: memory + vault rules and plugins are advanced-only', 
     }
   });
 });
-
-describe('REQ-MEM-006 AC5: entrypoint.sh merges hook registrations only in advanced mode', () => {
-  const entrypoint = readFileSync(resolve(__dirname, '../../../entrypoint.sh'), 'utf8');
-
-  it('default-mode SETTINGS_CONFIG contains only skipDangerousModePermissionPrompt', () => {
-    // The default-mode branch in entrypoint.sh writes a minimal config.
-    // Any drift (e.g. accidentally including a hooks block) would
-    // silently turn on capture/memory hooks for Standard users.
-    assert_contains(
-      entrypoint,
-      `SETTINGS_CONFIG='{"skipDangerousModePermissionPrompt":true}'`,
-      'default-mode SETTINGS_CONFIG block must be exactly {"skipDangerousModePermissionPrompt":true}'
-    );
-  });
-
-  it('advanced-mode SETTINGS_CONFIG includes UserPromptSubmit hook for memory-capture.sh', () => {
-    // The advanced-mode branch builds a larger hooks block. memory-capture.sh
-    // and vault-monitor-hook.sh must both register on UserPromptSubmit.
-    expect(entrypoint).toMatch(/codeflare-memory\/scripts\/memory-capture\.sh/);
-    expect(entrypoint).toMatch(/codeflare-vault\/scripts\/vault-monitor-hook\.sh/);
-  });
-
-  it('advanced-mode hook block is gated on the session mode branch', () => {
-    // The two SETTINGS_CONFIG assignments must be in separate
-    // branches: one in the advanced path, one in the default fallback.
-    // Find the `Advanced mode: configuring` and `Default mode: configuring`
-    // log lines as sentinels.
-    expect(entrypoint).toMatch(/Advanced mode: configuring settings\.json with hooks/);
-    expect(entrypoint).toMatch(/Default mode: configuring settings\.json without hooks/);
-    // Default mode log must come AFTER advanced (else branch).
-    const advIdx = entrypoint.indexOf('Advanced mode: configuring settings.json with hooks');
-    const defIdx = entrypoint.indexOf('Default mode: configuring settings.json without hooks');
-    expect(advIdx).toBeGreaterThan(0);
-    expect(defIdx).toBeGreaterThan(advIdx);
-  });
-});
-
-describe('REQ-MEM-006 AC8: reconcileAgentConfigs never touches user-created files', () => {
-  // Static structural check on the reconcile function: it must only
-  // act on keys whose source is a preseed-managed entry, never on
-  // user-written files. The function lives in src/lib/r2-seed.ts.
-  const r2seed = readFileSync(resolve(__dirname, '../../lib/r2-seed.ts'), 'utf8');
-
-  it('reconcileAgentConfigs is defined in r2-seed.ts', () => {
-    expect(r2seed).toMatch(/export\s+(async\s+)?function\s+reconcileAgentConfigs/);
-  });
-
-  it('reconcile only deletes keys that match an AGENTS_SEEDED_CONFIGS entry', () => {
-    // The function must NOT call deleteObjects with arbitrary key
-    // patterns; deletes are filtered through the manifest. Look for
-    // the manifest-driven key set used by the delete pass.
-    expect(r2seed).toMatch(/AGENTS_SEEDED_CONFIGS|AGENT_SEEDED_KEYS|agentSeedKeys/);
-  });
-
-  it('reconcile guards delete with a managed-keys allowlist (no bulk wildcard delete)', () => {
-    // A wildcard delete of '.claude/**' would obliterate user files.
-    // The function must iterate explicit keys from the manifest.
-    expect(r2seed).not.toMatch(/deleteAll\s*\(/);
-    expect(r2seed).not.toMatch(/deleteObjects\s*\(\s*['"]\.claude\/\*\*['"]/);
-  });
-});
-
-// Local helper -- supports the AC5 SETTINGS_CONFIG assertion that
-// would otherwise need a substring escape gymnastics for the JSON
-// literal containing single quotes and curlies.
-function assert_contains(haystack: string, needle: string, msg: string): void {
-  expect(haystack.includes(needle), msg).toBe(true);
-}

--- a/src/__tests__/lib/sync-fanout.test.ts
+++ b/src/__tests__/lib/sync-fanout.test.ts
@@ -168,46 +168,9 @@ describe('fanOutBisyncTrigger (REQ-STOR-015 backfill)', () => {
   });
 });
 
-describe('REQ-STOR-015 AC4: upload-side fire-and-forget trigger', () => {
-  it('AC4 contract: upload.ts wires fanOutBisyncTrigger through executionCtx.waitUntil', async () => {
-    // Static check: the upload route module imports fanOutBisyncTrigger
-    // AND its source contains the waitUntil wiring + .catch() defensive
-    // wrapper that prevents a trigger failure from poisoning the upload
-    // 200 response (lessons from prior incident around upload-side
-    // sync surfacing as 500s).
-    const fs = await import('node:fs');
-    const path = await import('node:path');
-    const url = await import('node:url');
-    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-    const upload = fs.readFileSync(
-      path.resolve(__dirname, '../../routes/storage/upload.ts'),
-      'utf8'
-    );
-    expect(upload).toContain("from '../../lib/sync-fanout'");
-    expect(upload).toContain('fanOutBisyncTrigger');
-    expect(upload).toMatch(/c\.executionCtx\?\.waitUntil\(/);
-    // .catch(() => undefined) is the defensive wrapper that swallows
-    // trigger failures so the R2 PUT can return 200 cleanly.
-    expect(upload).toMatch(/\.catch\(\(\) => undefined\)/);
-  });
-});
-
-describe('REQ-STOR-015 AC7: sessions-sync rate limit is 6/min', () => {
-  it('uses windowMs=60_000 + maxRequests=6 + keyPrefix=sessions-sync', async () => {
-    const fs = await import('node:fs');
-    const path = await import('node:path');
-    const url = await import('node:url');
-    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-    const lifecycle = fs.readFileSync(
-      path.resolve(__dirname, '../../routes/session/lifecycle.ts'),
-      'utf8'
-    );
-    // The block must contain all three required fields. Use a multi-
-    // line regex so we tolerate field ordering and whitespace.
-    expect(lifecycle).toMatch(/sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?windowMs:\s*60_?000[\s\S]*?\}\s*\)/);
-    expect(lifecycle).toMatch(/sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?maxRequests:\s*6[\s\S]*?\}\s*\)/);
-    expect(lifecycle).toMatch(/sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?keyPrefix:\s*['"]sessions-sync['"][\s\S]*?\}\s*\)/);
-    // The limiter must actually be attached to POST /sync.
-    expect(lifecycle).toMatch(/app\.post\(\s*['"]\/sync['"]\s*,\s*sessionsSyncRateLimiter/);
-  });
-});
+// AC4 (upload.ts wires fanOutBisyncTrigger through waitUntil) and AC7
+// (sessions-sync rate limiter shape) require reading source files at
+// runtime, which the Workers vitest pool does not allow. Those static
+// structural assertions live in host/__tests__/sync-fanout-static.test.js
+// (Node test runner with full fs access). See that file for the matching
+// fixture-free assertions.

--- a/src/__tests__/lib/sync-fanout.test.ts
+++ b/src/__tests__/lib/sync-fanout.test.ts
@@ -1,0 +1,213 @@
+// REQ-STOR-015 backfill: sync-fanout helper covers AC1 (enumerate +
+// fan out to running sessions only), AC2 (concurrency cap = 8),
+// AC3 (per-session failure isolation), and AC4 (upload-trigger wiring).
+// AC5 (SIGUSR1 in-flight/rerun coalescing) is asserted in
+// entrypoint-bisync-trigger.test.js. AC6 (frontend button disabled while
+// syncing) is asserted in web-ui StorageBrowser.test.tsx. AC7 (rate
+// limit 6/min) is asserted on the rate-limiter constant directly here.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Env } from '../../types';
+import { createMockKV } from '../helpers/mock-kv';
+import { fanOutBisyncTrigger } from '../../lib/sync-fanout';
+
+// Hoisted mutable state so vi.mock() factory below can read the latest
+// per-test container behavior without re-defining the module mock.
+const testState = vi.hoisted(() => ({
+  containerFetch: vi.fn(),
+  // Track which session IDs got their container.fetch called and when,
+  // so we can verify concurrency-cap chunking semantics.
+  fetchOrder: [] as Array<{ sessionId: string; t: number }>,
+  resetForCappedTest: false,
+}));
+
+vi.mock('@cloudflare/containers', () => ({
+  getContainer: vi.fn((_binding: unknown, containerId: string) => ({
+    fetch: (req: Request) => testState.containerFetch(containerId, req),
+  })),
+}));
+
+function buildEnv(kv: ReturnType<typeof createMockKV>): Env {
+  return {
+    KV: kv as unknown as KVNamespace,
+    CONTAINER: {} as unknown as DurableObjectNamespace,
+  } as unknown as Env;
+}
+
+function seedSession(
+  kv: ReturnType<typeof createMockKV>,
+  bucketName: string,
+  sessionId: string,
+  status: 'running' | 'stopped'
+): void {
+  // Use the metadata fast-path so list() returns SessionListMetadata.
+  // SessionListMetadata.s is the status field (compact serialization).
+  kv._set(
+    `session:${bucketName}:${sessionId}`,
+    {
+      id: sessionId,
+      name: 'Test',
+      userId: bucketName,
+      status,
+      createdAt: new Date().toISOString(),
+      lastAccessedAt: new Date().toISOString(),
+    },
+    { s: status === 'running' ? 'r' : 's' }
+  );
+}
+
+describe('fanOutBisyncTrigger (REQ-STOR-015 backfill)', () => {
+  let kv: ReturnType<typeof createMockKV>;
+  const bucket = 'test-bucket';
+
+  beforeEach(() => {
+    kv = createMockKV();
+    testState.containerFetch.mockReset();
+    testState.fetchOrder.length = 0;
+  });
+
+  it('AC1: enumerates the user sessions and fans out only to running ones', async () => {
+    seedSession(kv, bucket, 'aaaaaaaaaaaaaaaaaaaaaaaa', 'running');
+    seedSession(kv, bucket, 'bbbbbbbbbbbbbbbbbbbbbbbb', 'stopped');
+    seedSession(kv, bucket, 'cccccccccccccccccccccccc', 'running');
+    testState.containerFetch.mockResolvedValue(new Response(null, { status: 202 }));
+
+    const results = await fanOutBisyncTrigger(buildEnv(kv), bucket);
+
+    // Only the two running sessions get triggered; the stopped one is
+    // skipped client-side per AC1.
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === 'triggered')).toBe(true);
+    expect(testState.containerFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('AC1: returns empty array when the user has zero running sessions', async () => {
+    seedSession(kv, bucket, 'dddddddddddddddddddddddd', 'stopped');
+    seedSession(kv, bucket, 'eeeeeeeeeeeeeeeeeeeeeeee', 'stopped');
+
+    const results = await fanOutBisyncTrigger(buildEnv(kv), bucket);
+
+    expect(results).toEqual([]);
+    expect(testState.containerFetch).not.toHaveBeenCalled();
+  });
+
+  it('AC2: caps concurrent in-flight container.fetch calls at 8', async () => {
+    // Seed 20 running sessions and slow each container.fetch to keep
+    // them outstanding for one microtask window. Then count the maximum
+    // overlap of in-flight calls - it must be 8 or fewer.
+    for (let i = 0; i < 20; i++) {
+      seedSession(kv, bucket, `${i.toString().padStart(24, 'a')}`, 'running');
+    }
+
+    let inFlight = 0;
+    let peak = 0;
+    testState.containerFetch.mockImplementation(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      // Yield once so the next .map() iteration can launch before we
+      // resolve. Without an await, Promise.all would observe sequential
+      // synchronous returns and never see overlap.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      inFlight -= 1;
+      return new Response(null, { status: 202 });
+    });
+
+    const results = await fanOutBisyncTrigger(buildEnv(kv), bucket);
+
+    expect(results).toHaveLength(20);
+    expect(peak).toBeLessThanOrEqual(8);
+    expect(peak).toBeGreaterThan(1); // sanity: some parallelism happened
+  });
+
+  it('AC3: per-session failures do not break the rest of the fan-out', async () => {
+    seedSession(kv, bucket, 'aaaaaaaaaaaaaaaaaaaaaaaa', 'running'); // throws
+    seedSession(kv, bucket, 'bbbbbbbbbbbbbbbbbbbbbbbb', 'running'); // 503 - not-running
+    seedSession(kv, bucket, 'cccccccccccccccccccccccc', 'running'); // 202 - triggered
+
+    testState.containerFetch.mockImplementation(async (containerId: string) => {
+      if (containerId.includes('aaaaaaaa')) throw new Error('container went away');
+      if (containerId.includes('bbbbbbbb')) return new Response(null, { status: 503 });
+      return new Response(null, { status: 202 });
+    });
+
+    const results = await fanOutBisyncTrigger(buildEnv(kv), bucket);
+
+    // All three sessions get an entry. The thrown one is 'failed', the
+    // 503 is 'not-running', the 202 is 'triggered'. None should affect
+    // the others' outcomes.
+    expect(results).toHaveLength(3);
+    const statuses = results.map((r) => r.status).sort();
+    expect(statuses).toEqual(['failed', 'not-running', 'triggered']);
+    const failed = results.find((r) => r.status === 'failed');
+    expect(failed?.error).toContain('container went away');
+  });
+
+  it('AC1: 503 from container is reported as not-running, not failed', async () => {
+    seedSession(kv, bucket, 'aaaaaaaaaaaaaaaaaaaaaaaa', 'running');
+    testState.containerFetch.mockResolvedValue(new Response(null, { status: 503 }));
+
+    const results = await fanOutBisyncTrigger(buildEnv(kv), bucket);
+
+    expect(results).toEqual([
+      { sessionId: 'aaaaaaaaaaaaaaaaaaaaaaaa', status: 'not-running' },
+    ]);
+  });
+
+  it('AC1: fan-out POSTs to /internal/bisync-trigger on each container', async () => {
+    seedSession(kv, bucket, 'aaaaaaaaaaaaaaaaaaaaaaaa', 'running');
+    let capturedRequest: Request | undefined;
+    testState.containerFetch.mockImplementation(async (_id: string, req: Request) => {
+      capturedRequest = req;
+      return new Response(null, { status: 202 });
+    });
+
+    await fanOutBisyncTrigger(buildEnv(kv), bucket);
+
+    expect(capturedRequest).toBeDefined();
+    expect(capturedRequest!.method).toBe('POST');
+    expect(capturedRequest!.url).toContain('/internal/bisync-trigger');
+  });
+});
+
+describe('REQ-STOR-015 AC4: upload-side fire-and-forget trigger', () => {
+  it('AC4 contract: upload.ts wires fanOutBisyncTrigger through executionCtx.waitUntil', async () => {
+    // Static check: the upload route module imports fanOutBisyncTrigger
+    // AND its source contains the waitUntil wiring + .catch() defensive
+    // wrapper that prevents a trigger failure from poisoning the upload
+    // 200 response (lessons from prior incident around upload-side
+    // sync surfacing as 500s).
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+    const upload = fs.readFileSync(
+      path.resolve(__dirname, '../../routes/storage/upload.ts'),
+      'utf8'
+    );
+    expect(upload).toContain("from '../../lib/sync-fanout'");
+    expect(upload).toContain('fanOutBisyncTrigger');
+    expect(upload).toMatch(/c\.executionCtx\?\.waitUntil\(/);
+    // .catch(() => undefined) is the defensive wrapper that swallows
+    // trigger failures so the R2 PUT can return 200 cleanly.
+    expect(upload).toMatch(/\.catch\(\(\) => undefined\)/);
+  });
+});
+
+describe('REQ-STOR-015 AC7: sessions-sync rate limit is 6/min', () => {
+  it('uses windowMs=60_000 + maxRequests=6 + keyPrefix=sessions-sync', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+    const lifecycle = fs.readFileSync(
+      path.resolve(__dirname, '../../routes/session/lifecycle.ts'),
+      'utf8'
+    );
+    // The block must contain all three required fields. Use a multi-
+    // line regex so we tolerate field ordering and whitespace.
+    expect(lifecycle).toMatch(/sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?windowMs:\s*60_?000[\s\S]*?\}\s*\)/);
+    expect(lifecycle).toMatch(/sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?maxRequests:\s*6[\s\S]*?\}\s*\)/);
+    expect(lifecycle).toMatch(/sessionsSyncRateLimiter\s*=\s*createRateLimiter\(\s*\{[\s\S]*?keyPrefix:\s*['"]sessions-sync['"][\s\S]*?\}\s*\)/);
+    // The limiter must actually be attached to POST /sync.
+    expect(lifecycle).toMatch(/app\.post\(\s*['"]\/sync['"]\s*,\s*sessionsSyncRateLimiter/);
+  });
+});

--- a/web-ui/src/__tests__/components/StorageBrowser.test.tsx
+++ b/web-ui/src/__tests__/components/StorageBrowser.test.tsx
@@ -16,6 +16,9 @@ let mockStats: any = null;
 let mockPreviewFile: any = null;
 let mockWorkspaceSyncEnabled = true;
 let mockActiveSessionId: string | null = 'test-session';
+// REQ-STOR-015 AC6: Sync-now button disabled while a fan-out is in flight.
+// Default false; flip per test to assert disabled-state coupling.
+let mockSyncing = false;
 
 const mockBrowse = vi.fn();
 const mockNavigateTo = vi.fn();
@@ -44,6 +47,7 @@ const mockSearchFiles = vi.fn((q: string) => {
 const mockFetchStats = vi.fn();
 const mockOpenPreview = vi.fn();
 const mockClosePreview = vi.fn();
+const mockSyncNow = vi.fn();
 // MOCK-DRIFT RISK: The storageStore mock below replicates the public API surface
 // of stores/storage.ts. If the real store adds/removes/renames methods or changes
 // getter signatures, these tests will silently pass with stale behavior. When
@@ -61,7 +65,9 @@ vi.mock('../../stores/storage', () => ({
     get breadcrumbs() { return mockBreadcrumbs; },
     get stats() { return mockStats; },
     get previewFile() { return mockPreviewFile; },
+    get syncing() { return mockSyncing; },
     browse: (...args: any[]) => mockBrowse(...args),
+    syncNow: (...args: any[]) => mockSyncNow(...args),
     navigateTo: (...args: any[]) => mockNavigateTo(...args),
     navigateUp: (...args: any[]) => mockNavigateUp(...args),
     refresh: (...args: any[]) => mockRefresh(...args),
@@ -857,6 +863,56 @@ describe('StorageBrowser', () => {
       render(() => <StorageBrowser />);
 
       expect(screen.queryByTestId('storage-upload-queue')).not.toBeInTheDocument();
+    });
+  });
+
+  // REQ-STOR-015 AC6 backfill: the Sync-now (fan-out) button is disabled
+  // while any of the user's sessions reports sync.status === 'syncing'.
+  // The toolbar binds `disabled={storageStore.syncing}` and `class={... ?
+  // 'storage-sync-breathing' : ''}` to the same flag, so we drive
+  // mockSyncing to verify both behaviors plus the click-suppression
+  // contract.
+  describe('Sync-now fan-out button (REQ-STOR-015 AC6)', () => {
+    beforeEach(() => {
+      mockSyncing = false;
+      mockSyncNow.mockReset();
+    });
+
+    it('renders the fan-out button with the storage-sync-now-btn testid', () => {
+      render(() => <StorageBrowser />);
+      expect(screen.getByTestId('storage-sync-now-btn')).toBeInTheDocument();
+    });
+
+    it('is enabled and clickable when no fan-out is in flight', () => {
+      mockSyncing = false;
+      render(() => <StorageBrowser />);
+      const btn = screen.getByTestId('storage-sync-now-btn');
+      expect(btn).not.toBeDisabled();
+      fireEvent.click(btn);
+      expect(mockSyncNow).toHaveBeenCalledTimes(1);
+    });
+
+    it('is disabled while storageStore.syncing is true', () => {
+      mockSyncing = true;
+      render(() => <StorageBrowser />);
+      const btn = screen.getByTestId('storage-sync-now-btn');
+      expect(btn).toBeDisabled();
+    });
+
+    it('shows the breathing animation class while syncing', () => {
+      mockSyncing = true;
+      render(() => <StorageBrowser />);
+      const btn = screen.getByTestId('storage-sync-now-btn');
+      // Class is bound to the icon element, not the button container.
+      // Look for any descendant with the breathing class.
+      expect(btn.querySelector('.storage-sync-breathing')).toBeInTheDocument();
+    });
+
+    it('does NOT show the breathing animation class when idle', () => {
+      mockSyncing = false;
+      render(() => <StorageBrowser />);
+      const btn = screen.getByTestId('storage-sync-now-btn');
+      expect(btn.querySelector('.storage-sync-breathing')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

Retroactive AC test backfill for the sync-v2 and memory-pipeline epochs already on develop. Test-only changes; no production code touched.

Per the audit pass:
- REQ-STOR-003 was 0/6 ACs covered -> 6/6 (entrypoint-bisync-cadence.test.js)
- REQ-STOR-005 gaps on AC2 + AC3 -> covered (entrypoint-shutdown-budget.test.js)
- REQ-STOR-015 was 1/7 (correctly Partial) -> AC1-4 + AC6-7 covered (sync-fanout.test.ts + StorageBrowser.test.tsx)
- REQ-MEM-001 gaps on AC3 + AC4 + AC5 -> covered (memory-capture-pipeline.test.js)
- REQ-MEM-004 was 0/6 ACs covered -> AC1-6 covered (vault-r2-sync.test.js)
- REQ-MEM-006 was 0/4 covered -> AC3 + AC5 + AC8 structurally covered (pro-mode-gating.test.ts); AC1, AC2, AC7 remain in integration suite per spec Verification field

## Test plan

- [ ] CI green on PR Checks (test runners + lint + type-check)
- [ ] No production code changes - smoke test of develop behavior unchanged
- [ ] Spot-check: each new test file maps clearly to its REQ via labeled describe() blocks