### PR TITLE
fix(vault-extract): accumulate user_vault subgraph across extractions (REQ-MEM-009)

### DIFF
--- a/host/__tests__/vault-extract-merge.test.js
+++ b/host/__tests__/vault-extract-merge.test.js
@@ -1,0 +1,89 @@
+// REQ-MEM-009: the vault-extract pipeline must accumulate the user_vault
+// subgraph across extractions instead of replacing it on every run. The
+// haiku's prompt is the canonical contract -- it spells out the exact
+// commands and order. The tests below pattern-match the prompt's body
+// against the AC contract.
+//
+// The prompt is a markdown file with embedded bash code blocks; we read
+// it raw and assert the load/merge/persist/flock structure is present.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PROMPT_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'preseed',
+  'agents',
+  'claude',
+  'plugins',
+  'codeflare-vault',
+  'scripts',
+  'vault-extract-prompt.md',
+);
+
+function read() {
+  return fs.readFileSync(PROMPT_PATH, 'utf8');
+}
+
+test('REQ-MEM-009 AC1: prompt loads a persistent vault-graph.json before merging', () => {
+  const body = read();
+  assert.match(
+    body,
+    /vault-graph\.json/,
+    'prompt must reference /home/user/Vault/graphify-out/vault-graph.json',
+  );
+  // Must load before writing -- pattern: load path then later write same path.
+  const firstRead = body.indexOf('vault-graph.json');
+  const lastRead = body.lastIndexOf('vault-graph.json');
+  assert.notStrictEqual(firstRead, lastRead, 'prompt must both read and write vault-graph.json');
+});
+
+test('REQ-MEM-009 AC2: prompt does a hash-keyed union of new chunk into persistent graph', () => {
+  const body = read();
+  // nx.compose (networkx) or an equivalent set-union step over nodes+edges.
+  assert.match(
+    body,
+    /compose|nodes\.update|union|merge.*graph|graph.*merge/i,
+    'prompt must spell out a node-union/merge step (e.g. nx.compose) so existing IDs dedupe',
+  );
+});
+
+test('REQ-MEM-009 AC3: prompt feeds the persistent vault graph to `graphify global add --as user_vault`', () => {
+  const body = read();
+  assert.match(
+    body,
+    /graphify\s+global\s+add[\s\S]{0,200}--as\s+user_vault/,
+    'prompt must run `graphify global add ... --as user_vault` to publish the cumulative vault graph',
+  );
+  // The argument to global add MUST be the persistent vault graph,
+  // not the per-extraction chunk graph.
+  assert.match(
+    body,
+    /graphify\s+global\s+add\s+[^\n]*vault-graph\.json[\s\S]{0,200}--as\s+user_vault/,
+    'global add must consume vault-graph.json (not the per-chunk graph)',
+  );
+});
+
+test('REQ-MEM-009 AC4: prompt handles missing/unreadable vault-graph.json by starting fresh', () => {
+  const body = read();
+  // Must spell out an "if not exists" / "try/except" guard around the load
+  // so a fresh vault starts cleanly rather than crashing the haiku.
+  assert.match(
+    body,
+    /try:[\s\S]{0,200}vault-graph\.json|exists\([^)]*vault-graph\.json|FileNotFoundError|JSONDecodeError|except\s+\(.+\)\s*:/i,
+    'prompt must include a missing-file / parse-error guard around vault-graph.json load',
+  );
+});
+
+test('REQ-MEM-009 AC5: merge + persist step runs under flock /tmp/graphify-global.lock', () => {
+  const body = read();
+  assert.match(
+    body,
+    /flock\s+\/tmp\/graphify-global\.lock/,
+    'prompt must wrap the merge + global-add sequence with flock /tmp/graphify-global.lock to serialise with the capture pipeline',
+  );
+});

--- a/preseed/agents/claude/plugins/codeflare-vault/scripts/vault-extract-prompt.md
+++ b/preseed/agents/claude/plugins/codeflare-vault/scripts/vault-extract-prompt.md
@@ -147,14 +147,24 @@ still write an empty chunk JSON (`{"nodes":[],"edges":[],"hyperedges":[],...}`)
 and continue - step 6 needs to advance the marker so we do not loop
 on the same broken files.
 
-### 4. Build a vault graph.json from the chunk
+### 4. Build a vault graph.json from the chunk, merging into the persistent vault-graph
 
 `graphify global add` needs a fully-built `graph.json` (with clustering
-metadata), not the raw chunk. Run the build via graphify's Python API:
+metadata), not the raw chunk. REQ-MEM-009: we must also accumulate the
+cumulative vault subgraph across extractions -- the previous design
+called `graphify global add --as user_vault` with only the latest
+chunk, and `--as <tag>` replaces the entire repo-tag contribution, so
+every vault edit wiped all prior vault knowledge from the global graph.
+The fix is to maintain a persistent `vault-graph.json` that grows
+monotonically: load it (or start fresh if missing), nx.compose the
+new chunk's nodes/edges into it via hash-keyed union, re-cluster, and
+write it back. The persistent graph is then what `graphify global add`
+consumes in step 5.
 
 ```bash
 flock /tmp/graphify-global.lock /root/.local/share/uv/tools/graphifyy/bin/python -c "
 import json
+import networkx as nx
 from pathlib import Path
 from graphify.build import build_from_json
 from graphify.cluster import cluster
@@ -162,31 +172,68 @@ from graphify.export import to_json
 
 chunk_path = Path('/home/user/Vault/graphify-out/.graphify_chunk_01.json')
 out_path = Path('/home/user/Vault/graphify-out/graph.json')
+vault_graph_path = Path('/home/user/Vault/graphify-out/vault-graph.json')
 
+# REQ-MEM-009 AC4: missing/unreadable persistent vault-graph.json is
+# recoverable -- start fresh. Any JSON parse error or KeyError on the
+# expected node_link shape means the file is corrupt; treat as missing.
+G_prior = nx.DiGraph()
+try:
+    if vault_graph_path.exists():
+        prior_blob = json.loads(vault_graph_path.read_text(encoding='utf-8'))
+        # node_link_graph default in nx 3.x reads 'edges'; vault-graph.json
+        # historically wrote 'links'. Try both so older files still load.
+        try:
+            G_prior = nx.node_link_graph(prior_blob, edges='links')
+        except (KeyError, TypeError):
+            G_prior = nx.node_link_graph(prior_blob)
+except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
+    print(f'vault-graph.json unreadable ({e}); starting fresh')
+    G_prior = nx.DiGraph()
+
+# Build the new chunk into a graph.
 extraction = json.loads(chunk_path.read_text(encoding='utf-8'))
-G = build_from_json(extraction)
-communities = cluster(G) if G.number_of_nodes() else {}
-to_json(G, communities, str(out_path))
-print(f'vault graph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
+G_new = build_from_json(extraction)
+
+# REQ-MEM-009 AC2: hash-keyed union -- nx.compose dedupes nodes by ID
+# (existing IDs keep their attributes; new IDs append). Edges are
+# unioned by (source, target) tuple.
+G_merged = nx.compose(G_prior, G_new)
+
+# REQ-MEM-009 AC1: persist the cumulative vault graph for the next
+# extraction to load.
+to_json(G_merged, cluster(G_merged) if G_merged.number_of_nodes() else {}, str(vault_graph_path))
+
+# Also write the per-extraction graph.json (kept for backwards-compat
+# with any caller that still reads the chunk-shaped artifact).
+to_json(G_merged, cluster(G_merged) if G_merged.number_of_nodes() else {}, str(out_path))
+
+print(f'vault graph: {G_merged.number_of_nodes()} nodes ({G_new.number_of_nodes()} new, {G_prior.number_of_nodes()} prior), {G_merged.number_of_edges()} edges')
 "
 ```
 
 The `flock` lock matches the one used by `graphify global add` in step 5
 and `graphify-active-repo.sh`, so concurrent writers do not stomp the
-manifest.
+manifest. REQ-MEM-009 AC5: this lock covers the load+merge+persist
+sequence above plus the global-add in step 5.
 
 If the build prints `0 nodes, 0 edges`, that is fine - step 5 will
 no-op via `graphify global add`'s hash dedup. Continue to step 6.
 
-### 5. Merge the vault graph into the unified global graph
+### 5. Merge the cumulative vault graph into the unified global graph
+
+REQ-MEM-009 AC3: feed the persistent `vault-graph.json` (cumulative)
+to `graphify global add`, NOT the per-extraction chunk graph. The
+`--as user_vault` replace-semantics now publishes the cumulative
+vault state on every run instead of clobbering it.
 
 ```bash
 flock /tmp/graphify-global.lock /usr/local/bin/graphify global add \
-    /home/user/Vault/graphify-out/graph.json --as user_vault
+    /home/user/Vault/graphify-out/vault-graph.json --as user_vault
 ```
 
 `graphify global add` is hash-keyed and idempotent - re-running it
-with the same `graph.json` content is a no-op. Tagged `--as user_vault` so
+with the same `vault-graph.json` content is a no-op. Tagged `--as user_vault` so
 the global manifest can distinguish vault nodes from per-repo nodes.
 The internal `external_labels` pass dedupes concept nodes (those with
 `source_file: null`) against existing concept nodes by label, so

--- a/sdd/memory.md
+++ b/sdd/memory.md
@@ -156,3 +156,24 @@ Vault-based cross-session memory, automatic capture, hook delivery, and session-
 **Verification:** Automated test (`generate-agent-seed.mjs` output includes memory plugin files).
 
 **Status:** Implemented
+
+---
+
+## REQ-MEM-009: Vault graph accumulates monotonically across extractions
+
+**Intent:** Each vault-monitor extraction must add new nodes to the `user_vault` subgraph in the unified global graph without destroying nodes from prior extractions. Previously the haiku called `graphify global add ... --as user_vault` after building a chunk graph from only the newly-changed files; `--as <tag>` replaces the entire repo-tag contribution, so every vault edit wiped all prior vault knowledge from the global graph (observed: 17 nodes -> 2 nodes after the haiku ran on 2 newly-created stub `.md` files).
+
+**Applies To:** User
+
+**Acceptance Criteria:**
+1. The vault-extract haiku maintains a persistent vault graph at `/home/user/Vault/graphify-out/vault-graph.json`, loaded at the start of each pass and re-written at the end.
+2. Each extraction merges the new chunk's nodes/edges into the persistent graph using a hash-keyed union (existing IDs dedupe, new IDs append).
+3. The persistent vault graph is what `graphify global add ... --as user_vault` consumes, so the global graph's `user_vault` repo tag always reflects the cumulative vault content rather than only the most recent extraction.
+4. If the persistent vault graph file is missing or unreadable, the pass starts a fresh one (rather than crashing) and writes it at the end of the run.
+5. The merge step runs under `flock /tmp/graphify-global.lock` so it serialises with capture-pipeline writes and active-repo hooks.
+
+**Applies To:** User
+**Priority:** P0
+**Dependencies:** REQ-MEM-001 (capture pipeline contract), REQ-VAULT-002 (vault is always-on in the global graph)
+**Verification:** Automated test (`host/__tests__/vault-extract-merge.test.js` patterns the prompt for load + merge + persist + flock; integration smoke via running the haiku twice in a row and confirming the global graph's user_vault node count grows monotonically).
+**Status:** Implemented


### PR DESCRIPTION
## Summary
- Implements REQ-MEM-009: vault-extract pipeline no longer destroys prior vault knowledge on every extraction
- Adds persistent /home/user/Vault/graphify-out/vault-graph.json that grows monotonically; each pass loads it, hash-keyed-merges the new chunk via nx.compose, and re-writes it
- graphify global add now consumes the cumulative vault-graph.json (not the per-chunk graph) so the --as user_vault replace-semantics publishes the cumulative state
- Missing/unreadable vault-graph.json recoverable: starts fresh rather than crashing
- Load + merge + persist + global-add all run under flock /tmp/graphify-global.lock

## Test plan
- [ ] CI green on PR Checks
- [ ] Manual: run the haiku twice with different vault edits; confirm ~/.graphify/global-graph.json shows monotonic user_vault node growth