### PR TITLE
feat: sdd-skill improvements from zipline-native /sdd init audit

### DIFF
--- a/preseed/agents/claude/skills/sdd-init/SKILL.md
+++ b/preseed/agents/claude/skills/sdd-init/SKILL.md
@@ -18,7 +18,37 @@ Detect via source-file count (greenfield-vs-import) and presence of open triage 
 
 Compresses the old 10-15-turn back-and-forth into two decisions.
 
-1. **Ask for vision** (one free-form question if `$ARGUMENTS` is empty). Confirm what you heard in one sentence.
+1. **Ask for vision** (one free-form question if `$ARGUMENTS` is empty). Confirm what you heard in one sentence. **Then ask for spec flavour** with one question:
+
+   ```
+   What kind of spec is this?
+
+   1. Technical — REQs may name protocols (OAuth, JWT), vendors (Cloudflare,
+      Stripe), HTTP status codes, performance targets, and user-facing strings.
+      Default for engineering teams shipping software.
+
+   2. Business / behavioural — REQs describe observable behaviour only. No
+      protocols, no vendor names, no status codes inside REQs; technical
+      detail lives in documentation/. Pick this when stakeholders read REQs.
+
+   3. Custom — set each of the five forbidden-content allowlist flags
+      individually.
+   ```
+
+   The choice writes `forbidden_content_allowlist:` in `sdd/spec/config.yml` at step 5:
+
+   | Flag | Technical | Business | Custom |
+   |---|---|---|---|
+   | `protocols` | true | false | prompt |
+   | `vendors` | true | false | prompt |
+   | `http_codes_in_api_reqs` | true | false | prompt |
+   | `performance_numbers` | true | false | prompt |
+   | `user_facing_strings` | true | true | prompt |
+
+   `user_facing_strings` stays `true` on Business by default — quoted UI strings ARE the AC's assertion target, banning them leaves no concrete trigger to assert against. Custom can override.
+
+   This choice is binding: Business-flavour specs that later contain protocol/vendor/status-code references generate HIGH `forbidden-content-in-req` findings during enforcement, and the agent moves the content to `documentation/` rather than allowing it through.
+
 2. **Draft the entire spec in memory** without further questions. In Import Mode, drafting MUST iterate over the Phase 4 behavioral-enumeration table (see § "Behavioral enumeration (Phase 4)" below): every enumerated item MUST resolve to exactly one of (a) a drafted AC carrying an `@impl` anchor, (b) a triage entry in `.init-triage.md` with Context + Recommendation, or (c) an explicit one-line entry in the domain README's "Out of Scope" section. In greenfield this constraint is trivially satisfied because the drafted REQs ARE the enumeration; see Phase 4 for the greenfield carve-out. Items silently dropped from the draft on Import Mode are detected by the Phase 7b verifier (step 8) and block commit. Derive:
    - Actors (typically 2-3; User, Admin defaults; never "System")
    - Design principles (3-7 specific to this product, not generic)
@@ -39,6 +69,20 @@ Compresses the old 10-15-turn back-and-forth into two decisions.
    - One `sdd/spec/{domain}.md` per drafted domain (each AC carries `<!-- @impl: <path>::<symbol> -->` anchors per Phase 5's source-evidence pass)
    - Empty `sdd/spec/.review-queue.md` with `_Awaiting first finding._` placeholder
    - Empty `tests/` directory
+
+   **REQ rendering — MUST READ before writing any `sdd/spec/{domain}.md` file.** The canonical shape lives at `references/templates/req-shape-example.md` (single source of truth). Open that file and copy the SHAPE of REQ-EXAMPLE-001 for every REQ you emit. The hard rules below are scannable mid-write; the full exemplar with two worked cases (populated + `None.`-rendered) lives in the template file.
+
+   **Hard rules (every REQ in every emitted file):**
+   - Heading is `### REQ-{DOMAIN}-{NNN}: {Title}` (H3, not H2).
+   - Field order is locked: **Intent → Applies To → Acceptance Criteria → Notes (optional) → Constraints → Priority → Dependencies → Verification → Status**. Status is the LAST field, never the first.
+   - One blank line between every labeled field. Stacking two `**Field:**` lines on consecutive lines collapses them on GitHub and is MEDIUM `trailing-fields-collapsed`.
+   - ACs are NUMBERED (`1. 2. 3.`), never bulleted (`-`). Bulleted ACs are MEDIUM `ac-bullets-not-numbered`.
+   - `Constraints:` and `Dependencies:` ALWAYS present. Render `None.` (literal) when empty. CON-* and REQ-* IDs MUST render as markdown anchor links, not plain text.
+   - Every AC describing observable behaviour ends with `<!-- @impl: <path>::<symbol> -->`. ACs asserting a concrete value use `<!-- @impl: <path>::<symbol> = <value-pattern> -->`.
+   - `**Applies To:**`, `**Priority:**`, `**Verification:**` are REQUIRED — no REQ is allowed to omit them.
+   - Each REQ ends with `---` on its own line, blank lines either side.
+
+   Deviation from this shape is a MEDIUM finding caught by `spec-enforce` row 3 (REQ rendering template) on the next PR-boundary review. **The shape is non-negotiable** — do not invent a tighter form because writing 15-45 REQs in a row is tedious. Re-open `req-shape-example.md` between domains if drift creeps in.
 
    **Emit only files in the canonical layout** (defined in `spec-driven-development` § "Spec structure"). Anything outside that layout — including `sdd/spec/README.md` or `documentation/lanes/README.md` — is a HIGH `layout-violation` caught by `doc-enforce-lanes` § Layout conformance on the next review. The single comprehensive index lives in `sdd/README.md` (Domains table linking to `spec/{file}.md`) and `documentation/README.md` (Jump-TOC linking to lanes + decisions).
 6. **Run Phase 6 — documentation lane emission and audit.** Conditional per-lane emission driven by source evidence (see § Phase 6 below). Emit each template VERBATIM — the `documentation-readme.md` template includes Jump-TOC, Lane ownership table, REQ backlinks section, Synonym glossary, Reading order, and Related links; abbreviated emission that strips any of those sections is a HIGH `scaffold-template-stripped` finding caught by step 9's iterate-to-clean (the audit verifies all template section headings are present in the emitted output). Outputs:

--- a/preseed/agents/claude/skills/spec-driven-development/SKILL.md
+++ b/preseed/agents/claude/skills/spec-driven-development/SKILL.md
@@ -80,51 +80,20 @@ The enforcement check (one walk, one rule) lives in `doc-enforce-lanes` § Layou
 
 ## REQ format
 
-Every Active REQ in `sdd/{domain}.md` MUST render in this exact shape. Deviations are MEDIUM, auto-fixed by re-rendering (mechanics in `spec-enforce` § REQ rendering template).
+**Canonical shape: see `references/templates/req-shape-example.md`.** That file is the single source of truth — a fully-rendered two-REQ example with every field, blank lines, numbered ACs, source-anchor comments, and the empty-field (`None.`) rendering. Every Active REQ in `sdd/{domain}.md` (or `sdd/spec/{domain}.md` on the nested layout) MUST copy that shape verbatim. Deviations are MEDIUM, auto-fixed by re-rendering (mechanics in `spec-enforce` § REQ rendering template).
 
-```markdown
-### REQ-{DOMAIN}-{NNN}: {Title}
+**Hard rules (scannable mid-write — the full exemplar is in the template):**
 
-**Intent:** {one paragraph, 1-4 sentences. No bullets, no headings, no code blocks.}
-
-**Applies To:** {single actor name — User, Admin, etc. Never "System".}
-
-**Acceptance Criteria:**
-
-1. {first AC, single behavioural statement, <=150 words} <!-- @impl: <path>::<symbol> -->
-2. {AC asserting a concrete value} <!-- @impl: <path>::<symbol> = <value-pattern> -->
-3. {...up to 7 maximum}
-
-**Constraints:** [CON-X-NNN](constraints.md#con-x-nnn-title-slug), [CON-Y-NNN](constraints.md#con-y-nnn-title-slug)
-
-**Priority:** P0 | P1 | P2 | P3
-
-**Dependencies:** [REQ-X-NNN](#req-x-nnn-title-slug), [REQ-Y-NNN](other-domain.md#req-y-nnn-title-slug)
-
-**Verification:** Automated test | Integration test | Manual check
-
-**Status:** Proposed | Planned | Partial | Implemented
-
----
-```
-
-The `<!-- @impl: ... -->` HTML comment is rendered invisibly by Markdown and carries the source-anchor used by the Truth-guarantee validators. Full convention at § "Source-anchor convention" above.
-
-**Required fields, always present:**
-- **Intent**, **Applies To**, **Acceptance Criteria**, **Priority**, **Verification**, **Status** — always populated.
-- **Constraints**, **Dependencies** — always present. Render `None.` (literal) when empty. A REQ missing these fields entirely is MEDIUM `req-missing-required-field`.
-
-**ACs are numbered** (`1.`, `2.`, `3.`), never bulleted. Bulleted ACs are MEDIUM `ac-bullets-not-numbered`, auto-fixed.
-
-**Each labeled field is on its own line**, separated by a single blank line. Stacking Priority/Dependencies/Verification/Status on consecutive lines without blank-line separation collapses them into one rendered paragraph on GitHub — MEDIUM `trailing-fields-collapsed`.
-
-**Cross-references render as markdown anchor links**, not plain text. Plain-text REQ-* or CON-* IDs inside `**Constraints:**` or `**Dependencies:**` are MEDIUM `cross-reference-not-linked`, auto-fixed.
-
-**Notes** is OPTIONAL — only two shapes (see `spec-enforce` § Rule B): Partial-explanation (`Status: Partial` only, ≤3 sentences) or Doc-pointer (any status, ≤2 sentences, MUST contain a markdown link to `documentation/**` or `sdd/**`). Sibling-REQ cross-references go in `Dependencies:`.
-
-**Deprecated REQs are deleted, not tombstoned.** No `Replaced By:` field, no `Removed In:` field. Out-of-scope ideas go to `## Out of Scope` in the domain README.
-
-**Inline source-anchors on AC bullets (binding from /sdd init forward).** Every AC bullet describing observable behaviour SHOULD carry a trailing `<!-- @impl: <path>::<symbol> -->` HTML comment naming the implementing symbol. AC bullets describing a specific concrete value (number, threshold, retry count, storage target) SHOULD carry `<!-- @impl: <path>::<symbol> = <value-pattern> -->`. Validators (CQ-SOURCE in `spec-enforce-truth`) read these comments and verify the symbol + value against source. AC bullets without an anchor are valid but generate `ac-missing-source-anchor` findings (MEDIUM) during enforcement; `Verification: Manual check` REQs are exempt. The convention applies to ADR `Context:` blocks too.
+- Heading is `### REQ-{DOMAIN}-{NNN}: {Title}` (H3, never H2).
+- Field order is locked: **Intent → Applies To → Acceptance Criteria → Notes (optional) → Constraints → Priority → Dependencies → Verification → Status**. Status is the LAST field, never the first.
+- **Required fields** (every REQ): Intent, Applies To, Acceptance Criteria, Constraints, Priority, Dependencies, Verification, Status. Constraints and Dependencies render the literal `None.` when empty; omitting them entirely is MEDIUM `req-missing-required-field`.
+- One blank line between every `**Field:**` line. Stacking two label lines on consecutive lines collapses them on GitHub render — MEDIUM `trailing-fields-collapsed`.
+- ACs are **numbered** (`1. 2. 3.`), never bulleted (`-`) — MEDIUM `ac-bullets-not-numbered`. Maximum 7 ACs per REQ.
+- CON-* and REQ-* IDs inside Constraints/Dependencies render as markdown anchor links, not plain text — MEDIUM `cross-reference-not-linked`.
+- Every AC describing observable behaviour ends with `<!-- @impl: <path>::<symbol> -->`. ACs asserting a concrete value use `<!-- @impl: <path>::<symbol> = <value-pattern> -->`. Validators in `spec-enforce-truth` (CQ-SOURCE) read these comments and verify symbol + value against source. AC bullets without an anchor are valid but generate `ac-missing-source-anchor` findings (MEDIUM); `Verification: Manual check` REQs are exempt. Same convention applies to ADR `Context:` blocks.
+- **Notes** is OPTIONAL — only two shapes (see `spec-enforce` § Rule B): Partial-explanation (`Status: Partial` only, ≤3 sentences) or Doc-pointer (any status, ≤2 sentences, MUST contain a markdown link to `documentation/**` or `sdd/**`). Sibling-REQ cross-references go in `Dependencies:`.
+- Each REQ ends with `---` on its own line, blank lines either side.
+- **Deprecated REQs are deleted, not tombstoned.** No `Replaced By:`, no `Removed In:`. Out-of-scope ideas go to `## Out of Scope` in the domain README.
 
 ## Source-anchor convention (binding, single source of truth)
 
@@ -312,6 +281,7 @@ All scaffolding templates live in `references/templates/` within this skill. The
 
 | Template | Used by |
 |---|---|
+| `req-shape-example.md` | Read-only exemplar — canonical shape every REQ MUST copy. NOT emitted as a file; consulted before every REQ write. |
 | `root-readme.md` | `/sdd init` → `README.md` |
 | `sdd-readme.md` | `/sdd init` → `sdd/README.md` |
 | `sdd-glossary.md` | `/sdd init` → `sdd/spec/glossary.md` |

--- a/preseed/agents/claude/skills/spec-driven-development/references/templates/req-shape-example.md
+++ b/preseed/agents/claude/skills/spec-driven-development/references/templates/req-shape-example.md
@@ -1,0 +1,83 @@
+<!-- doc-discipline: copy-fixture, not a real domain file. Agent copies the
+     SHAPE of a single REQ block from here. The full skill manifest lives in
+     spec-driven-development § "REQ format" and spec-enforce § "REQ rendering
+     template"; this file is the literal exemplar so the agent does not
+     re-derive the shape from prose. -->
+
+# Example Domain
+
+One-paragraph domain summary — what this slice of behaviour covers and why it exists. No edit history, no dates, no "this file was extracted from..." lines (those go in `sdd/spec/changes.md`).
+
+## REQ-EXAMPLE-001: One-line title in sentence case
+
+**Intent:** One paragraph, 1-4 sentences, plain prose. No bullets, no headings, no code blocks. Describes WHAT the system does and WHY a user cares. Stays focused on observable behaviour; mechanism detail moves to `documentation/`.
+
+**Applies To:** User
+
+**Acceptance Criteria:**
+
+1. First observable behaviour, single sentence, <=150 words. Describes what is true after the system runs. <!-- @impl: lib/services/example_service.dart::doThing -->
+2. Second behaviour asserting a concrete value. Use the `= <value-pattern>` form on the anchor so the value-drift check can resolve. <!-- @impl: lib/services/example_service.dart::doThing = 3 -->
+3. Up to 7 ACs maximum, numbered (`1.`, `2.`, ...), never bulleted (`-`). <!-- @impl: lib/services/example_service.dart::doThing -->
+
+**Constraints:** [CON-EXAMPLE-001](constraints.md#con-example-001-title-slug), [CON-SEC-001](constraints.md#con-sec-001-title-slug)
+
+**Priority:** P1
+
+**Dependencies:** [REQ-OTHER-001](other-domain.md#req-other-001-title-slug)
+
+**Verification:** Automated test
+
+**Status:** Implemented
+
+---
+
+## REQ-EXAMPLE-002: Second REQ shows the empty-field rendering
+
+**Intent:** A REQ with no constraints and no dependencies still has both fields present. The literal token `None.` renders for each empty field. Omitting either field entirely is a MEDIUM `req-missing-required-field` finding.
+
+**Applies To:** User
+
+**Acceptance Criteria:**
+
+1. The single AC describes one behaviour. <!-- @impl: lib/services/example_service.dart::otherThing -->
+
+**Constraints:** None.
+
+**Priority:** P2
+
+**Dependencies:** None.
+
+**Verification:** Manual check
+
+**Status:** Partial
+
+**Notes:** Status is `Partial` because the UI affordance exists but the server endpoint is not yet wired. See [pending.md](../../../pending.md).
+
+---
+
+<!--
+  Shape rules pinned by this fixture (deviation is a MEDIUM auto-fix in
+  spec-enforce row 3):
+
+  1. REQ heading is H3 (`### REQ-{DOMAIN}-{NNN}: {Title}`), never H2.
+  2. Field order is LOCKED: Intent -> Applies To -> Acceptance Criteria
+     -> Notes (optional) -> Constraints -> Priority -> Dependencies
+     -> Verification -> Status. Status is ALWAYS the last field.
+  3. One blank line between every `**Field:**` line. Two label lines on
+     consecutive lines collapse on GitHub render.
+  4. ACs are numbered (`1.`, `2.`, `3.`), never bulleted (`-`).
+  5. Constraints and Dependencies ALWAYS present; render `None.` (literal,
+     with trailing period) when empty.
+  6. CON-* and REQ-* references inside Constraints/Dependencies render as
+     markdown anchor links, never plain text.
+  7. Every AC describing observable behaviour ends with
+     `<!-- @impl: <path>::<symbol> -->`. ACs asserting a concrete value
+     use `<!-- @impl: <path>::<symbol> = <value-pattern> -->`.
+  8. Applies To, Priority, and Verification are REQUIRED on every REQ.
+  9. Each REQ ends with `---` on its own line, blank lines either side.
+ 10. Notes is OPTIONAL and uses one of two shapes only: Partial-explanation
+     (Status=Partial only, <=3 sentences) OR Doc-pointer (any status,
+     <=2 sentences, MUST contain a markdown link to documentation/** or
+     sdd/**). Sibling-REQ cross-references go in Dependencies, not Notes.
+-->

--- a/preseed/agents/claude/skills/spec-driven-development/references/templates/sdd-config.yml
+++ b/preseed/agents/claude/skills/spec-driven-development/references/templates/sdd-config.yml
@@ -56,13 +56,25 @@ test_globs:
   - "e2e/**"
 
 # Forbidden content allowlist — which categories are acceptable inside REQs.
-# When false, the category is banned. When true, it's allowed.
+# When false, the category is banned and any AC/Intent mentioning it is
+# flagged HIGH `forbidden-content-in-req`; the content moves to
+# documentation/. When true, the category is allowed.
+#
+# These five flags are set by the agent at /sdd init time based on the
+# spec-flavour prompt:
+#   - Technical (default for engineering teams): all five flags = true.
+#   - Business / behavioural (stakeholders read REQs): protocols, vendors,
+#     http_codes_in_api_reqs, performance_numbers = false; user_facing_strings
+#     stays true (quoted UI strings ARE the assertion target).
+#   - Custom: each flag set individually at init.
+#
+# Re-run `/sdd mode allowlist` to flip the flavour mid-project.
 forbidden_content_allowlist:
-  protocols: true        # OAuth, JWT, WebSocket, etc.
-  vendors: true          # Cloudflare Access, Stripe, Resend, etc.
-  http_codes_in_api_reqs: true  # HTTP status codes when documenting an API contract REQ
-  performance_numbers: true  # "p95 < 200ms", "LCP < 2.5s"
-  user_facing_strings: true  # quoted text the user actually sees
+  protocols: {{ALLOWLIST_PROTOCOLS}}        # OAuth, JWT, WebSocket, etc.
+  vendors: {{ALLOWLIST_VENDORS}}          # Cloudflare Access, Stripe, Resend, etc.
+  http_codes_in_api_reqs: {{ALLOWLIST_HTTP_CODES}}  # HTTP status codes when documenting an API contract REQ
+  performance_numbers: {{ALLOWLIST_PERFORMANCE}}  # "p95 < 200ms", "LCP < 2.5s"
+  user_facing_strings: {{ALLOWLIST_USER_FACING}}  # quoted text the user actually sees
 
 # Per-REQ overrides — REQ IDs that opt out of forbidden-content checks entirely
 forbidden_content_overrides: []

--- a/preseed/agents/claude/skills/spec-enforce/SKILL.md
+++ b/preseed/agents/claude/skills/spec-enforce/SKILL.md
@@ -104,45 +104,21 @@ Auto-fix in `auto`/`unleashed`: detect `Status: Deprecated` REQs and delete them
 
 ## REQ rendering template (binding)
 
-Every Active REQ in `sdd/{domain}.md` MUST render in exactly this shape. Deviations are MEDIUM, auto-fixed by re-rendering.
+**Canonical shape: `spec-driven-development/references/templates/req-shape-example.md`.** That fixture is the single source of truth for REQ rendering. Every Active REQ in `sdd/{domain}.md` (flat layout) or `sdd/spec/{domain}.md` (nested layout) MUST copy its shape exactly. Deviations from any rule below are MEDIUM, auto-fixed by re-rendering.
 
-```
-### REQ-{DOMAIN}-{NNN}: {Title}
+**Rules walked by this row (single normative list):**
 
-**Intent:** {one paragraph, 1-4 sentences. No bullets, no headings, no code blocks.}
+- **Heading**: `### REQ-{DOMAIN}-{NNN}: {Title}` (H3, never H2).
+- **Field order is locked**: Intent → Applies To → Acceptance Criteria → Notes (optional) → Constraints → Priority → Dependencies → Verification → Status. Status is ALWAYS the last field. Out-of-order fields = MEDIUM `req-field-order-violation`.
+- **Required fields** present in every REQ: Intent, Applies To, Acceptance Criteria, Constraints, Priority, Dependencies, Verification, Status. Missing field = MEDIUM `req-missing-required-field`.
+- **Empty Constraints/Dependencies render the literal `None.`** (with trailing period). Omitting the field entirely is a `req-missing-required-field` violation, NOT a no-op.
+- **Cross-reference linking**: Every `CON-*` and `REQ-*` ID inside `**Constraints:**` and `**Dependencies:**` MUST render as a markdown anchor link. Same-file REQ: `[REQ-X-NNN](#req-x-nnn-title-slug)`. Other-domain REQ: `[REQ-X-NNN](other-domain.md#req-x-nnn-title-slug)`. Constraint: `[CON-X-NNN](constraints.md#con-x-nnn-title-slug)`. Slugs follow GFM convention. Plain-text IDs in these fields = MEDIUM `cross-reference-not-linked`. Detection: regex `\b(REQ|CON)-[A-Z]+-\d+\b` inside the field values, outside `]( )` parentheses.
+- **Blank-line policy**: one blank line between every `**Field:**` line, including each member of the trailing-fields block (Constraints, Priority, Dependencies, Verification, Status). Two label lines on consecutive lines collapse on GitHub render = MEDIUM `trailing-fields-collapsed`. Closing `---` separator on its own line, blank lines either side.
+- **AC numbering**: ACs are numbered (`1. 2. 3.`), never bulleted (`-`) = MEDIUM `ac-bullets-not-numbered`. Maximum 7 ACs per REQ.
+- **Source anchors**: Every AC describing observable behaviour ends with `<!-- @impl: <path>::<symbol> -->`. ACs asserting a concrete value use `<!-- @impl: <path>::<symbol> = <value-pattern> -->`. Anchor absent on an AC = MEDIUM `ac-missing-source-anchor` (Manual-check REQs exempt).
+- **Banned inside a REQ body**: sub-headings (`####`/`#####`), nested lists, code blocks, tables, strikethrough, "Current behaviour:" / "Previously:" branches, block quotes.
 
-**Applies To:** {single actor name from sdd/README.md actors table. Never "System".}
-
-**Acceptance Criteria:**
-
-1. {first AC, single behavioural statement, <=150 words, no sub-bullets, no nested lists}
-2. {second AC, same shape}
-3. {...up to 7 maximum}
-
-**Notes:** {OPTIONAL. Two sanctioned shapes - see Rule B.}
-
-**Constraints:** [CON-AUTH-001](constraints.md#con-auth-001-title-slug), [CON-SEC-001](constraints.md#con-sec-001-title-slug)
-
-**Priority:** {P0 | P1 | P2 | P3}
-
-**Dependencies:** [REQ-AUTH-002](#req-auth-002-title-slug), [REQ-AUTH-003](authentication.md#req-auth-003-title-slug)
-
-**Verification:** {Automated test | Integration test | Manual check}
-
-**Status:** {Proposed | Planned | Partial | Implemented}
-```
-
-**Cross-reference linking (binding).** Every `CON-*` and `REQ-*` ID inside `**Constraints:**` and `**Dependencies:**` MUST render as a markdown anchor link, not plain text. Form:
-
-- Same-file REQ reference: `[REQ-X-NNN](#req-x-nnn-title-slug)`
-- Other-domain REQ reference: `[REQ-X-NNN](other-domain.md#req-x-nnn-title-slug)`
-- Constraint reference: `[CON-X-NNN](constraints.md#con-x-nnn-title-slug)`
-
-Slugs follow GitHub-flavoured Markdown convention. Plain-text IDs in these four fields are a MEDIUM finding `cross-reference-not-linked`, auto-fixed by rewriting to the link form. Detection: regex `\b(REQ|CON)-[A-Z]+-\d+\b` inside the four field values, outside `]( )` parentheses.
-
-**Banned inside a REQ body:** sub-headings (`####`/`#####`), nested lists, code blocks, tables, strikethrough, "Current behaviour:" / "Previously:" branches, block quotes.
-
-**Blank-line policy (binding):** one blank line between every labeled field, including each of the trailing-fields block (`Constraints`, `Priority`, `Dependencies`, `Verification`, `Status`). Stacking these on consecutive lines without blank-line separation collapses them into one rendered paragraph on GitHub, MEDIUM `trailing-fields-collapsed`. Closing `---` separator on its own line, preceded and followed by one blank line.
+Auto-fix in `auto`/`unleashed`: re-render the REQ from its parsed fields into the canonical shape (inserts blank lines, renumbers ACs, reorders fields, rewrites cross-refs as anchor links, fills `None.` on empty Constraints/Dependencies). Interactive mode prompts before each rewrite. If a required field cannot be inferred from existing content (e.g. `Applies To:` was never written), escalate to triage rather than fabricate.
 
 ## REQ length guidance
 


### PR DESCRIPTION
## Summary

Audit of \`/sdd init\` output on zipline-native (develop branch) showed 45/45 REQs drifted from the canonical shape on every stylistic rule. Rules existed in skill prose; the agent re-derived shape from prose under load and got it consistently wrong (Status at top, no blank lines, bulleted ACs, missing Applies To / Priority / Verification, H2 instead of H3).

Five changes, no script-based verifier:

1. \`sdd-init\` step 1: spec-flavour prompt (Technical / Business / Custom). User picks at init time; choice drives the five \`forbidden_content_allowlist\` flags. Replaces the prior hardcoded all-true defaults which silently opted every spec into technical content rules.
2. \`sdd-init\` step 5: REQ-write block opens with MUST READ pointer to \`req-shape-example.md\` + 10-line hard rules list. No inline rendering example.
3. \`references/templates/req-shape-example.md\` (new): canonical exemplar with two fully rendered REQs.
4. \`references/templates/sdd-config.yml\`: hardcoded \`true: true: true: true: true:\` replaced with \`{{ALLOWLIST_*}}\` placeholders.
5. \`spec-enforce\` row 3 + \`spec-driven-development\` § REQ format: both point at \`req-shape-example.md\` as canonical, rules listed once normatively.

## Test plan

- [ ] Re-run \`/sdd init\` on a fresh scratch repo, verify Technical / Business / Custom prompt appears
- [ ] Verify emitted REQs match \`req-shape-example.md\` shape (H3, numbered ACs, blank lines, all required fields, anchor links)
- [ ] Verify generated \`sdd/spec/config.yml\` has the chosen allowlist values, not the hardcoded defaults
- [ ] Spot-check that a Business-mode REQ mentioning a vendor name surfaces as HIGH \`forbidden-content-in-req\` on the next spec-enforce run