### PR TITLE
fix(security): escape all regex metacharacters (CodeQL #54)

### DIFF
--- a/documentation/lanes/security.md
+++ b/documentation/lanes/security.md
@@ -72,7 +72,7 @@ Fixes from 6 rounds of automated code review before 1500-user launch:
 
 **SaaS service-token guard:** `cf-access-client-id` header in `getUserFromRequest` is only trusted when `!isSaasModeActive()`. In SaaS mode there is no CF Access edge to validate this header, making it attacker-controlled.
 
-**Session mode billing enforcement:** `resolveSessionMode` result is clamped against the billing-resolved effective tier at both container start (`lifecycle.ts`) and preferences save (`preferences.ts`). A canceled user with stale `sessionMode: 'advanced'` preference gets `'default'` because the free tier only allows `['default']`. Both paths use `getEffectiveTier` (not raw JWT `subscriptionTier`).
+**Session mode billing enforcement:** The stored `sessionMode` preference is clamped against the billing-resolved effective tier by `clampSessionModeToTier` in `src/lib/session-mode.ts` (implements [REQ-SEC-015](../../sdd/spec/security.md#req-sec-015-blocked-user-cannot-self-upgrade-subscription) AC2/AC3). Applied at container start (`lifecycle.ts`) and preferences save (`preferences.ts`). A canceled user with stale `sessionMode: 'advanced'` preference gets `'default'` because the free tier only allows `['default']`. Both call sites use `getEffectiveTier` (not raw JWT `subscriptionTier`).
 
 **Concurrent cache dedup (CF-002):** Auth config fetch in `access.ts` wrapped in `pendingAuthConfigFetch` Promise sentinel (mirrors `pendingJWKSFetch` pattern from `jwt.ts`). Two concurrent cold-start requests reuse the in-flight fetch instead of issuing redundant KV reads. Sentinel cleared on TTL expiry and `resetAuthConfigCache()`.
 

--- a/host/__tests__/memory-capture-block.test.js
+++ b/host/__tests__/memory-capture-block.test.js
@@ -125,7 +125,10 @@ describe('memory-capture-block.sh - hard block / REQ-MEM-012 AC3', () => {
     });
     assert.equal(r.status, 2);
     assert.match(r.stderr, /PROMPT_FILE=/);
-    assert.match(r.stderr, new RegExp(`VARS_FILE=${varsPath.replace(/[/.]/g, '\\$&')}`));
+    // Escape every regex metacharacter (including backslash) so a path with
+    // any special char in it is matched literally. CodeQL alert #54
+    // (js/incomplete-sanitization) caught the prior 2-char class missing \\.
+    assert.match(r.stderr, new RegExp(`VARS_FILE=${varsPath.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}`));
     assert.match(r.stderr, /subagent_type:\s*"memory-capture"/);
     assert.match(r.stderr, /run_in_background:\s*true/);
     assert.match(r.stderr, /sonnet/);


### PR DESCRIPTION
## Summary

CodeQL alert #54 (js/incomplete-sanitization, HIGH) on host/__tests__/memory-capture-block.test.js:128. The 2-char class [/.] only escaped / and . — a backslash in the path would have been left unescaped and re-interpreted as a regex meta. Replaced with the full standard escape set covering . * + ? ^ \$ { } ( ) | [ ] \ /.

Test behaviour unchanged on Linux paths. The fix only widens the input domain the regex can safely handle.

## Test plan

- [x] CI green on PR Checks
- [x] CodeQL re-scan clears alert #54