### PR TITLE
test(REQ-MEM-001 AC3): add HTTP-level USER_TIMEZONE regression coverage

### DIFF
--- a/src/__tests__/container/index.test.ts
+++ b/src/__tests__/container/index.test.ts
@@ -454,6 +454,57 @@ describe('container DO class', () => {
       expect(response.status).toBe(400);
     });
 
+    // REQ-MEM-001 AC3 / REQ-SESSION-016: the previous regression coverage
+    // exercised applyBucketName and applyPrefsOnRestart in isolation with
+    // userTimezone already in the input arg, which would stay green even if
+    // the handleSetBucketName destructure were reverted to the PR #390 bug
+    // shape (silently dropping userTimezone from the Worker JSON body).
+    // These two tests post to /_internal/setBucketName end-to-end and assert
+    // the env var actually surfaces, so removing the destructure makes them
+    // red.
+    it('setBucketName reads userTimezone from JSON body and emits USER_TIMEZONE env var', async () => {
+      mockStorage.get.mockImplementation(async (key: string) => {
+        if (key === 'bucketName') return null;
+        return null;
+      });
+
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+
+      const request = new Request('http://container/_internal/setBucketName', {
+        method: 'POST',
+        body: JSON.stringify({ bucketName: 'new-bucket', userTimezone: 'Europe/Zurich' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const response = await instance.fetch(request);
+      expect(response.status).toBe(200);
+
+      expect(mockStorage.put).toHaveBeenCalledWith('userTimezone', 'Europe/Zurich');
+      expect(instance.envVars?.USER_TIMEZONE).toBe('Europe/Zurich');
+    });
+
+    it('setBucketName updates USER_TIMEZONE on restart (bucket already set, prefs change path)', async () => {
+      mockStorage.get.mockImplementation(async (key: string) => {
+        if (key === 'bucketName') return 'existing-bucket';
+        if (key === 'userTimezone') return 'Europe/Zurich';
+        return null;
+      });
+
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+
+      const request = new Request('http://container/_internal/setBucketName', {
+        method: 'POST',
+        body: JSON.stringify({ bucketName: 'existing-bucket', userTimezone: 'America/New_York' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const response = await instance.fetch(request);
+      expect(response.status).toBe(409);
+
+      expect(mockStorage.put).toHaveBeenCalledWith('userTimezone', 'America/New_York');
+      expect(instance.envVars?.USER_TIMEZONE).toBe('America/New_York');
+    });
+
     it('proxies unknown routes via super.fetch when container is running', async () => {
       mockContainerRuntime.running = true;
       mockStorage.get.mockImplementation(async (key: string) => {


### PR DESCRIPTION
## Summary

Closes the CRITICAL test-theater finding from code-reviewer on PR #395.

The 4 regression tests added in commit `1605306` exercise `applyBucketName` and `applyPrefsOnRestart` directly, with `userTimezone` already in the input argument. They never traverse `handleSetBucketName`, which is the JSON-body destructure where the actual PR #390 bug lived. Reverting the one-line destructure fix at `src/container/index.ts:396` leaves those 4 tests green — so the "regression coverage" doesn't actually gate the regression.

This PR adds two HTTP-level tests that POST to `/_internal/setBucketName` and assert `instance.envVars.USER_TIMEZONE` surfaces correctly:

1. First-time bucket set with `userTimezone` in the body → asserts storage.put + envVar
2. Restart path (`409 Bucket name already set`) with a changed `userTimezone` → asserts the prefs-update branch in `applyPrefsOnRestart` flows through to env

Both fail under the reverted-destructure shape (because `userTimezone` is `undefined` in the destructured opts and never reaches `setBucketName`/`applyPrefsOnRestart`).

## Test plan
- [ ] CI green
- [ ] After merge to develop, fast-forward into PR #395 (or include as additional develop commit)

## Provenance
Found via code-reviewer (Opus 4.7) cross-verified by GPT-5.2 on PR #395 review. Single CRITICAL finding; this PR addresses it. Remaining HIGH/MEDIUM findings on #395 (`applyPrefsOnRestart` no-clear semantics, mutate-before-persist, schema validation, `_sessionId` key drift) are separate follow-ups.
