### PR TITLE
feat(timezone): wire browser IANA TZ through to container USER_TIMEZONE (REQ-MEM-001 AC3)

### DIFF
--- a/src/__tests__/container/container-env.test.ts
+++ b/src/__tests__/container/container-env.test.ts
@@ -1,0 +1,68 @@
+// REQ-MEM-001 AC3: buildEnvVars must propagate the per-session
+// USER_TIMEZONE so the capture haiku's `TZ="$RESOLVED" date '+%...'`
+// step produces a wall-clock timestamp in the user's local zone
+// instead of falling all the way through to UTC. Without this, every
+// vault capture filename gets a +0000 suffix regardless of where the
+// user actually is.
+
+import { describe, it, expect } from 'vitest';
+import { buildEnvVars, type ContainerEnvState } from '../../container/container-env';
+import type { Env } from '../../types';
+
+function baseState(): ContainerEnvState {
+  return {
+    _bucketName: 'codeflare-test',
+    _r2AccountId: 'acc',
+    _r2Endpoint: 'https://r2.test',
+    _r2AccessKeyId: 'AK',
+    _r2SecretAccessKey: 'SK',
+    _workspaceSyncEnabled: false,
+    _fastStartEnabled: false,
+    _tabConfig: null,
+    _openaiApiKey: null,
+    _geminiApiKey: null,
+    _githubToken: null,
+    _cloudflareApiToken: null,
+    _cloudflareAccountId: null,
+    _encryptionKey: null,
+    _sessionMode: 'default',
+    _containerAuthToken: 'tok',
+    _sessionId: 'sid-abcdef12',
+    _userEmail: 'user@example.com',
+    // Field gated by REQ-MEM-001 AC3 (added in this PR).
+    _userTimezone: null,
+  } as unknown as ContainerEnvState;
+}
+
+const baseEnv: Env = {} as Env;
+
+describe('buildEnvVars (REQ-MEM-001 AC3)', () => {
+  it('emits USER_TIMEZONE when _userTimezone is set', () => {
+    const state = baseState();
+    (state as unknown as { _userTimezone: string | null })._userTimezone = 'Europe/Zurich';
+    const vars = buildEnvVars(state, baseEnv);
+    expect(vars.USER_TIMEZONE).toBe('Europe/Zurich');
+  });
+
+  it('omits USER_TIMEZONE when _userTimezone is null', () => {
+    const state = baseState();
+    const vars = buildEnvVars(state, baseEnv);
+    expect(vars.USER_TIMEZONE).toBeUndefined();
+  });
+
+  it('omits USER_TIMEZONE when _userTimezone is empty string', () => {
+    const state = baseState();
+    (state as unknown as { _userTimezone: string | null })._userTimezone = '';
+    const vars = buildEnvVars(state, baseEnv);
+    expect(vars.USER_TIMEZONE).toBeUndefined();
+  });
+
+  it('does not affect other env vars (regression guard)', () => {
+    const state = baseState();
+    (state as unknown as { _userTimezone: string | null })._userTimezone = 'Europe/Zurich';
+    const vars = buildEnvVars(state, baseEnv);
+    expect(vars.R2_BUCKET_NAME).toBe('codeflare-test');
+    expect(vars.CONTAINER_AUTH_TOKEN).toBe('tok');
+    expect(vars.SESSION_ID).toBe('sid-abcdef12');
+  });
+});

--- a/src/__tests__/routes/preferences.test.ts
+++ b/src/__tests__/routes/preferences.test.ts
@@ -436,5 +436,49 @@ describe('Preferences Routes', () => {
       expect(body.sessionMode).toBe('advanced');
     });
   });
+
+  describe('userTimezone (REQ-MEM-001 AC3)', () => {
+    it('accepts a valid IANA timezone and persists it', async () => {
+      const app = createTestApp();
+      const res = await app.request('/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userTimezone: 'Europe/Zurich' }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { userTimezone?: string };
+      expect(body.userTimezone).toBe('Europe/Zurich');
+    });
+
+    it('accepts UTC as a special-case valid timezone', async () => {
+      const app = createTestApp();
+      const res = await app.request('/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userTimezone: 'UTC' }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects a syntactically valid but non-existent IANA tz', async () => {
+      const app = createTestApp();
+      const res = await app.request('/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userTimezone: 'Mars/Olympus' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an empty string timezone', async () => {
+      const app = createTestApp();
+      const res = await app.request('/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userTimezone: '' }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
 });
 

--- a/src/container/container-env.ts
+++ b/src/container/container-env.ts
@@ -71,6 +71,8 @@ export interface SetBucketNameCreds {
   cloudflareAccountId?: string;
   encryptionKey?: string;
   sessionMode?: string;
+  /** REQ-MEM-001 AC3: user's IANA timezone forwarded from /start. */
+  userTimezone?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +241,14 @@ export async function applyBucketName(
 
   // Store session mode in instance memory only (not persisted to DO storage; re-sent on each container start)
   if (r2Creds?.sessionMode) state._sessionMode = r2Creds.sessionMode;
+
+  // REQ-MEM-001 AC3: persist userTimezone so the capture pipeline sees
+  // the user's IANA zone on subsequent DO wakes too (the env var flows
+  // through buildEnvVars to the container's entrypoint).
+  if (r2Creds?.userTimezone) {
+    state._userTimezone = r2Creds.userTimezone;
+    await storage.put('userTimezone', r2Creds.userTimezone);
+  }
 
   // Use Worker-provided R2 credentials (most reliable — Worker definitely has secrets)
   if (r2Creds?.r2AccessKeyId) state._r2AccessKeyId = r2Creds.r2AccessKeyId;

--- a/src/container/container-env.ts
+++ b/src/container/container-env.ts
@@ -36,6 +36,8 @@ export interface ContainerEnvState {
   _containerAuthToken: string | null;
   _sessionId: string | null;
   _userEmail: string | null;
+  /** REQ-MEM-001 AC3: user's IANA timezone (e.g. "Europe/Zurich"). */
+  _userTimezone: string | null;
 }
 
 /** Fields sent in the setBucketName body that may need updating on restart. */
@@ -183,6 +185,11 @@ export function buildEnvVars(
     ...(state._cloudflareAccountId && { CLOUDFLARE_ACCOUNT_ID: state._cloudflareAccountId }),
     // Session mode (controls memory persistence in entrypoint.sh)
     SESSION_MODE: state._sessionMode,
+    // REQ-MEM-001 AC3: user's IANA timezone. The capture haiku resolves
+    // wall-clock time as TZ="$USER_TIMEZONE" date '+%Y-%m-%dT...'; only
+    // emit when set so the entrypoint's existing fallback chain ($TZ ->
+    // /etc/timezone -> UTC) handles the unset case.
+    ...(state._userTimezone && { USER_TIMEZONE: state._userTimezone }),
   };
 }
 

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -108,6 +108,8 @@ export class container extends Container<Env> {
   private _containerAuthToken: string | null = null;
   private _sessionId: string | null = null;
   private _userEmail: string | null = null;
+  /** REQ-MEM-001 AC3: user's IANA timezone (e.g. "Europe/Zurich"). */
+  private _userTimezone: string | null = null;
   /**
    * Timestamp captured at the start of destroy(); read by onStop() to
    * log shutdown elapsed-ms. Helps telemetry decide whether the 135s
@@ -149,6 +151,10 @@ export class container extends Container<Env> {
       this._sessionId = await this.ctx.storage.get<string>(SESSION_ID_KEY) || null;
       this._usageSeconds = await this.ctx.storage.get<number>('usageSeconds') || 0;
       this._userEmail = await this.ctx.storage.get<string>('userEmail') || null;
+      // REQ-MEM-001 AC3: restore the user's IANA timezone so the capture
+      // pipeline's TZ resolution produces wall-clock filenames after a
+      // DO wake (matches the pattern for sessionId / userEmail above).
+      this._userTimezone = await this.ctx.storage.get<string>('userTimezone') || null;
       // Restore the container auth token from storage. Without this,
       // every DO wake regenerates a fresh UUID via updateEnvVars() while the
       // container process (which may have been hibernated, not restarted)

--- a/src/lib/container-config-schema.ts
+++ b/src/lib/container-config-schema.ts
@@ -27,4 +27,6 @@ export const SetBucketNameBodySchema = z.object({
   encryptionKey: z.string().optional(),
   sessionMode: z.string(),
   sleepAfter: z.string(),
+  /** REQ-MEM-001 AC3: forward the user's IANA timezone to the container. */
+  userTimezone: z.string().optional(),
 }).passthrough();

--- a/src/routes/container/lifecycle.ts
+++ b/src/routes/container/lifecycle.ts
@@ -65,6 +65,10 @@ function buildSetBucketNameBody(params: ContainerConfigPayload): string {
     ...(params.encryptionKey && { encryptionKey: params.encryptionKey }),
     sessionMode: params.sessionMode,
     sleepAfter: params.sleepAfter,
+    // REQ-MEM-001 AC3: forward the user's IANA timezone so the capture
+    // pipeline's TZ resolution produces wall-clock filenames matching
+    // the user's location instead of UTC.
+    ...(params.userTimezone && { userTimezone: params.userTimezone }),
   });
   return JSON.stringify(body);
 }
@@ -518,6 +522,10 @@ app.post('/start', containerStartRateLimiter, async (c) => {
       encryptionKey: c.env.ENCRYPTION_KEY,
       llmKeys: llmKeys ?? undefined,
       deployKeys: deployKeys ?? undefined,
+      // REQ-MEM-001 AC3: forward the browser's IANA timezone (captured
+      // on createSession) into the container so capture filenames reflect
+      // the user's wall-clock instead of UTC.
+      userTimezone: preferences.userTimezone,
       logger: reqLogger,
     });
 

--- a/src/routes/preferences.ts
+++ b/src/routes/preferences.ts
@@ -18,6 +18,23 @@ import { createLogger } from '../lib/logger';
 
 const logger = createLogger('preferences');
 
+/**
+ * REQ-MEM-001 AC3: validate an IANA timezone string by attempting to
+ * construct an Intl.DateTimeFormat with it. Browsers throw RangeError
+ * on unsupported zones; valid zones round-trip cleanly. This avoids
+ * shipping a 400+ entry static zone list while still catching
+ * typos and non-existent zones like "Mars/Olympus".
+ */
+function isValidIanaTz(tz: string): boolean {
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const UpdatePreferencesBody = z.object({
   lastAgentType: AgentTypeSchema.optional(),
   lastPresetId: z.string().max(100).optional(),
@@ -25,6 +42,9 @@ const UpdatePreferencesBody = z.object({
   fastStartEnabled: z.boolean().optional(),
   sessionMode: SessionModeSchema.optional(),
   sleepAfter: z.enum(SleepAfterOptions as unknown as [string, ...string[]]).optional(),
+  userTimezone: z.string().min(1).max(64).refine(isValidIanaTz, {
+    message: 'Invalid IANA timezone',
+  }).optional(),
 }).strict();
 
 const preferencesPatchRateLimiter = createRateLimiter({

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,6 +273,8 @@ export interface ContainerConfigPayload {
   encryptionKey?: string;
   llmKeys?: LlmKeys;
   deployKeys?: DeployKeys;
+  /** REQ-MEM-001 AC3: user's IANA timezone forwarded to the container. */
+  userTimezone?: string;
 }
 
 interface StorageObject {

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,8 @@ export interface UserPreferences {
   fastStartEnabled?: boolean;
   sessionMode?: SessionMode;
   sleepAfter?: SleepAfterOption;
+  /** REQ-MEM-001 AC3: user's IANA timezone, captured from the browser. */
+  userTimezone?: string;
 }
 
 /**

--- a/web-ui/src/__tests__/lib/timezone-sync.test.ts
+++ b/web-ui/src/__tests__/lib/timezone-sync.test.ts
@@ -1,0 +1,83 @@
+// REQ-MEM-001 AC3: the frontend captures the browser's IANA timezone
+// via Intl.DateTimeFormat().resolvedOptions().timeZone on Dashboard
+// mount and persists it via updatePreferences. Future sessions started
+// from that browser propagate the same zone into the container so the
+// capture pipeline's `TZ="$RESOLVED" date '+%...'` step produces a
+// wall-clock filename.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { syncBrowserTimezone, getBrowserTimezone } from '../../lib/timezone-sync';
+
+describe('getBrowserTimezone (REQ-MEM-001 AC3)', () => {
+  it('returns a non-empty IANA string in a real browser environment', () => {
+    // In the vitest jsdom/happy-dom environment, Intl.DateTimeFormat
+    // resolves to the host's timezone (typically UTC in CI, local in dev).
+    const tz = getBrowserTimezone();
+    expect(typeof tz).toBe('string');
+    expect(tz.length).toBeGreaterThan(0);
+  });
+
+  it('returns null if Intl.DateTimeFormat throws (defensive)', () => {
+    const original = globalThis.Intl;
+    (globalThis as unknown as { Intl: { DateTimeFormat: () => never } }).Intl = {
+      DateTimeFormat: () => {
+        throw new Error('boom');
+      },
+    };
+    try {
+      expect(getBrowserTimezone()).toBeNull();
+    } finally {
+      globalThis.Intl = original;
+    }
+  });
+});
+
+describe('syncBrowserTimezone (REQ-MEM-001 AC3)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls updatePreferences with the resolved timezone when it differs from current', async () => {
+    const updatePrefs = vi.fn(async (_prefs: { userTimezone?: string }) => undefined);
+    await syncBrowserTimezone({
+      currentTimezone: undefined,
+      browserTimezone: 'Europe/Zurich',
+      updatePreferences: updatePrefs,
+    });
+    expect(updatePrefs).toHaveBeenCalledWith({ userTimezone: 'Europe/Zurich' });
+  });
+
+  it('is a no-op when current and browser timezone match', async () => {
+    const updatePrefs = vi.fn(async () => undefined);
+    await syncBrowserTimezone({
+      currentTimezone: 'Europe/Zurich',
+      browserTimezone: 'Europe/Zurich',
+      updatePreferences: updatePrefs,
+    });
+    expect(updatePrefs).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when browser timezone is null (cannot detect)', async () => {
+    const updatePrefs = vi.fn(async () => undefined);
+    await syncBrowserTimezone({
+      currentTimezone: 'Europe/Zurich',
+      browserTimezone: null,
+      updatePreferences: updatePrefs,
+    });
+    expect(updatePrefs).not.toHaveBeenCalled();
+  });
+
+  it('swallows updatePreferences rejections (does not block dashboard mount)', async () => {
+    const updatePrefs = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    await expect(syncBrowserTimezone({
+      currentTimezone: undefined,
+      browserTimezone: 'Europe/Zurich',
+      updatePreferences: updatePrefs,
+    })).resolves.toBeUndefined();
+  });
+});

--- a/web-ui/src/components/Dashboard.tsx
+++ b/web-ui/src/components/Dashboard.tsx
@@ -56,7 +56,7 @@ const Dashboard: Component<DashboardProps> = (props) => {
     // to the user's preferences so the next session start propagates
     // USER_TIMEZONE into the container env. Best-effort; never blocks.
     void syncBrowserTimezone({
-      currentTimezone: sessionStore.state.preferences.userTimezone,
+      currentTimezone: sessionStore.preferences.userTimezone,
       browserTimezone: getBrowserTimezone(),
       updatePreferences: sessionStore.updatePreferences,
     });

--- a/web-ui/src/components/Dashboard.tsx
+++ b/web-ui/src/components/Dashboard.tsx
@@ -17,6 +17,7 @@ import ScrambleText from './ScrambleText';
 import KittScanner from './KittScanner';
 import DashboardCard from './TipsRotator';
 import { sessionStore, isAtUsageQuota } from '../stores/session';
+import { getBrowserTimezone, syncBrowserTimezone } from '../lib/timezone-sync';
 import UsageInlineBadge from './UsageInlineBadge';
 import '../styles/dashboard.css';
 
@@ -50,6 +51,15 @@ const Dashboard: Component<DashboardProps> = (props) => {
   onMount(() => {
     sessionStore.startR2Polling();
     storageStore.fetchStats();
+
+    // REQ-MEM-001 AC3: capture the browser's IANA timezone and sync it
+    // to the user's preferences so the next session start propagates
+    // USER_TIMEZONE into the container env. Best-effort; never blocks.
+    void syncBrowserTimezone({
+      currentTimezone: sessionStore.state.preferences.userTimezone,
+      browserTimezone: getBrowserTimezone(),
+      updatePreferences: sessionStore.updatePreferences,
+    });
 
     // User menu close is handled by the Portal overlay onClick — no document
     // mousedown listener needed. Document mousedown fires before click on mobile,

--- a/web-ui/src/components/Dashboard.tsx
+++ b/web-ui/src/components/Dashboard.tsx
@@ -55,11 +55,16 @@ const Dashboard: Component<DashboardProps> = (props) => {
     // REQ-MEM-001 AC3: capture the browser's IANA timezone and sync it
     // to the user's preferences so the next session start propagates
     // USER_TIMEZONE into the container env. Best-effort; never blocks.
-    void syncBrowserTimezone({
-      currentTimezone: sessionStore.preferences.userTimezone,
-      browserTimezone: getBrowserTimezone(),
-      updatePreferences: sessionStore.updatePreferences,
-    });
+    // Tests use a vi.mock that may stub sessionStore with a partial shape;
+    // guard against undefined preferences / updatePreferences so unit
+    // tests that don't care about TZ sync still render the component.
+    if (typeof sessionStore.updatePreferences === 'function') {
+      void syncBrowserTimezone({
+        currentTimezone: sessionStore.preferences?.userTimezone,
+        browserTimezone: getBrowserTimezone(),
+        updatePreferences: sessionStore.updatePreferences,
+      });
+    }
 
     // User menu close is handled by the Portal overlay onClick — no document
     // mousedown listener needed. Document mousedown fires before click on mobile,

--- a/web-ui/src/lib/timezone-sync.ts
+++ b/web-ui/src/lib/timezone-sync.ts
@@ -1,0 +1,31 @@
+// REQ-MEM-001 AC3: capture the browser's IANA timezone via
+// Intl.DateTimeFormat().resolvedOptions().timeZone and sync it to the
+// user's preferences when it differs from the stored value. The
+// container's capture pipeline reads USER_TIMEZONE from env on the
+// next session start; this side-car sync keeps the backend's stored
+// preference current as the user moves between locations.
+
+export function getBrowserTimezone(): string | null {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return tz || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface SyncBrowserTimezoneInput {
+  currentTimezone: string | undefined;
+  browserTimezone: string | null;
+  updatePreferences: (prefs: { userTimezone?: string }) => Promise<void>;
+}
+
+export async function syncBrowserTimezone(input: SyncBrowserTimezoneInput): Promise<void> {
+  if (!input.browserTimezone) return;
+  if (input.currentTimezone === input.browserTimezone) return;
+  try {
+    await input.updatePreferences({ userTimezone: input.browserTimezone });
+  } catch {
+    // Best-effort sync; never block the caller (e.g. dashboard mount).
+  }
+}

--- a/web-ui/src/types.ts
+++ b/web-ui/src/types.ts
@@ -31,6 +31,8 @@ export interface UserPreferences {
   fastStartEnabled?: boolean;
   sessionMode?: SessionMode;
   sleepAfter?: SleepAfterOption;
+  /** REQ-MEM-001 AC3: user's IANA timezone captured from the browser. */
+  userTimezone?: string;
 }
 
 /** Mirrors backend Session type (see src/types.ts). Keep in sync manually. */


### PR DESCRIPTION
## Summary
- Implements REQ-MEM-001 AC3: capture-pipeline filenames now reflect the user's wall-clock instead of UTC
- Frontend captures Intl.DateTimeFormat().resolvedOptions().timeZone on Dashboard mount and syncs via PATCH /api/preferences
- Backend validates IANA timezone via Intl.DateTimeFormat constructor (rejects Mars/Olympus, empty string)
- Container DO persists _userTimezone in ctx.storage and emits USER_TIMEZONE env var via buildEnvVars
- /start handler forwards preferences.userTimezone into configureContainerDO -> SetBucketNameBody schema

## Test plan
- [ ] CI green on PR Checks + CodeQL + Fuzz
- [ ] Manual: open Codeflare on a non-UTC machine, create a new session, observe Raw/Sessions/2026-MM-DDT...+XXXX-{sid}.md filename with local offset