### PR TITLE
fix(vault): same-origin fallback for SB attachment uploads (REQ-VAULT-009)

### DIFF
--- a/sdd/vault.md
+++ b/sdd/vault.md
@@ -219,3 +219,25 @@ Persistent Obsidian-style note vault: agent-written session captures plus user-c
 **Status:** Implemented
 
 ---
+
+## REQ-VAULT-009: Vault writes succeed end-to-end for SilverBullet attachment uploads
+
+**Intent:** SilverBullet's drag-drop attachment upload (PUT `/api/vault/<sid>/Inbox/<file>`) must succeed when the user is authenticated, regardless of whether the browser's fetch implementation set the Origin header. The previous code path required Origin to be present and allowlisted before synthesising the CSRF guard header, so a service-worker-controlled fetch or a same-origin fetch that omitted Origin landed at the auth chain without X-Requested-With and was rejected. PDF uploads from the SB Inbox plug repeatedly surfaced this as a 401 to the user.
+
+**Applies To:** User
+
+**Acceptance Criteria:**
+1. A state-changing PUT/POST/PATCH/DELETE request to `/api/vault/<sid>/...` with no Origin header is treated as same-origin and proceeds through CSRF synthesis. The synthesis adds `X-Requested-With: XMLHttpRequest` so the downstream `authenticateRequest` CSRF guard does not reject the write.
+2. A state-changing request with an Origin header that fails the allowlist still returns 403; the missing-Origin fallback does NOT widen the allowlist.
+3. The forward chain preserves the request body bytes end-to-end (no double-read, no disturbed stream) on both the with-Origin and the no-Origin paths.
+4. Existing GET / HEAD / OPTIONS requests behave unchanged; only state-changing methods enter the fallback path.
+
+**Constraints:**
+- Browsers since 2020 always set Origin on state-changing cross-origin requests; the fallback is for SB's same-origin path (where Origin is "null" or omitted) and CLI-style clients. It does NOT bypass the allowlist when an Origin IS present and disallowed.
+
+**Priority:** P1
+**Dependencies:** REQ-VAULT-005 (Worker proxy exposes vault editor)
+**Verification:** Unit (`src/__tests__/routes/vault.test.ts` regression for missing-Origin PUT path).
+**Status:** Implemented
+
+---

--- a/src/__tests__/routes/vault.test.ts
+++ b/src/__tests__/routes/vault.test.ts
@@ -4,6 +4,7 @@ import {
   maybeSynthesizeCsrfHeader,
   isServiceWorkerRegistration,
   VAULT_NOOP_SERVICE_WORKER_JS,
+  inferOriginValidated,
 } from '../../routes/vault';
 
 /**
@@ -253,6 +254,54 @@ describe('validateVaultRoute', () => {
       expect(VAULT_NOOP_SERVICE_WORKER_JS).toContain('clients.claim');
       expect(VAULT_NOOP_SERVICE_WORKER_JS).toContain('install');
       expect(VAULT_NOOP_SERVICE_WORKER_JS).toContain('activate');
+    });
+  });
+
+  describe('inferOriginValidated (REQ-VAULT-009 AC1+2)', () => {
+    function req(method: string, headers: Record<string, string> = {}): Request {
+      return new Request('https://codeflare.ch/api/vault/abcdef12/Inbox/file.pdf', {
+        method,
+        headers: new Headers(headers),
+      });
+    }
+
+    it('AC2: returns false on PUT with Origin set (caller still allowlist-checks)', () => {
+      // When Origin is present, the caller MUST allowlist-check it
+      // explicitly; inferOriginValidated does NOT short-circuit that.
+      expect(inferOriginValidated(req('PUT', { Origin: 'https://codeflare.ch' }))).toBe(false);
+    });
+
+    it('AC1: returns true on PUT with no Origin (same-origin fallback)', () => {
+      expect(inferOriginValidated(req('PUT'))).toBe(true);
+    });
+
+    it('AC1: returns true on POST with no Origin', () => {
+      expect(inferOriginValidated(req('POST'))).toBe(true);
+    });
+
+    it('AC1: returns true on PATCH with no Origin', () => {
+      expect(inferOriginValidated(req('PATCH'))).toBe(true);
+    });
+
+    it('AC1: returns true on DELETE with no Origin', () => {
+      expect(inferOriginValidated(req('DELETE'))).toBe(true);
+    });
+
+    it('AC4: returns false on GET with no Origin (safe methods do not enter fallback)', () => {
+      expect(inferOriginValidated(req('GET'))).toBe(false);
+    });
+
+    it('AC4: returns false on HEAD with no Origin', () => {
+      expect(inferOriginValidated(req('HEAD'))).toBe(false);
+    });
+
+    it('AC4: returns false on OPTIONS with no Origin', () => {
+      expect(inferOriginValidated(req('OPTIONS'))).toBe(false);
+    });
+
+    it('AC1: case-insensitive method comparison', () => {
+      expect(inferOriginValidated(req('put'))).toBe(true);
+      expect(inferOriginValidated(req('Post'))).toBe(true);
     });
   });
 

--- a/src/routes/vault.ts
+++ b/src/routes/vault.ts
@@ -153,6 +153,37 @@ export function isServiceWorkerRegistration(request: Request, remainingPath: str
   return true;
 }
 
+/**
+ * Same-origin fallback for the CSRF synthesis gate. Returns true when
+ * the request is a state-changing method (POST/PUT/PATCH/DELETE) AND
+ * the Origin header is absent. Such a request is by Fetch-spec
+ * definition either same-origin (browsers since 2020 always set Origin
+ * on cross-origin state-changing requests) or originates from a CLI /
+ * non-browser caller for which CSRF is not a defence (those callers
+ * cannot be tricked by an attacker page into making the request).
+ *
+ * SilverBullet's attachment upload path (PUT `/api/vault/<sid>/Inbox/
+ * <file>`) is the production path this closes: SB's drag-drop fetch
+ * lands at the Worker without an Origin header in some browser
+ * configurations, the previous code path left `originValidated=false`,
+ * `maybeSynthesizeCsrfHeader` skipped synthesis, and the downstream
+ * `authenticateRequest` rejected the write for a missing
+ * `X-Requested-With` header (presented to the user as 401 via the SB
+ * retry-on-stale-cookie path).
+ *
+ * Returns false on safe methods and on any state-changing method that
+ * DID supply an Origin — the caller MUST still run the allowlist
+ * check on the Origin in that case; this helper does not widen the
+ * allowlist.
+ *
+ * Implements REQ-VAULT-009 AC1+AC4.
+ */
+export function inferOriginValidated(request: Request): boolean {
+  if (request.headers.get('Origin')) return false;
+  const method = request.method.toUpperCase();
+  return method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
+}
+
 export function validateVaultRoute(request: Request): VaultRouteResult {
   const url = new URL(request.url);
   const match = url.pathname.match(/^\/api\/vault\/([^/]+)(\/.*)$/);
@@ -259,6 +290,13 @@ export async function handleVaultRequest(
         { status: 403, headers: jsonHeaders },
       );
     }
+    originValidated = true;
+  } else if (inferOriginValidated(request)) {
+    // REQ-VAULT-009 AC1: state-changing request with no Origin header
+    // is same-origin by Fetch-spec semantics; treat as validated so the
+    // downstream CSRF synthesiser attaches X-Requested-With and the
+    // authenticateRequest CSRF guard does not reject the SB attachment
+    // upload (PUT /api/vault/<sid>/Inbox/<file>).
     originValidated = true;
   }
 


### PR DESCRIPTION
## Summary
- Implements REQ-VAULT-009: SB attachment uploads (PUT /api/vault/<sid>/Inbox/<file>) no longer fail with 401 when the SB client omits the Origin header
- New `inferOriginValidated()` helper treats state-changing methods (POST/PUT/PATCH/DELETE) with no Origin as same-origin per Fetch-spec semantics, so the downstream CSRF synthesiser attaches X-Requested-With and authenticateRequest accepts the write
- Allowlist check on a present-but-disallowed Origin is unchanged (still returns 403); fallback does NOT widen the allowlist
- Safe methods (GET/HEAD/OPTIONS) are unaffected

## Test plan
- [ ] CI green on PR Checks + CodeQL + Fuzz
- [ ] Manual: drag-drop a PDF into Inbox in SB; confirm file appears under /home/user/Vault/Raw/Pasted/
- [ ] Manual: check Worker logs show 200 (not 401) on the upload PUT