### PR TITLE
feat(REQ-VAULT-008): SB vault encryption + cold-start payload + lifecycle (WIP)

### DIFF
--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -1039,6 +1039,35 @@ Three smaller decisions bundled in:
 
 ---
 
+### AD59: Zero-UI vault encryption with per-session DO-storage key
+
+**Status:** Accepted
+
+**Context:** SilverBullet's IndexedDB cache stores every vault file as plaintext on the user's browser profile. Three concerns are coupled: (1) SB cold-start is ~30s on every new session because the per-`:sid` URL produces a new IDB hash every time; (2) plaintext IDB exposes vault content to anyone with read access to the user's browser profile (backup leak, profile theft, ransomware scan); (3) deleted sessions leave orphan IDBs that grow monotonically against the per-origin quota. The team wanted encryption-at-rest without adding a passphrase UI (it would create a "forgotten passphrase" support load and the vault is already coupled to the codeflare login).
+
+**Decision:** Each session's Container DO mints a 32-byte random key on first boot, persists in `ctx.storage`, and exposes it via an RPC method `ensureVaultKey()`. The Worker `/.config` proxy fetches the key via RPC and injects it into SilverBullet's BootConfig. A Worker-side `<script>` injection into the shell HTML exposes `window.__codeflareVaultBoot` carrying the key, raised sync concurrency, and lazy-path prefixes for the SB client to consume. The frontend nukes the per-session IDB on session DELETE and runs an orphan-sweep on Dashboard mount.
+
+**Threat model (BitLocker-grade, not Bitwarden-grade):**
+- DEFEATS: offline disk attacks - recovered/stolen browser profile, leaked filesystem backup, ransomware filesystem scan, forensic IDB extraction from a powered-off machine.
+- DOES NOT DEFEAT: anyone with an authenticated browser tab on the codeflare origin (they can read `window.__codeflareVaultBoot` directly from page JS); the codeflare Worker operator (the key crosses the Worker on every request); a compromised Cloudflare edge.
+
+**Consequences:**
+- Vault contents in IndexedDB become AES ciphertext rather than plaintext markdown - a recovered profile no longer leaks notes.
+- The encryption is forward-secret: `container.destroy()` (session DELETE) wipes both the DO key and the browser IDB, so deletion is unrecoverable even by the user.
+- The key MUST NOT rotate mid-session - rotation would orphan all existing IDB ciphertext and force re-sync on every container restart, defeating the cold-start optimisation.
+- The key is per-session, so cross-session reads remain isolated (each `:sid` has its own IDB hash).
+- Worker-side script injection is fragile: a future SB upstream change to the shell HTML template could break the `</head>` insertion point. The fail-safe is "return HTML unchanged" so a missed injection degrades to a passphrase prompt rather than a white screen.
+
+**Alternative considered:** Per-user passphrase derived via PBKDF2 from the codeflare password. Rejected - adds a "forgotten passphrase" recovery flow that requires the user to re-enter their vault password on every fresh device, defeating the always-on coupling to the codeflare session.
+
+**Alternative considered:** Build SilverBullet from source with native encryption support baked in. Rejected - Deno toolchain in the image adds ~400MB and locks codeflare to a fork rather than tracking SB upstream. Runtime injection through the already-text-rewriting Worker proxy is the lowest-overhead option.
+
+**Alternative considered:** Server-side encryption only (rclone bisync to R2 SSE-C, leave IDB plaintext). Rejected - R2 SSE-C already covers at-rest on R2; the gap is the browser cache, which is where the new requirement lives.
+
+**Related REQ:** REQ-VAULT-008 (zero-UI vault encryption + cold-start payload + IDB lifecycle), REQ-VAULT-005 (Worker proxy exposes vault editor).
+
+---
+
 ## Related Documentation
 
 - [Architecture — System Components](../architecture.md#system-components) - Component overview

--- a/host/__tests__/preseed-config-treeview.test.js
+++ b/host/__tests__/preseed-config-treeview.test.js
@@ -1,0 +1,46 @@
+// REQ-VAULT-008 AC7: preseed CONFIG.md declares treeview exclude patterns
+// for the agent-derived / system folders that should not appear in the
+// SB tree pane: Library/**, Repositories/**, top-level preseed pages
+// (CONFIG.md, Index.md, README.md, STYLES.md), .silverbullet/**,
+// graphify-out/**.
+//
+// Server-side `/.fs` filtering (AC6) hides graphify-out from the
+// raw listing. The treeview plug runs client-side from the same
+// listing data but ALSO reads its exclude patterns from a config
+// page, so a future SB version that ignores server-filtered entries
+// (e.g. caches the raw response) still hides them at the UI surface.
+// Two independent guards — server + UI — survive a bug in either.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CONFIG_PATH = path.join(__dirname, '..', '..', 'preseed', 'silverbullet', 'CONFIG.md');
+
+test('CONFIG.md declares a treeview exclude block (REQ-VAULT-008 AC7)', () => {
+  const body = fs.readFileSync(CONFIG_PATH, 'utf8');
+  assert.match(body, /treeview/i, 'CONFIG.md must reference treeview config');
+});
+
+test('CONFIG.md excludes graphify-out from treeview (REQ-VAULT-008 AC7)', () => {
+  const body = fs.readFileSync(CONFIG_PATH, 'utf8');
+  assert.match(body, /graphify-out/, 'CONFIG.md must list graphify-out in treeview exclude');
+});
+
+test('CONFIG.md excludes Library/ from treeview (REQ-VAULT-008 AC7)', () => {
+  const body = fs.readFileSync(CONFIG_PATH, 'utf8');
+  assert.match(body, /Library/, 'CONFIG.md must list Library in treeview exclude');
+});
+
+test('CONFIG.md excludes .silverbullet/ from treeview (REQ-VAULT-008 AC7)', () => {
+  const body = fs.readFileSync(CONFIG_PATH, 'utf8');
+  assert.match(body, /\.silverbullet/, 'CONFIG.md must list .silverbullet in treeview exclude');
+});
+
+test('CONFIG.md excludes top-level preseed pages (CONFIG/Index/README/STYLES) from treeview (REQ-VAULT-008 AC7)', () => {
+  const body = fs.readFileSync(CONFIG_PATH, 'utf8');
+  for (const page of ['CONFIG', 'Index', 'README', 'STYLES']) {
+    assert.match(body, new RegExp(page), `CONFIG.md must mention ${page} as treeview-excluded`);
+  }
+});

--- a/preseed/silverbullet/CONFIG.md
+++ b/preseed/silverbullet/CONFIG.md
@@ -8,4 +8,24 @@ Add custom config in the block below:
 -- Codeflare-managed config. Hand-edits survive but this page is
 -- overwritten on every container boot. See preseed/silverbullet/CONFIG.md
 -- in the codeflare repo to make changes that persist across releases.
+
+-- REQ-VAULT-008 AC7: treeview exclude patterns. The folders / pages
+-- listed below are hidden from the SB tree pane because they are
+-- either derived/agent-owned (graphify-out, Library), editor state
+-- (.silverbullet), or top-level preseed pages the user should not
+-- accidentally edit (CONFIG, Index, README, STYLES). The server-side
+-- /.fs filter (AC6) handles graphify-out at the response layer; this
+-- block is the parallel UI-side guard.
+config.set("plug.treeview", {
+  exclude = {
+    "Library/*",
+    "Repositories/*",
+    "graphify-out/*",
+    ".silverbullet/*",
+    "CONFIG",
+    "Index",
+    "README",
+    "STYLES",
+  },
+})
 ```

--- a/sdd/vault.md
+++ b/sdd/vault.md
@@ -245,7 +245,7 @@ Persistent Obsidian-style note vault: agent-written session captures plus user-c
 
 **Priority:** P0
 **Dependencies:** REQ-VAULT-005 (Worker proxy exposes vault editor), REQ-VAULT-001 (vault directory survives sessions), REQ-MEM-006 (Pro mode gating)
-**Verification:** Unit tests (DO `ensureVaultKey()` persistence + idempotency in `src/__tests__/container/index.test.ts`; Worker `/.config` merge in `src/__tests__/routes/vault.test.ts`; `cleanupSessionVaultCache` + `sweepOrphanVaultCaches` in `web-ui/src/__tests__/lib/vault-cache.test.ts`); structural tests (CONFIG.md treeview exclude in `host/__tests__/preseed-config-treeview.test.js`; SB bundle patches in `host/__tests__/silverbullet-bundle-patches.test.js`; Dockerfile fs-filter for graphify-out in `host/__tests__/silverbullet-fs-filter.test.js`); manual smoke (cold-start time under 5s on second session; IDB bytes are AES ciphertext; deleted-session IDB is gone).
-**Status:** Planned
+**Verification:** Unit tests (DO `ensureVaultKey()` persistence + idempotency in `src/__tests__/container/index.test.ts`; Worker `/.config` merge + boot-script injection + `/.fs` filter in `src/__tests__/routes/vault.test.ts`; `cleanupSessionVaultCache` + `sweepOrphanVaultCaches` in `web-ui/src/__tests__/lib/vault-cache.test.ts`; CONFIG.md treeview exclude in `host/__tests__/preseed-config-treeview.test.js`); manual smoke (cold-start time under 5s on second session; IDB bytes are AES ciphertext; deleted-session IDB is gone).
+**Status:** Partial
 
 ---

--- a/sdd/vault.md
+++ b/sdd/vault.md
@@ -219,3 +219,33 @@ Persistent Obsidian-style note vault: agent-written session captures plus user-c
 **Status:** Implemented
 
 ---
+
+## REQ-VAULT-008: Zero-UI vault encryption + cold-start payload reduction + per-session IDB lifecycle
+
+**Intent:** SilverBullet's IndexedDB caches every vault file as raw bytes. Three coupled improvements ship as one requirement: (a) the IDB cache is encrypted at rest with a per-session key generated and stored by the Container DO (no user passphrase prompt), (b) the cold-start payload is reduced (concurrency bumped, lazy attachments, server-side filter for derived output, treeview nav filtered), and (c) deleted sessions have their IDB cleaned up rather than lingering across browser sessions. The threat model is BitLocker-grade: defeats offline disk attacks (profile theft, backup leak, ransomware scan), does NOT defeat anyone with an authenticated browser tab. The key dies with `container.destroy()` so deletion is forward-secret.
+
+**Applies To:** User
+
+**Acceptance Criteria:**
+1. Container DO generates a 32-byte random `vaultKey` on first start, persists in `ctx.storage` under key `vaultKey`, and returns the same key on every subsequent read. The key is never rotated; it is wiped only when `container.destroy()` runs (session DELETE).
+2. The Worker `/api/vault/:sid/.config` proxy fetches the vault key via DO RPC and merges `{ vaultEncryptionKey: "<base64>", enableClientEncryption: true }` into the BootConfig JSON returned to SilverBullet.
+3. SilverBullet consumes `bootConfig.vaultEncryptionKey` and uses it as both the `encryptionKeyPart` in `deriveDbName` AND the encryption key for IndexedDB contents. No passphrase prompt is shown.
+4. The vendored SilverBullet bundle sets `syncConcurrency = 15` (default was 3) to accelerate the unavoidable first-sync.
+5. Files matching `Raw/Pasted/**` are not eagerly synced into IndexedDB on the bulk-sync path; SilverBullet falls through to the standard `readFile` path on user open, fetching attachments on demand.
+6. The vendored SilverBullet Go server filters `/.fs` listings to exclude `graphify-out/**` so derived output never reaches the browser.
+7. The preseed `CONFIG.md` declares a `treeview.exclude` block hiding `Library/**`, `Repositories/**`, the four top-level preseed pages (`CONFIG.md`, `Index.md`, `README.md`, `STYLES.md`), `.silverbullet/**`, and `graphify-out/**` from the navigation tree.
+8. The frontend invokes `cleanupSessionVaultCache(sessionId)` on session DELETE (not stop) -- deletes both `sb_files_<hash>` and `sb_data_<hash>` databases, unregisters the SilverBullet service worker registered at `/api/vault/<sid>/`, and removes the `localStorage["vault-session-<sid>"]` marker.
+9. On dashboard mount and on every session-list refresh, the frontend sweeps `localStorage["vault-session-<sid>"]` markers and nukes the IDB + marker for any session NOT present in the user's active sessions list (covers the case where the session was deleted from another device).
+
+**Constraints:**
+- Encryption protects against offline attacks ONLY. Anyone with an authenticated browser tab (or who can run JavaScript in the codeflare origin) can fetch the key from `/.config` and decrypt. The threat-model trade-off is documented in `documentation/decisions/README.md` AD-NN (TBD on land).
+- The vault key MUST NOT be rotated mid-session. Rotation would orphan all existing IDB ciphertext on the browser and force a fresh re-sync on every container restart, defeating the cold-start optimisation.
+- The vault key MUST be wiped on `container.destroy()`. Persistence of the key after deletion would let a recovered browser profile decrypt the orphaned IDB.
+- Per-session `:sid` MUST remain in the proxy URL to preserve the parallel-session isolation property (each session has its own IDB; cross-session reads/writes never collide).
+
+**Priority:** P0
+**Dependencies:** REQ-VAULT-005 (Worker proxy exposes vault editor), REQ-VAULT-001 (vault directory survives sessions), REQ-MEM-006 (Pro mode gating)
+**Verification:** Unit tests (DO `ensureVaultKey()` persistence + idempotency in `src/__tests__/container/index.test.ts`; Worker `/.config` merge in `src/__tests__/routes/vault.test.ts`; `cleanupSessionVaultCache` + `sweepOrphanVaultCaches` in `web-ui/src/__tests__/lib/vault-cache.test.ts`); structural tests (CONFIG.md treeview exclude in `host/__tests__/preseed-config-treeview.test.js`; SB bundle patches in `host/__tests__/silverbullet-bundle-patches.test.js`; Dockerfile fs-filter for graphify-out in `host/__tests__/silverbullet-fs-filter.test.js`); manual smoke (cold-start time under 5s on second session; IDB bytes are AES ciphertext; deleted-session IDB is gone).
+**Status:** Planned
+
+---

--- a/src/__tests__/container/index.test.ts
+++ b/src/__tests__/container/index.test.ts
@@ -235,7 +235,12 @@ describe('container DO class', () => {
       const instance = new ContainerClass(mockCtx as any, mockEnv);
       // Constructor blockConcurrencyWhile may have run by now; wait
       // for envVars to be settled so we know init finished.
-      await vi.waitFor(() => expect(instance.envVars).toBeDefined());
+      // Wait for the constructor's blockConcurrencyWhile body to reach
+      // the vaultKey restore -- once the storage.get('vaultKey') call
+      // lands in the mock, init is past the relevant restore branch.
+      await vi.waitFor(() =>
+        expect(mockStorage.get.mock.calls.some((c) => c[0] === 'vaultKey')).toBe(true),
+      );
 
       const key = await (instance as any).ensureVaultKey();
       expect(typeof key).toBe('string');
@@ -256,7 +261,12 @@ describe('container DO class', () => {
       });
 
       const instance = new ContainerClass(mockCtx as any, mockEnv);
-      await vi.waitFor(() => expect(instance.envVars).toBeDefined());
+      // Wait for the constructor's blockConcurrencyWhile body to reach
+      // the vaultKey restore -- once the storage.get('vaultKey') call
+      // lands in the mock, init is past the relevant restore branch.
+      await vi.waitFor(() =>
+        expect(mockStorage.get.mock.calls.some((c) => c[0] === 'vaultKey')).toBe(true),
+      );
 
       const first = await (instance as any).ensureVaultKey();
       const second = await (instance as any).ensureVaultKey();
@@ -283,7 +293,12 @@ describe('container DO class', () => {
       });
 
       const instance = new ContainerClass(mockCtx as any, mockEnv);
-      await vi.waitFor(() => expect(instance.envVars).toBeDefined());
+      // Wait for the constructor's blockConcurrencyWhile body to reach
+      // the vaultKey restore -- once the storage.get('vaultKey') call
+      // lands in the mock, init is past the relevant restore branch.
+      await vi.waitFor(() =>
+        expect(mockStorage.get.mock.calls.some((c) => c[0] === 'vaultKey')).toBe(true),
+      );
 
       const key = await (instance as any).ensureVaultKey();
       expect(key).toBe(PRIOR_KEY);

--- a/src/__tests__/container/index.test.ts
+++ b/src/__tests__/container/index.test.ts
@@ -217,6 +217,84 @@ describe('container DO class', () => {
 
   });
 
+  // REQ-VAULT-008 AC1: Container DO mints a per-session vault encryption
+  // key, persists it in ctx.storage, and returns the same value on
+  // every read until container.destroy() wipes storage. The key is
+  // injected by the Worker into SilverBullet's /.config response so
+  // SB encrypts IndexedDB without prompting the user.
+  describe('ensureVaultKey (REQ-VAULT-008 AC1)', () => {
+    it('generates a 32-byte vault key on first call and persists it', async () => {
+      // Fresh DO -- no key in storage. ensureVaultKey() must generate
+      // 32 random bytes, base64-encode them, persist under the
+      // `vaultKey` storage key, and return the encoded string.
+      mockStorage.get.mockImplementation(async (key: string) => {
+        if (key === 'vaultKey') return null;
+        return null;
+      });
+
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+      // Constructor blockConcurrencyWhile may have run by now; wait
+      // for envVars to be settled so we know init finished.
+      await vi.waitFor(() => expect(instance.envVars).toBeDefined());
+
+      const key = await (instance as any).ensureVaultKey();
+      expect(typeof key).toBe('string');
+      // base64 of 32 bytes = 44 chars (including trailing '=' padding).
+      expect(key).toMatch(/^[A-Za-z0-9+/]{43}=$/);
+
+      // Persistence: the storage layer must have been called with
+      // ('vaultKey', <key>). Find the last put call for this key.
+      const putCall = mockStorage.put.mock.calls.find((c) => c[0] === 'vaultKey');
+      expect(putCall).toBeDefined();
+      expect(putCall?.[1]).toBe(key);
+    });
+
+    it('returns the same key on every subsequent call without re-generating', async () => {
+      mockStorage.get.mockImplementation(async (key: string) => {
+        if (key === 'vaultKey') return null;
+        return null;
+      });
+
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+      await vi.waitFor(() => expect(instance.envVars).toBeDefined());
+
+      const first = await (instance as any).ensureVaultKey();
+      const second = await (instance as any).ensureVaultKey();
+      const third = await (instance as any).ensureVaultKey();
+
+      expect(first).toBe(second);
+      expect(second).toBe(third);
+
+      // Only ONE write to storage; subsequent calls must hit the
+      // in-memory cache.
+      const puts = mockStorage.put.mock.calls.filter((c) => c[0] === 'vaultKey');
+      expect(puts.length).toBe(1);
+    });
+
+    it('restores an existing key from storage instead of generating a new one (DO wake)', async () => {
+      // Simulates a DO that previously generated a key, hibernated,
+      // and is now waking up. Storage returns the previously persisted
+      // value; ensureVaultKey() must return it untouched and MUST NOT
+      // write a new value to storage.
+      const PRIOR_KEY = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+      mockStorage.get.mockImplementation(async (key: string) => {
+        if (key === 'vaultKey') return PRIOR_KEY;
+        return null;
+      });
+
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+      await vi.waitFor(() => expect(instance.envVars).toBeDefined());
+
+      const key = await (instance as any).ensureVaultKey();
+      expect(key).toBe(PRIOR_KEY);
+
+      // No new put for vaultKey on this run -- the restore branch must
+      // not regenerate.
+      const newPuts = mockStorage.put.mock.calls.filter((c) => c[0] === 'vaultKey');
+      expect(newPuts.length).toBe(0);
+    });
+  });
+
   describe('internal route dispatch', () => {
     it('dispatches POST /_internal/setBucketName to handler', async () => {
       // No existing bucket - storage returns null for all keys

--- a/src/__tests__/routes/vault.test.ts
+++ b/src/__tests__/routes/vault.test.ts
@@ -6,6 +6,7 @@ import {
   VAULT_NOOP_SERVICE_WORKER_JS,
   injectVaultEncryptionConfig,
   injectVaultBootScript,
+  filterVaultFsListing,
 } from '../../routes/vault';
 
 /**
@@ -351,6 +352,52 @@ describe('validateVaultRoute', () => {
         syncConcurrency: 15,
         lazyPathPrefixes: [],
       })).toThrow();
+    });
+  });
+
+  describe('filterVaultFsListing (REQ-VAULT-008 AC6)', () => {
+    it('removes entries with names starting with graphify-out/', () => {
+      const body = JSON.stringify([
+        { name: 'Notes/foo.md', size: 10 },
+        { name: 'graphify-out/graph.json', size: 5000 },
+        { name: 'graphify-out/vault-graph.html', size: 200000 },
+        { name: 'Raw/Sessions/x.md', size: 100 },
+      ]);
+      const filtered = JSON.parse(filterVaultFsListing(body));
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((e: { name: string }) => e.name)).toEqual([
+        'Notes/foo.md',
+        'Raw/Sessions/x.md',
+      ]);
+    });
+
+    it('returns input unchanged if body is not a JSON array', () => {
+      const invalid = '{"not":"array"}';
+      expect(filterVaultFsListing(invalid)).toBe(invalid);
+    });
+
+    it('returns input unchanged on parse error', () => {
+      const garbage = 'not json at all';
+      expect(filterVaultFsListing(garbage)).toBe(garbage);
+    });
+
+    it('handles entries with no graphify-out prefix as no-op', () => {
+      const body = JSON.stringify([{ name: 'a.md' }, { name: 'b.md' }]);
+      const out = JSON.parse(filterVaultFsListing(body));
+      expect(out).toHaveLength(2);
+    });
+
+    it('also filters nested graphify-out paths (e.g. Raw/graphify-out should NOT match — only top-level)', () => {
+      const body = JSON.stringify([
+        { name: 'graphify-out/x.json' },
+        { name: 'Notes/graphify-out-notes.md' },
+        { name: 'Notes/sub/file.md' },
+      ]);
+      const out = JSON.parse(filterVaultFsListing(body));
+      expect(out.map((e: { name: string }) => e.name)).toEqual([
+        'Notes/graphify-out-notes.md',
+        'Notes/sub/file.md',
+      ]);
     });
   });
 

--- a/src/__tests__/routes/vault.test.ts
+++ b/src/__tests__/routes/vault.test.ts
@@ -5,6 +5,7 @@ import {
   isServiceWorkerRegistration,
   VAULT_NOOP_SERVICE_WORKER_JS,
   injectVaultEncryptionConfig,
+  injectVaultBootScript,
 } from '../../routes/vault';
 
 /**
@@ -288,6 +289,68 @@ describe('validateVaultRoute', () => {
 
     it('throws if key is empty (vaultEncryptionKey must be a non-empty string)', () => {
       expect(() => injectVaultEncryptionConfig('{}', '')).toThrow();
+    });
+  });
+
+  describe('injectVaultBootScript (REQ-VAULT-008 AC3+4+5)', () => {
+    it('injects a <script> with vaultEncryptionKey, syncConcurrency, and lazyPathPrefixes before </head>', () => {
+      const html = '<!DOCTYPE html><html><head><title>SB</title></head><body></body></html>';
+      const out = injectVaultBootScript(html, {
+        vaultEncryptionKey: 'k1',
+        syncConcurrency: 15,
+        lazyPathPrefixes: ['Raw/Pasted/'],
+      });
+      expect(out).toContain('window.__codeflareVaultBoot');
+      expect(out).toContain('"k1"');
+      expect(out).toContain('"syncConcurrency":15');
+      expect(out).toContain('"Raw/Pasted/"');
+      expect(out.indexOf('window.__codeflareVaultBoot')).toBeLessThan(out.indexOf('</head>'));
+    });
+
+    it('escapes </script> in injected payload to prevent HTML break-out (XSS guard)', () => {
+      const html = '<html><head></head><body></body></html>';
+      const out = injectVaultBootScript(html, {
+        vaultEncryptionKey: 'safe-key',
+        syncConcurrency: 15,
+        lazyPathPrefixes: ['</script><script>alert(1)</script>'],
+      });
+      expect(out).not.toContain('</script><script>alert(1)');
+      expect(out).toContain('<\\/script>');
+    });
+
+    it('is idempotent — re-injecting on already-patched HTML produces single block', () => {
+      const html = '<html><head></head><body></body></html>';
+      const once = injectVaultBootScript(html, {
+        vaultEncryptionKey: 'k',
+        syncConcurrency: 15,
+        lazyPathPrefixes: [],
+      });
+      const twice = injectVaultBootScript(once, {
+        vaultEncryptionKey: 'k',
+        syncConcurrency: 15,
+        lazyPathPrefixes: [],
+      });
+      const occurrences = (twice.match(/window\.__codeflareVaultBoot/g) || []).length;
+      expect(occurrences).toBe(1);
+    });
+
+    it('returns input unchanged when no </head> tag exists (fail-safe, not error)', () => {
+      const html = '<html><body>no head</body></html>';
+      const out = injectVaultBootScript(html, {
+        vaultEncryptionKey: 'k',
+        syncConcurrency: 15,
+        lazyPathPrefixes: [],
+      });
+      expect(out).toBe(html);
+    });
+
+    it('throws if vaultEncryptionKey is empty', () => {
+      const html = '<html><head></head><body></body></html>';
+      expect(() => injectVaultBootScript(html, {
+        vaultEncryptionKey: '',
+        syncConcurrency: 15,
+        lazyPathPrefixes: [],
+      })).toThrow();
     });
   });
 

--- a/src/__tests__/routes/vault.test.ts
+++ b/src/__tests__/routes/vault.test.ts
@@ -4,6 +4,7 @@ import {
   maybeSynthesizeCsrfHeader,
   isServiceWorkerRegistration,
   VAULT_NOOP_SERVICE_WORKER_JS,
+  injectVaultEncryptionConfig,
 } from '../../routes/vault';
 
 /**
@@ -253,6 +254,40 @@ describe('validateVaultRoute', () => {
       expect(VAULT_NOOP_SERVICE_WORKER_JS).toContain('clients.claim');
       expect(VAULT_NOOP_SERVICE_WORKER_JS).toContain('install');
       expect(VAULT_NOOP_SERVICE_WORKER_JS).toContain('activate');
+    });
+  });
+
+  describe('injectVaultEncryptionConfig (REQ-VAULT-008 AC2)', () => {
+    it('adds vaultEncryptionKey and enableClientEncryption=true to a JSON BootConfig body', () => {
+      const original = JSON.stringify({ spaceFolderPath: '/Vault', readOnly: false });
+      const result = injectVaultEncryptionConfig(original, 'AAAA-base64-key-AAAA');
+      const parsed = JSON.parse(result);
+      expect(parsed.vaultEncryptionKey).toBe('AAAA-base64-key-AAAA');
+      expect(parsed.enableClientEncryption).toBe(true);
+      expect(parsed.spaceFolderPath).toBe('/Vault');
+      expect(parsed.readOnly).toBe(false);
+    });
+
+    it('does not mutate the input string and returns valid JSON', () => {
+      const original = '{"a":1}';
+      const out = injectVaultEncryptionConfig(original, 'k');
+      expect(original).toBe('{"a":1}');
+      expect(() => JSON.parse(out)).not.toThrow();
+    });
+
+    it('overrides any pre-existing vaultEncryptionKey from upstream (Worker is canonical)', () => {
+      const original = JSON.stringify({ vaultEncryptionKey: 'stale-or-empty', enableClientEncryption: false });
+      const parsed = JSON.parse(injectVaultEncryptionConfig(original, 'fresh-key'));
+      expect(parsed.vaultEncryptionKey).toBe('fresh-key');
+      expect(parsed.enableClientEncryption).toBe(true);
+    });
+
+    it('throws if input body is not valid JSON (fail loud, do not silently break SB boot)', () => {
+      expect(() => injectVaultEncryptionConfig('not json', 'k')).toThrow();
+    });
+
+    it('throws if key is empty (vaultEncryptionKey must be a non-empty string)', () => {
+      expect(() => injectVaultEncryptionConfig('{}', '')).toThrow();
     });
   });
 

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -106,6 +106,18 @@ export class container extends Container<Env> {
   private _encryptionKey: string | null = null;
   private _sessionMode: string = 'default';
   private _containerAuthToken: string | null = null;
+  /**
+   * Per-session vault encryption key (REQ-VAULT-008 AC1). 32 random
+   * bytes, base64-encoded. Generated on first ensureVaultKey() call,
+   * persisted in ctx.storage under 'vaultKey', restored on DO wake.
+   * Wiped by destroy() so deletion is forward-secret: a recovered
+   * browser profile after session DELETE cannot decrypt the orphaned
+   * IndexedDB ciphertext because the only key that ever existed lived
+   * in this DO's storage. The Worker /.config proxy reads this via
+   * RPC and injects it into SilverBullet's BootConfig so the browser
+   * encrypts IDB without prompting the user for a passphrase.
+   */
+  private _vaultKey: string | null = null;
   private _sessionId: string | null = null;
   private _userEmail: string | null = null;
   /**
@@ -157,6 +169,11 @@ export class container extends Container<Env> {
       // `{"error":"Unauthorized"}` on every proxied request until the user
       // recreates the session manually.
       this._containerAuthToken = await this.ctx.storage.get<string>('containerAuthToken') || null;
+      // REQ-VAULT-008 AC1: restore the per-session vault key on wake.
+      // Generation is lazy (ensureVaultKey()); restore is eager so the
+      // Worker /.config proxy can hand it out without ever waiting for
+      // a write on the request path.
+      this._vaultKey = await this.ctx.storage.get<string>('vaultKey') || null;
 
       // Restore user-configured idle timeout (survives DO resets).
       // Storage key remains 'sleepAfter' for backwards compat with existing sessions.
@@ -229,6 +246,58 @@ export class container extends Container<Env> {
     }
 
     this.envVars = buildEnvVars(this.envState, this.env);
+  }
+
+  /**
+   * REQ-VAULT-008 AC1: Return the per-session vault encryption key,
+   * generating + persisting on the first call. The key is 32 random
+   * bytes, base64-encoded so SilverBullet can use it as a string token
+   * in BootConfig. Repeated calls return the cached value -- no extra
+   * storage writes.
+   *
+   * The key is wiped only on container.destroy(); a DO hibernation +
+   * wake cycle restores the same key from ctx.storage (see the
+   * blockConcurrencyWhile restore branch). This is the guarantee that
+   * deletion is forward-secret: once destroy() runs, the key is gone
+   * everywhere and the browser's IDB ciphertext is unrecoverable.
+   *
+   * Worker callers reach this method via a DO RPC from the /.config
+   * proxy handler (REQ-VAULT-008 AC2).
+   */
+  async ensureVaultKey(): Promise<string> {
+    if (this._vaultKey) return this._vaultKey;
+
+    // No cached key -- mint one. crypto.getRandomValues is the
+    // WebCrypto entry point available on the Workers runtime.
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    // Convert to base64 without Buffer (not available on Workers).
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    const key = btoa(binary);
+    this._vaultKey = key;
+
+    // Persist so the next DO wake's restore branch finds the same
+    // value. Promise.resolve wrap matches the containerAuthToken
+    // pattern: production returns a real Promise but some test mocks
+    // return undefined synchronously, so `.catch` on the bare call
+    // would NPE without the wrap.
+    const putPromise = Promise.resolve(
+      this.ctx.storage.put('vaultKey', key),
+    ).catch((err) => {
+      this.logger.warn('Failed to persist vaultKey', { error: toErrorMessage(err) });
+    });
+    if (typeof this.ctx.waitUntil === 'function') {
+      this.ctx.waitUntil(putPromise);
+    } else {
+      // Test mocks without waitUntil: await the put inline so the
+      // assertion against mockStorage.put can observe the call before
+      // the test moves on.
+      await putPromise;
+    }
+    return key;
   }
 
   /** Override fetch to handle internal routes via map-based dispatch. */
@@ -468,11 +537,17 @@ export class container extends Container<Env> {
       // old one would let an unrelated request out of a previous lifecycle
       // authenticate against the new container.
       await this.ctx.storage.delete('containerAuthToken');
+      // REQ-VAULT-008 AC1: wipe the vault key so deletion is
+      // forward-secret. The browser's IDB ciphertext (if not yet
+      // cleaned by the frontend lifecycle hook) becomes permanently
+      // unrecoverable once this delete commits.
+      await this.ctx.storage.delete('vaultKey');
       this._bucketName = null;
       this._sessionId = null;
       this._r2AccessKeyId = null;
       this._r2SecretAccessKey = null;
       this._containerAuthToken = null;
+      this._vaultKey = null;
       this._openaiApiKey = null;
       this._geminiApiKey = null;
       this._githubToken = null;

--- a/src/routes/vault.ts
+++ b/src/routes/vault.ts
@@ -180,6 +180,67 @@ export function injectVaultEncryptionConfig(bootConfigJson: string, vaultEncrypt
   return JSON.stringify(merged);
 }
 
+/**
+ * Inject a SilverBullet bootstrap configuration script into the shell
+ * HTML. The script lands BEFORE `</head>` and exposes a global
+ * `window.__codeflareVaultBoot` object that the SilverBullet client
+ * patch reads on startup to:
+ *
+ *   - skip the encryption passphrase prompt and use `vaultEncryptionKey`
+ *     directly as the IDB encryption key (AC3),
+ *   - raise initial-sync concurrency from the default 3 to a higher
+ *     value (`syncConcurrency`, AC4),
+ *   - exclude `lazyPathPrefixes` from the bulk-sync set; SB lazy-fetches
+ *     these via the standard readFile path on open (AC5).
+ *
+ * Why this lives in the Worker and not in the SB binary:
+ *   SilverBullet 2.8 ships as a Deno-compiled single binary (see
+ *   Dockerfile L116-131); patching its bundled client.js at build time
+ *   would require either a source rebuild (Deno toolchain in the image,
+ *   ~400MB) or post-link binary surgery. Runtime injection through the
+ *   already-text-rewriting Worker proxy (see the `<base href>` rewrite
+ *   below) is the lowest-overhead option and keeps the SB binary
+ *   immutable.
+ *
+ * Security:
+ *   - Throws on empty `vaultEncryptionKey` so a misconfigured DO key
+ *     never silently degrades to plaintext IDB.
+ *   - Escapes `</script>` sequences in any string field to prevent HTML
+ *     break-out via crafted lazyPathPrefixes.
+ *   - Idempotent: re-injection over already-patched HTML is a no-op,
+ *     so a reload that lands on a Worker-cached shell does not stack
+ *     boot scripts.
+ *
+ * Returns the original HTML unchanged if `</head>` is not present
+ * (defensive fail-safe, not an error: the SB error pages and 404 HTML
+ * do not have a `<head>` and must not be mutilated).
+ *
+ * Implements REQ-VAULT-008 AC3+4+5.
+ */
+export interface VaultBootConfig {
+  vaultEncryptionKey: string;
+  syncConcurrency: number;
+  lazyPathPrefixes: string[];
+}
+
+const VAULT_BOOT_MARKER = 'window.__codeflareVaultBoot';
+
+export function injectVaultBootScript(html: string, config: VaultBootConfig): string {
+  if (!config.vaultEncryptionKey) {
+    throw new Error('injectVaultBootScript: vaultEncryptionKey must be non-empty');
+  }
+  if (html.includes(VAULT_BOOT_MARKER)) {
+    return html;
+  }
+  if (!html.includes('</head>')) {
+    return html;
+  }
+  // Escape </ to <\/ to defang any literal </script> inside the payload.
+  const serialised = JSON.stringify(config).replace(/<\//g, '<\\/');
+  const tag = `<script>${VAULT_BOOT_MARKER} = ${serialised};</script>`;
+  return html.replace('</head>', `${tag}</head>`);
+}
+
 export function validateVaultRoute(request: Request): VaultRouteResult {
   const url = new URL(request.url);
   const match = url.pathname.match(/^\/api\/vault\/([^/]+)(\/.*)$/);
@@ -494,10 +555,34 @@ export async function handleVaultRequest(
     if (contentType.includes('text/html')) {
       const prefix = `/api/vault/${sessionId}`;
       const body = await response.text();
-      const rewritten = body.replace(
+      let rewritten = body.replace(
         /<base\s+href="\/"\s*\/?>/gi,
         `<base href="${prefix}/" />`,
       );
+
+      // REQ-VAULT-008 AC3+4+5: inject the per-session vault boot config
+      // into the shell HTML so the SB client patch can pick up the
+      // encryption key, raised sync concurrency, and lazy path filters
+      // without a passphrase prompt. Only fires on the 200 shell paths
+      // where SB will actually bootstrap a client; error pages and
+      // non-shell text/html responses are left untouched by the
+      // VAULT_BOOT_MARKER idempotency guard inside the helper.
+      const isShellPath =
+        remainingPath === '/' || remainingPath === '/index.html';
+      if (response.status === 200 && isShellPath) {
+        try {
+          const vaultEncryptionKey = await (container as unknown as {
+            ensureVaultKey: () => Promise<string>;
+          }).ensureVaultKey();
+          rewritten = injectVaultBootScript(rewritten, {
+            vaultEncryptionKey,
+            syncConcurrency: 15,
+            lazyPathPrefixes: ['Raw/Pasted/'],
+          });
+        } catch (err) {
+          logger.warn('vault boot-script injection skipped', { error: toErrorMessage(err) });
+        }
+      }
       // Only warn on the shell paths where the rewrite is load-bearing
       // (`/` and `/index.html`). On any other text/html path - error
       // pages, 404 HTML, future plug-served HTML - a no-op rewrite is

--- a/src/routes/vault.ts
+++ b/src/routes/vault.ts
@@ -642,8 +642,6 @@ export async function handleVaultRequest(
       // pages, 404 HTML, future plug-served HTML - a no-op rewrite is
       // expected, not a signal. Logging unconditionally fills prod logs
       // with false positives on every non-shell error response.
-      const isShellPath =
-        remainingPath === '/' || remainingPath === '/index.html';
       if (rewritten === body && response.status === 200 && isShellPath) {
         logger.warn('vault base-href rewrite no-op', {
           pathname: vaultUrl.pathname,

--- a/src/routes/vault.ts
+++ b/src/routes/vault.ts
@@ -241,6 +241,40 @@ export function injectVaultBootScript(html: string, config: VaultBootConfig): st
   return html.replace('</head>', `${tag}</head>`);
 }
 
+/**
+ * Filter a SilverBullet `/.fs` JSON listing response, removing entries
+ * whose `name` starts with `graphify-out/`. The vault contains agent-
+ * derived graph artifacts (sometimes multi-MB graph.html) that must
+ * not appear in the SB UI's space listing — they would clutter the
+ * tree, slow initial sync, and confuse the user.
+ *
+ * Server-side filter (here) is the canonical enforcement point because
+ * the SB binary embeds its own listing logic and we cannot reach in
+ * to add an exclude pattern. Treeview UI exclusion (AC7) is a parallel
+ * surface guard for the editor's tree pane.
+ *
+ * Fail-safe: returns the input string unchanged on any parse error or
+ * if the body is not a JSON array — never breaks a 200 response just
+ * because the upstream shape drifted.
+ *
+ * Implements REQ-VAULT-008 AC6.
+ */
+export function filterVaultFsListing(body: string): string {
+  try {
+    const parsed = JSON.parse(body);
+    if (!Array.isArray(parsed)) return body;
+    const filtered = parsed.filter((entry) => {
+      if (entry == null || typeof entry !== 'object') return true;
+      const name = (entry as { name?: unknown }).name;
+      if (typeof name !== 'string') return true;
+      return !name.startsWith('graphify-out/');
+    });
+    return JSON.stringify(filtered);
+  } catch {
+    return body;
+  }
+}
+
 export function validateVaultRoute(request: Request): VaultRouteResult {
   const url = new URL(request.url);
   const match = url.pathname.match(/^\/api\/vault\/([^/]+)(\/.*)$/);
@@ -550,6 +584,26 @@ export async function handleVaultRequest(
           code: 'VAULT_CONFIG_INJECT_FAILED',
         }), { status: 500, headers: jsonHeaders });
       }
+    }
+
+    // REQ-VAULT-008 AC6: strip graphify-out/** entries from SB's space
+    // listing. SB 2.x serves the listing as `index.json` (legacy) and
+    // `/.fs/` (newer); both endpoints return a JSON array of file
+    // metadata. The filter is a no-op for any other JSON shape.
+    if (
+      response.ok &&
+      (remainingPath === '/index.json' || remainingPath === '/.fs' || remainingPath === '/.fs/')
+    ) {
+      const body = await response.text();
+      const filtered = filterVaultFsListing(body);
+      const headers = new Headers(response.headers);
+      headers.delete('content-length');
+      headers.delete('content-encoding');
+      return new Response(filtered, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
     }
 
     if (contentType.includes('text/html')) {

--- a/src/routes/vault.ts
+++ b/src/routes/vault.ts
@@ -153,6 +153,33 @@ export function isServiceWorkerRegistration(request: Request, remainingPath: str
   return true;
 }
 
+/**
+ * Inject the per-session vault encryption key into a SilverBullet
+ * BootConfig JSON body. The Worker is the canonical source of the key
+ * (it lives in the container DO's ctx.storage and is RPC-fetched at
+ * request time); any value the container might emit for this field is
+ * stale or empty and is overridden here.
+ *
+ * Fail-loud contract: throws if `bootConfigJson` is not parseable JSON
+ * or if `vaultEncryptionKey` is empty. A silently-broken /.config
+ * response would still render the SB shell but client-side encryption
+ * would fall back to plaintext IDB - a silent data-at-rest regression.
+ *
+ * Implements REQ-VAULT-008 AC2.
+ */
+export function injectVaultEncryptionConfig(bootConfigJson: string, vaultEncryptionKey: string): string {
+  if (!vaultEncryptionKey) {
+    throw new Error('injectVaultEncryptionConfig: vaultEncryptionKey must be non-empty');
+  }
+  const parsed = JSON.parse(bootConfigJson);
+  const merged = {
+    ...parsed,
+    vaultEncryptionKey,
+    enableClientEncryption: true,
+  };
+  return JSON.stringify(merged);
+}
+
 export function validateVaultRoute(request: Request): VaultRouteResult {
   const url = new URL(request.url);
   const match = url.pathname.match(/^\/api\/vault\/([^/]+)(\/.*)$/);
@@ -429,6 +456,41 @@ export async function handleVaultRequest(
     // href, added attribute, etc.) surfaces as a logged signal instead
     // of a silent white-screen regression.
     const contentType = response.headers.get('content-type') ?? '';
+
+    // REQ-VAULT-008 AC2: inject the per-session vault encryption key into
+    // SilverBullet's BootConfig response. The DO is the canonical key
+    // source - SB sees the key through this same authenticated channel
+    // and uses it as the IDB encryption key without ever showing the
+    // user a passphrase prompt. We treat any 2xx /.config response as
+    // injection-eligible regardless of upstream content-type because
+    // SB's Go server has shipped both application/json and text/plain
+    // for this endpoint across versions; the JSON.parse inside
+    // injectVaultEncryptionConfig fails loud if the body is not JSON.
+    if (remainingPath === '/.config' && response.ok) {
+      try {
+        const vaultEncryptionKey = await (container as unknown as {
+          ensureVaultKey: () => Promise<string>;
+        }).ensureVaultKey();
+        const body = await response.text();
+        const rewritten = injectVaultEncryptionConfig(body, vaultEncryptionKey);
+        const headers = new Headers(response.headers);
+        headers.delete('content-length');
+        headers.delete('content-encoding');
+        headers.set('content-type', 'application/json');
+        return new Response(rewritten, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      } catch (err) {
+        logger.error('vault /.config injection failed', toError(err));
+        return new Response(JSON.stringify({
+          error: 'Vault config injection failed',
+          code: 'VAULT_CONFIG_INJECT_FAILED',
+        }), { status: 500, headers: jsonHeaders });
+      }
+    }
+
     if (contentType.includes('text/html')) {
       const prefix = `/api/vault/${sessionId}`;
       const body = await response.text();

--- a/web-ui/src/__tests__/lib/vault-cache.test.ts
+++ b/web-ui/src/__tests__/lib/vault-cache.test.ts
@@ -1,0 +1,171 @@
+// REQ-VAULT-008 AC8+AC9: cleanupSessionVaultCache(sid) and
+// sweepOrphanVaultCaches(activeSessionIds) clean up the per-session
+// SilverBullet IndexedDB databases on session DELETE and on dashboard
+// mount respectively. These are pure functions over IDB + localStorage
+// + service-worker APIs; the tests stub each surface with vi.fn().
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { cleanupSessionVaultCache, sweepOrphanVaultCaches } from '../../lib/vault-cache';
+
+type DbInfo = { name: string };
+
+function installFakeIndexedDB(initialDbs: DbInfo[]) {
+  const deleted: string[] = [];
+  const fake = {
+    databases: vi.fn(async () => initialDbs.slice()),
+    deleteDatabase: vi.fn((name: string) => {
+      deleted.push(name);
+      return { onsuccess: null, onerror: null, onblocked: null };
+    }),
+  };
+  (globalThis as unknown as { indexedDB: typeof fake }).indexedDB = fake;
+  return { fake, deleted };
+}
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  const fake = {
+    getItem: vi.fn((k: string) => store.get(k) ?? null),
+    setItem: vi.fn((k: string, v: string) => { store.set(k, v); }),
+    removeItem: vi.fn((k: string) => { store.delete(k); }),
+    key: vi.fn((i: number) => Array.from(store.keys())[i] ?? null),
+    get length() { return store.size; },
+    clear: vi.fn(() => store.clear()),
+  };
+  (globalThis as unknown as { localStorage: typeof fake }).localStorage = fake;
+  return { fake, store };
+}
+
+function installFakeServiceWorker() {
+  const unregistered: string[] = [];
+  const registrations: { scope: string; unregister: () => Promise<boolean> }[] = [];
+  const sw = {
+    getRegistrations: vi.fn(async () => registrations),
+    getRegistration: vi.fn(async (scope?: string) => {
+      const reg = registrations.find((r) => !scope || r.scope.includes(scope));
+      return reg;
+    }),
+  };
+  (globalThis as unknown as { navigator: { serviceWorker: typeof sw } }).navigator = { serviceWorker: sw };
+  return { sw, registrations, unregistered };
+}
+
+describe('cleanupSessionVaultCache (REQ-VAULT-008 AC8)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    delete (globalThis as { navigator?: unknown }).navigator;
+  });
+
+  it('deletes IDBs whose names contain the session id', async () => {
+    const sid = 'abcdef12';
+    const { fake } = installFakeIndexedDB([
+      { name: `sb_files_${sid}_hash1` },
+      { name: `sb_data_${sid}_hash1` },
+      { name: 'sb_files_otherid_hash2' },
+      { name: 'unrelated-db' },
+    ]);
+    installFakeLocalStorage();
+    installFakeServiceWorker();
+    await cleanupSessionVaultCache(sid);
+    const deletedNames = fake.deleteDatabase.mock.calls.map((c) => c[0]);
+    expect(deletedNames).toContain(`sb_files_${sid}_hash1`);
+    expect(deletedNames).toContain(`sb_data_${sid}_hash1`);
+    expect(deletedNames).not.toContain('sb_files_otherid_hash2');
+    expect(deletedNames).not.toContain('unrelated-db');
+  });
+
+  it('removes the localStorage vault-session-<sid> marker', async () => {
+    const sid = 'abcdef12';
+    installFakeIndexedDB([]);
+    const { fake, store } = installFakeLocalStorage();
+    store.set(`vault-session-${sid}`, '1');
+    store.set('vault-session-other', '1');
+    installFakeServiceWorker();
+    await cleanupSessionVaultCache(sid);
+    expect(fake.removeItem).toHaveBeenCalledWith(`vault-session-${sid}`);
+    expect(fake.removeItem).not.toHaveBeenCalledWith('vault-session-other');
+  });
+
+  it('unregisters service worker scoped to the session id', async () => {
+    const sid = 'abcdef12';
+    installFakeIndexedDB([]);
+    installFakeLocalStorage();
+    const { registrations } = installFakeServiceWorker();
+    const unregisterSpy = vi.fn(async () => true);
+    registrations.push({ scope: `https://codeflare.ch/api/vault/${sid}/`, unregister: unregisterSpy });
+    registrations.push({ scope: `https://codeflare.ch/api/vault/other/`, unregister: vi.fn(async () => true) });
+    await cleanupSessionVaultCache(sid);
+    expect(unregisterSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw if indexedDB.databases() rejects', async () => {
+    const sid = 'abcdef12';
+    (globalThis as unknown as { indexedDB: { databases: () => Promise<never>; deleteDatabase: (n: string) => void } }).indexedDB = {
+      databases: () => Promise.reject(new Error('not supported')),
+      deleteDatabase: vi.fn(),
+    };
+    installFakeLocalStorage();
+    installFakeServiceWorker();
+    await expect(cleanupSessionVaultCache(sid)).resolves.toBeUndefined();
+  });
+
+  it('does not throw if globals are missing (SSR / test pre-mount safety)', async () => {
+    await expect(cleanupSessionVaultCache('abcdef12')).resolves.toBeUndefined();
+  });
+});
+
+describe('sweepOrphanVaultCaches (REQ-VAULT-008 AC9)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    delete (globalThis as { navigator?: unknown }).navigator;
+  });
+
+  it('nukes IDBs whose sid is not in the active list', async () => {
+    const { fake } = installFakeIndexedDB([
+      { name: 'sb_files_active1_hash' },
+      { name: 'sb_data_active1_hash' },
+      { name: 'sb_files_orphan_hash' },
+      { name: 'sb_data_orphan_hash' },
+    ]);
+    const { store } = installFakeLocalStorage();
+    store.set('vault-session-active1', '1');
+    store.set('vault-session-orphan', '1');
+    installFakeServiceWorker();
+
+    await sweepOrphanVaultCaches(['active1']);
+    const deletedNames = fake.deleteDatabase.mock.calls.map((c) => c[0]);
+    expect(deletedNames).toContain('sb_files_orphan_hash');
+    expect(deletedNames).toContain('sb_data_orphan_hash');
+    expect(deletedNames).not.toContain('sb_files_active1_hash');
+    expect(deletedNames).not.toContain('sb_data_active1_hash');
+  });
+
+  it('is a no-op when all sessions are active', async () => {
+    const { fake } = installFakeIndexedDB([
+      { name: 'sb_files_a_h' },
+      { name: 'sb_data_a_h' },
+    ]);
+    const { store } = installFakeLocalStorage();
+    store.set('vault-session-a', '1');
+    installFakeServiceWorker();
+    await sweepOrphanVaultCaches(['a']);
+    expect(fake.deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('removes orphan localStorage markers even if no IDB matches', async () => {
+    installFakeIndexedDB([]);
+    const { fake, store } = installFakeLocalStorage();
+    store.set('vault-session-orphan', '1');
+    installFakeServiceWorker();
+    await sweepOrphanVaultCaches([]);
+    expect(fake.removeItem).toHaveBeenCalledWith('vault-session-orphan');
+  });
+});

--- a/web-ui/src/components/Dashboard.tsx
+++ b/web-ui/src/components/Dashboard.tsx
@@ -17,6 +17,7 @@ import ScrambleText from './ScrambleText';
 import KittScanner from './KittScanner';
 import DashboardCard from './TipsRotator';
 import { sessionStore, isAtUsageQuota } from '../stores/session';
+import { sweepOrphanVaultCaches } from '../lib/vault-cache';
 import UsageInlineBadge from './UsageInlineBadge';
 import '../styles/dashboard.css';
 
@@ -50,6 +51,15 @@ const Dashboard: Component<DashboardProps> = (props) => {
   onMount(() => {
     sessionStore.startR2Polling();
     storageStore.fetchStats();
+
+    // REQ-VAULT-008 AC9: sweep orphan SilverBullet IDB caches whose
+    // sid is not in the user's current session list. Catches the case
+    // where a session was deleted via API in another tab or after a
+    // browser crash before cleanupSessionVaultCache could run.
+    const activeIds = props.sessions.map((s) => s.id);
+    void sweepOrphanVaultCaches(activeIds).catch(() => {
+      // Best-effort; never block dashboard mount on cache sweep.
+    });
 
     // User menu close is handled by the Portal overlay onClick — no document
     // mousedown listener needed. Document mousedown fires before click on mobile,

--- a/web-ui/src/lib/vault-cache.ts
+++ b/web-ui/src/lib/vault-cache.ts
@@ -168,4 +168,3 @@ export async function sweepOrphanVaultCaches(activeSessionIds: string[]): Promis
   }
 }
 
-export const VAULT_SESSION_MARKER_PREFIX = VAULT_MARKER_PREFIX;

--- a/web-ui/src/lib/vault-cache.ts
+++ b/web-ui/src/lib/vault-cache.ts
@@ -1,0 +1,171 @@
+// REQ-VAULT-008 AC8+AC9: per-session SilverBullet IDB lifecycle.
+//
+// SilverBullet maintains two IDBs per (spaceFolderPath, baseURI,
+// encryptionKeyPart) tuple: `sb_files_<hash>` and `sb_data_<hash>`.
+// The hash is keyed on the per-session vault key (REQ-VAULT-008 AC1),
+// so a destroyed session leaves orphan IDBs that never get reused.
+// Without cleanup, IndexedDB usage grows monotonically across the
+// session lifecycle and the user eventually hits the per-origin quota.
+//
+// Cleanup happens at two surfaces:
+//
+//   - cleanupSessionVaultCache(sid): called from deleteSession() to
+//     nuke any sb_files_* / sb_data_* DB whose name contains the
+//     session id, drop the vault-session-<sid> marker, and unregister
+//     the SW scoped to /api/vault/<sid>/.
+//   - sweepOrphanVaultCaches(activeSessionIds): called on Dashboard
+//     mount. For every vault-session-<sid> marker in localStorage,
+//     if the sid is not in activeSessionIds, treat it as orphan and
+//     run the same cleanup. Handles the case where the user deleted
+//     a session via API in another tab or after a browser crash.
+//
+// All operations are fail-safe — a missing global (SSR, fresh tab)
+// or rejected IDB query is swallowed silently because cleanup is
+// best-effort and must never block the delete UI or dashboard mount.
+
+const VAULT_MARKER_PREFIX = 'vault-session-';
+
+function getIDB(): IDBFactory | null {
+  try {
+    return (globalThis as unknown as { indexedDB?: IDBFactory }).indexedDB ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getLS(): Storage | null {
+  try {
+    return (globalThis as unknown as { localStorage?: Storage }).localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getSW(): ServiceWorkerContainer | null {
+  try {
+    return (globalThis as unknown as { navigator?: { serviceWorker?: ServiceWorkerContainer } })
+      .navigator?.serviceWorker ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function listDatabaseNames(idb: IDBFactory): Promise<string[]> {
+  try {
+    const dbs = await (idb as unknown as { databases?: () => Promise<{ name?: string }[]> }).databases?.();
+    if (!Array.isArray(dbs)) return [];
+    return dbs.map((d) => d.name).filter((n): n is string => typeof n === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function deleteIDB(idb: IDBFactory, name: string): void {
+  try {
+    idb.deleteDatabase(name);
+  } catch {
+    // Best-effort; a blocked-delete event will trigger on next open.
+  }
+}
+
+async function unregisterSwForSession(sw: ServiceWorkerContainer, sid: string): Promise<void> {
+  try {
+    const regs = await sw.getRegistrations();
+    for (const reg of regs) {
+      if (reg.scope.includes(`/api/vault/${sid}/`)) {
+        try {
+          await reg.unregister();
+        } catch {
+          // Swallow — registration may already be gone.
+        }
+      }
+    }
+  } catch {
+    // No SW support in this context.
+  }
+}
+
+function listSessionMarkers(ls: Storage): string[] {
+  const sids: string[] = [];
+  for (let i = 0; i < ls.length; i++) {
+    const key = ls.key(i);
+    if (key && key.startsWith(VAULT_MARKER_PREFIX)) {
+      sids.push(key.slice(VAULT_MARKER_PREFIX.length));
+    }
+  }
+  return sids;
+}
+
+export async function cleanupSessionVaultCache(sid: string): Promise<void> {
+  const idb = getIDB();
+  const ls = getLS();
+  const sw = getSW();
+
+  if (idb) {
+    const names = await listDatabaseNames(idb);
+    for (const name of names) {
+      if (name.includes(sid)) {
+        deleteIDB(idb, name);
+      }
+    }
+  }
+
+  if (ls) {
+    try {
+      ls.removeItem(`${VAULT_MARKER_PREFIX}${sid}`);
+    } catch {
+      // Quota / disabled storage; ignore.
+    }
+  }
+
+  if (sw) {
+    await unregisterSwForSession(sw, sid);
+  }
+}
+
+export async function sweepOrphanVaultCaches(activeSessionIds: string[]): Promise<void> {
+  const ls = getLS();
+  const idb = getIDB();
+  const active = new Set(activeSessionIds);
+
+  const orphanSids = new Set<string>();
+  if (ls) {
+    for (const sid of listSessionMarkers(ls)) {
+      if (!active.has(sid)) orphanSids.add(sid);
+    }
+  }
+
+  if (idb) {
+    const names = await listDatabaseNames(idb);
+    for (const name of names) {
+      // Only consider SB cache DBs.
+      if (!name.startsWith('sb_files_') && !name.startsWith('sb_data_')) continue;
+      // Any sid that is not in the active set is orphan.
+      let isOrphan = true;
+      for (const activeSid of active) {
+        if (name.includes(activeSid)) {
+          isOrphan = false;
+          break;
+        }
+      }
+      if (isOrphan) {
+        deleteIDB(idb, name);
+        // Try to infer the sid from the DB name to also drop the marker.
+        const match = name.match(/^sb_(?:files|data)_([^_]+)/);
+        if (match) orphanSids.add(match[1]);
+      }
+    }
+  }
+
+  if (ls) {
+    for (const sid of orphanSids) {
+      try {
+        ls.removeItem(`${VAULT_MARKER_PREFIX}${sid}`);
+      } catch {
+        // Ignore.
+      }
+    }
+  }
+}
+
+export const VAULT_SESSION_MARKER_PREFIX = VAULT_MARKER_PREFIX;

--- a/web-ui/src/stores/session.ts
+++ b/web-ui/src/stores/session.ts
@@ -4,6 +4,7 @@ import type { SessionWithStatus, SessionStatus, InitProgress, SessionTerminals, 
 import * as api from '../api/client';
 import { terminalStore } from './terminal';
 import { logger } from '../lib/logger';
+import { cleanupSessionVaultCache } from '../lib/vault-cache';
 import { MAX_STOP_POLL_ATTEMPTS, STOP_POLL_INTERVAL_MS, MAX_STOP_POLL_ERRORS, CONTEXT_EXPIRY_MS } from '../lib/constants';
 import {
   setTilingLayout,
@@ -349,6 +350,12 @@ async function deleteSession(id: string): Promise<void> {
     await api.deleteSession(id);
     sessionMissCounters.delete(id);
     cleanupTerminalsForSession(id);
+    // REQ-VAULT-008 AC8: drop the per-session SilverBullet IDB cache,
+    // localStorage marker, and SW registration. Best-effort and async
+    // — we do not block the UI on it.
+    void cleanupSessionVaultCache(id).catch((err) =>
+      logger.warn('vault cache cleanup failed', { id, error: err instanceof Error ? err.message : String(err) }),
+    );
     setState(
       produce((s) => {
         s.sessions = s.sessions.filter((session) => session.id !== id);


### PR DESCRIPTION
## Summary
- Implements REQ-VAULT-008 (zero-UI vault encryption + per-session lifecycle + cold-start payload reduction)
- AC1 in: container DO mints/persists per-session vault key
- ACs 2-9 in progress (Worker /.config injection, SB client patches, Go server filter, treeview exclude, cleanup-on-delete, orphan IDB sweep)

## Test plan
- [ ] CI green on PR Checks + CodeQL + Fuzz
- [ ] Manual: fresh-session SB cold-start <5s
- [ ] Manual: delete-session removes IDB
- [ ] Manual: orphan IDB swept on dashboard mount

Draft until all 9 ACs land; then promote to ready.