### PR TITLE
feat: restore Cloudflare token scope tiers with prefilled URLs (REQ-AGENT-028)

### DIFF
--- a/documentation/lanes/configuration.md
+++ b/documentation/lanes/configuration.md
@@ -105,47 +105,36 @@ Base image: Node.js 24 Debian (bookworm-slim).
 
 ## API Token Permissions
 
-### Cloudflare API Token (Operator)
+### Cloudflare API Token (User)
 
-These are the permissions required for the Cloudflare API token used by the deploy workflow and worker runtime. Codeflare recommends using the **"Edit Cloudflare Workers"** template when creating the token, then adding the additional scopes listed below.
+Users connect their Cloudflare account by creating an API token. Codeflare offers three scope tiers -- choose based on what you build:
 
-#### Account Permissions
+| Scope | Minimal | Recommended | Advanced | Why |
+|---|---|---|---|---|
+| **Workers Scripts: Edit** | yes | yes | yes | Deploy Workers and manage secrets |
+| **Workers KV Storage: Edit** | yes | yes | yes | KV namespace management |
+| **Workers R2 Storage: Edit** | yes | yes | yes | Object storage for user data |
+| **D1: Edit** | yes | yes | yes | SQL database management |
+| **Workers Routes: Edit** | yes | yes | yes | Route traffic to Workers |
+| **Account Settings: Read** | yes | yes | yes | Account ID discovery |
+| **Zone: Read** | yes | yes | yes | Zone ID resolution |
+| **DNS: Edit** | - | yes | yes | Manage DNS records for custom domains |
+| **Access: Apps and Policies: Edit** | - | yes | yes | Cloudflare Access applications |
+| **Access: Orgs, IdPs, and Groups: Edit** | - | yes | yes | Access groups and identity providers |
+| **Cloudflare Pages: Edit** | - | - | yes | Deploy static sites and full-stack apps |
+| **Containers: Edit** | - | - | yes | Container lifecycle management |
+| **API Tokens: Edit** | - | - | yes | Create/revoke scoped tokens programmatically |
+| **Queues: Edit** | - | - | yes | Message queue management |
+| **Workers AI: Edit** | - | - | yes | Inference and model management |
+| **Workers AI: Read** | - | - | yes | Read-only inference access |
+| **Vectorize: Edit** | - | - | yes | Vector database for AI embeddings |
+| **Turnstile: Edit** | - | - | yes | CAPTCHA widget management |
+| **Workers Builds Configuration: Edit** | - | - | yes | CI/CD build pipeline configuration |
+| **Workers Observability: Edit** | - | - | yes | Logs, traces, and monitoring |
+| **Workers R2 Data Catalog: Edit** | - | - | yes | R2 bucket metadata and catalog |
+| **Workers Agents Configuration: Edit** | - | - | yes | Cloudflare Agents configuration |
 
-| Permission | Access | Required | Why |
-|-----------|--------|----------|-----|
-| Account Settings | Read | Yes | Account ID discovery |
-| Workers Scripts | Edit | Yes | Deploy worker + secrets |
-| Workers KV Storage | Edit | Yes | KV namespace management |
-| Workers R2 Storage | Edit | Yes | Per-user R2 buckets |
-| Containers | Edit | Yes | Container lifecycle |
-| Access: Apps and Policies | Edit | Yes | Managed Access app |
-| Access: Organizations, Identity Providers, and Groups | Edit | Yes | Access groups + auth_domain |
-| Turnstile | Edit | Only if onboarding active | Turnstile widget |
-| API Tokens | Edit | Yes | Create/revoke per-user scoped R2 tokens |
-
-#### Zone Permissions
-
-| Permission | Access | Required | Why |
-|-----------|--------|----------|-----|
-| Zone | Read | Yes | Zone ID resolution |
-| DNS | Edit | Yes | Proxied CNAME |
-| Workers Routes | Edit | Yes | Worker route upsert |
-
-#### Additional Scopes You May Need
-
-If your agent asks for additional permissions, you can add them by editing your token in the [Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens):
-
-| Permission | Level | When Needed |
-|---|---|---|
-| D1 | Edit | Creating and managing D1 databases |
-| DNS | Edit | Managing DNS records for custom domains |
-| Zone | Read | Required alongside DNS for zone resolution |
-| Turnstile | Edit | Creating CAPTCHA widgets |
-| Access: Apps and Policies | Edit | Managing Cloudflare Access applications |
-| Access: Organizations | Edit | Managing Access groups and identity providers |
-| API Tokens | Edit | Managing other API tokens programmatically |
-
-Cloudflare API tokens do not expire by default but can be set to expire during creation. You can scope tokens to specific accounts and zones, or use "All accounts" and "All zones" for convenience.
+The connect flow pre-fills the Cloudflare dashboard token creation form with the correct permissions for the selected tier. Cloudflare API tokens do not expire by default but can be set to expire during creation. Scope tokens to specific accounts and zones, or use "All accounts" and "All zones" for convenience. Implements [REQ-AGENT-028](../../sdd/spec/agents.md#req-agent-028-deploy-credential-token-creation-ux) AC2.
 
 ### GitHub Fine-Grained PAT (User)
 

--- a/documentation/lanes/configuration.md
+++ b/documentation/lanes/configuration.md
@@ -105,6 +105,48 @@ Base image: Node.js 24 Debian (bookworm-slim).
 
 ## API Token Permissions
 
+### Cloudflare API Token (Operator)
+
+These are the permissions required for the Cloudflare API token used by the deploy workflow and worker runtime. Codeflare recommends using the **"Edit Cloudflare Workers"** template when creating the token, then adding the additional scopes listed below.
+
+#### Account Permissions
+
+| Permission | Access | Required | Why |
+|-----------|--------|----------|-----|
+| Account Settings | Read | Yes | Account ID discovery |
+| Workers Scripts | Edit | Yes | Deploy worker + secrets |
+| Workers KV Storage | Edit | Yes | KV namespace management |
+| Workers R2 Storage | Edit | Yes | Per-user R2 buckets |
+| Containers | Edit | Yes | Container lifecycle |
+| Access: Apps and Policies | Edit | Yes | Managed Access app |
+| Access: Organizations, Identity Providers, and Groups | Edit | Yes | Access groups + auth_domain |
+| Turnstile | Edit | Only if onboarding active | Turnstile widget |
+| API Tokens | Edit | Yes | Create/revoke per-user scoped R2 tokens |
+
+#### Zone Permissions
+
+| Permission | Access | Required | Why |
+|-----------|--------|----------|-----|
+| Zone | Read | Yes | Zone ID resolution |
+| DNS | Edit | Yes | Proxied CNAME |
+| Workers Routes | Edit | Yes | Worker route upsert |
+
+#### Additional Scopes You May Need
+
+If your agent asks for additional permissions, you can add them by editing your token in the [Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens):
+
+| Permission | Level | When Needed |
+|---|---|---|
+| D1 | Edit | Creating and managing D1 databases |
+| DNS | Edit | Managing DNS records for custom domains |
+| Zone | Read | Required alongside DNS for zone resolution |
+| Turnstile | Edit | Creating CAPTCHA widgets |
+| Access: Apps and Policies | Edit | Managing Cloudflare Access applications |
+| Access: Organizations | Edit | Managing Access groups and identity providers |
+| API Tokens | Edit | Managing other API tokens programmatically |
+
+Cloudflare API tokens do not expire by default but can be set to expire during creation. You can scope tokens to specific accounts and zones, or use "All accounts" and "All zones" for convenience.
+
 ### Cloudflare API Token (User)
 
 Users connect their Cloudflare account by creating an API token. Codeflare offers three scope tiers -- choose based on what you build:

--- a/sdd/spec/agents.md
+++ b/sdd/spec/agents.md
@@ -1591,7 +1591,7 @@ None.
 
 <!-- @impl: web-ui/src/lib/token-scopes.ts -->
 <!-- @impl: web-ui/src/components/settings/ProviderRow.tsx -->
-<!-- @test: web-ui/src/__tests__/lib/token-scopes.test.ts (GITHUB_TIERS + getGithubTokenUrl + CLOUDFLARE_TOKEN_PAGE describes -> AC1 three-tier scope selector with correct scope prefills per tier + AC2 Cloudflare token page targeting) -->
+<!-- @test: web-ui/src/__tests__/lib/token-scopes.test.ts (GITHUB_TIERS + getGithubTokenUrl describes -> AC1 three-tier GitHub scope selector; CLOUDFLARE_TIERS + getCloudflareTokenUrl describes -> AC2 three-tier Cloudflare scope selector with 7/10/22 scope counts) -->
 
 **Intent:** Token creation for GitHub and Cloudflare must guide users through scope selection so they create the smallest token that still unlocks the features they need, without copy-pasting raw scope strings.
 
@@ -1600,18 +1600,18 @@ None.
 **Acceptance Criteria:**
 
 1. GitHub token creation offers three scope tiers (Minimal, Recommended, Advanced) via a selector in the connect flow, with Recommended pre-selected and the URL pre-filling the correct scopes per tier.
-2. Cloudflare token creation directs users to use the "Edit Cloudflare Workers" template with account and zone selection. No scope pre-fill (Cloudflare template URLs are broken).
+2. Cloudflare token creation offers three scope tiers (Minimal, Recommended, Advanced) via the same selector pattern, with Recommended pre-selected and the URL pre-filling the correct permission group keys per tier.
 3. A documentation page lists all scopes per tier with explanations of why each is needed, linked from the UI via "See all scopes".
 
 **Constraints:**
 
 - GitHub Minimal: 1 scope (contents). Recommended: 6 scopes (contents, PRs, actions, workflows, administration, secrets). Advanced: all 19 scopes including Copilot.
-- Cloudflare: "Edit Cloudflare Workers" template covers Workers, KV, R2, Pages, Containers, Routes. Users add extra scopes (D1, DNS, Access, Turnstile) when their agent requests them.
+- Cloudflare Minimal: 7 scopes (Workers Scripts, KV, R2, D1, Routes, Account Settings read, Zone read). Recommended: 10 scopes (Minimal + DNS, Access Apps+Policies, Access Orgs+IdPs). Advanced: 22 scopes (Recommended + Pages, Containers, API Tokens, Queues, AI read+write, Vectorize, Turnstile, Builds, Observability, R2 Data Catalog, Agents).
 
 **Priority:** P1
 
 **Dependencies:** [REQ-AGENT-010](#req-agent-010-deploy-credential-storage-github-pat-cf-api-token), [REQ-AGENT-019](#req-agent-019-branded-settings-ui)
 
-**Verification:** Manual check
+**Verification:** [Token scope tests](../../web-ui/src/__tests__/lib/token-scopes.test.ts)
 
 **Status:** Implemented

--- a/sdd/spec/changes.md
+++ b/sdd/spec/changes.md
@@ -5,6 +5,7 @@ Semantic changes to the specification. Git history captures diffs; this file cap
 ## 2026-05-26
 
 - REQ-AGENT-049 added: preseed content is now reconciled automatically on first dashboard load when a release ships updated agent skills, rules, or plugins. Build-time SHA-256 hash piggybacked on batch-status initial load; hash stored in UserPreferences KV. UI prevents session creation during the brief upgrade. No manual "Recreate" click required.
+- REQ-AGENT-028 AC2 updated: Cloudflare token creation now uses three-tier scope selector (Minimal 7 / Recommended 10 / Advanced 22 scopes) with prefilled template URLs, matching the existing GitHub pattern. Replaces the plain API tokens page link that was a workaround after Cloudflare broke the old template URL syntax.
 
 ## 2026-05-25
 

--- a/web-ui/src/__tests__/lib/token-scopes.test.ts
+++ b/web-ui/src/__tests__/lib/token-scopes.test.ts
@@ -1,9 +1,10 @@
-// Implements REQ-AGENT-010
+// Implements REQ-AGENT-010, REQ-AGENT-028
 import { describe, it, expect } from 'vitest';
 import {
   getGithubTokenUrl,
   GITHUB_TIERS,
-  CLOUDFLARE_TOKEN_PAGE,
+  getCloudflareTokenUrl,
+  CLOUDFLARE_TIERS,
 } from '../../lib/token-scopes';
 
 describe('GITHUB_TIERS / REQ-AGENT-010 (deploy credential token scope tiers)', () => {
@@ -98,8 +99,106 @@ describe('getGithubTokenUrl', () => {
   });
 });
 
-describe('CLOUDFLARE_TOKEN_PAGE', () => {
-  it('points to Cloudflare API tokens page', () => {
-    expect(CLOUDFLARE_TOKEN_PAGE).toBe('https://dash.cloudflare.com/profile/api-tokens');
+describe('CLOUDFLARE_TIERS / REQ-AGENT-028 AC2 (Cloudflare token scope tiers)', () => {
+  it('has exactly 3 tiers', () => {
+    expect(Object.keys(CLOUDFLARE_TIERS)).toHaveLength(3);
+  });
+
+  it('has minimal, recommended, and advanced', () => {
+    expect(CLOUDFLARE_TIERS.minimal).toBeDefined();
+    expect(CLOUDFLARE_TIERS.recommended).toBeDefined();
+    expect(CLOUDFLARE_TIERS.advanced).toBeDefined();
+  });
+
+  it('each tier has label and description', () => {
+    for (const tier of Object.values(CLOUDFLARE_TIERS)) {
+      expect(tier.label).toBeTruthy();
+      expect(tier.description).toBeTruthy();
+    }
+  });
+});
+
+describe('getCloudflareTokenUrl', () => {
+  it('all tiers include permissionGroupKeys and name=Codeflare', () => {
+    for (const tier of ['minimal', 'recommended', 'advanced'] as const) {
+      const url = getCloudflareTokenUrl(tier);
+      expect(url).toContain('permissionGroupKeys=');
+      expect(url).toContain('name=Codeflare');
+      expect(url).toContain('accountId=%2A');
+      expect(url).toContain('zoneId=all');
+    }
+  });
+
+  it('minimal has 7 scopes', () => {
+    const url = getCloudflareTokenUrl('minimal');
+    const params = new URL(url).searchParams;
+    const scopes = JSON.parse(params.get('permissionGroupKeys')!);
+    expect(scopes).toHaveLength(7);
+  });
+
+  it('recommended has 10 scopes (superset of minimal)', () => {
+    const url = getCloudflareTokenUrl('recommended');
+    const params = new URL(url).searchParams;
+    const scopes = JSON.parse(params.get('permissionGroupKeys')!);
+    expect(scopes).toHaveLength(10);
+
+    const minimalUrl = getCloudflareTokenUrl('minimal');
+    const minimalScopes = JSON.parse(new URL(minimalUrl).searchParams.get('permissionGroupKeys')!);
+    for (const scope of minimalScopes) {
+      expect(scopes).toContainEqual(scope);
+    }
+  });
+
+  it('advanced has 22 scopes (superset of recommended)', () => {
+    const url = getCloudflareTokenUrl('advanced');
+    const params = new URL(url).searchParams;
+    const scopes = JSON.parse(params.get('permissionGroupKeys')!);
+    expect(scopes).toHaveLength(22);
+
+    const recUrl = getCloudflareTokenUrl('recommended');
+    const recScopes = JSON.parse(new URL(recUrl).searchParams.get('permissionGroupKeys')!);
+    for (const scope of recScopes) {
+      expect(scopes).toContainEqual(scope);
+    }
+  });
+
+  it('minimal includes core Worker scopes', () => {
+    const url = getCloudflareTokenUrl('minimal');
+    const scopes = JSON.parse(new URL(url).searchParams.get('permissionGroupKeys')!);
+    const keys = scopes.map((s: { key: string }) => s.key);
+    expect(keys).toContain('workers_scripts');
+    expect(keys).toContain('workers_kv_storage');
+    expect(keys).toContain('workers_r2');
+    expect(keys).toContain('d1');
+  });
+
+  it('minimal does NOT include dns or access', () => {
+    const url = getCloudflareTokenUrl('minimal');
+    const scopes = JSON.parse(new URL(url).searchParams.get('permissionGroupKeys')!);
+    const keys = scopes.map((s: { key: string }) => s.key);
+    expect(keys).not.toContain('dns');
+    expect(keys).not.toContain('access');
+  });
+
+  it('recommended includes dns and access', () => {
+    const url = getCloudflareTokenUrl('recommended');
+    const scopes = JSON.parse(new URL(url).searchParams.get('permissionGroupKeys')!);
+    const keys = scopes.map((s: { key: string }) => s.key);
+    expect(keys).toContain('dns');
+    expect(keys).toContain('access');
+    expect(keys).toContain('access_acct');
+  });
+
+  it('advanced includes AI, Containers, Queues, and Agents', () => {
+    const url = getCloudflareTokenUrl('advanced');
+    const scopes = JSON.parse(new URL(url).searchParams.get('permissionGroupKeys')!);
+    const keys = scopes.map((s: { key: string }) => s.key);
+    expect(keys).toContain('ai');
+    expect(keys).toContain('containers');
+    expect(keys).toContain('queues');
+    expect(keys).toContain('cf_agents');
+    expect(keys).toContain('challenge_widgets');
+    expect(keys).toContain('workers_ci');
+    expect(keys).toContain('r2_catalog');
   });
 });

--- a/web-ui/src/components/OnboardingPage.tsx
+++ b/web-ui/src/components/OnboardingPage.tsx
@@ -6,7 +6,7 @@ import ScrambleText from './ScrambleText';
 import Icon from './Icon';
 import { mdiArrowRight } from '@mdi/js';
 import { logger } from '../lib/logger';
-import { getGithubTokenUrl, GITHUB_TIERS, CLOUDFLARE_TOKEN_PAGE, SCOPES_DOCS_URL, CLOUDFLARE_BRAND_COLOR } from '../lib/token-scopes';
+import { getGithubTokenUrl, GITHUB_TIERS, getCloudflareTokenUrl, CLOUDFLARE_TIERS, SCOPES_DOCS_URL } from '../lib/token-scopes';
 import '../styles/login-page.css';
 import '../styles/onboarding-page.css';
 
@@ -347,8 +347,6 @@ const OnboardingPage: Component = () => {
               icon={CloudflareIcon}
               name="Cloudflare"
               brandColor="#f38020"
-              externalUrl={CLOUDFLARE_TOKEN_PAGE}
-              externalLabel="Open Cloudflare"
               placeholder="Cloudflare API token..."
               connected={cfConnected()}
               onSave={(token) => { void handleSaveCloudflare(token); }}
@@ -358,7 +356,11 @@ const OnboardingPage: Component = () => {
               message={cfMessage()}
               error={cfError()}
               testId="onboarding-cloudflare-row"
-              instructions={<>Press <span style={{color: CLOUDFLARE_BRAND_COLOR, "font-weight": "600"}}>"Open Cloudflare"</span> below, click <span style={{color: CLOUDFLARE_BRAND_COLOR, "font-weight": "600"}}>"Create Token"</span>, then use the <span style={{color: CLOUDFLARE_BRAND_COLOR, "font-weight": "600"}}>"Edit Cloudflare Workers"</span> template. Select your account and zones, then create the token.</>}
+              tierOptions={{
+                tiers: CLOUDFLARE_TIERS,
+                getUrl: getCloudflareTokenUrl,
+                docsUrl: SCOPES_DOCS_URL,
+              }}
             />
             {/* Multi-account dropdown */}
             <Show when={cfAccounts().length > 1}>

--- a/web-ui/src/components/settings/DeployKeysSection.tsx
+++ b/web-ui/src/components/settings/DeployKeysSection.tsx
@@ -3,7 +3,7 @@ import { getDeployKeys, updateDeployKeys } from '../../api/client';
 import type { DeployKeysResponse } from '../../api/client';
 import ProviderRow from './ProviderRow';
 import { GitHubIcon, CloudflareIcon } from './BrandIcons';
-import { getGithubTokenUrl, GITHUB_TIERS, CLOUDFLARE_TOKEN_PAGE, SCOPES_DOCS_URL, CLOUDFLARE_BRAND_COLOR } from '../../lib/token-scopes';
+import { getGithubTokenUrl, GITHUB_TIERS, getCloudflareTokenUrl, CLOUDFLARE_TIERS, SCOPES_DOCS_URL } from '../../lib/token-scopes';
 
 interface CloudflareAccount {
   id: string;
@@ -155,8 +155,6 @@ const DeployKeysSection: Component = () => {
         icon={CloudflareIcon}
         name="Cloudflare"
         brandColor="#f38020"
-        externalUrl={CLOUDFLARE_TOKEN_PAGE}
-        externalLabel="Open Cloudflare"
         placeholder="Cloudflare API token..."
         connected={cfConnected()}
         onSave={(token) => { void handleSaveCloudflare(token); }}
@@ -166,7 +164,11 @@ const DeployKeysSection: Component = () => {
         message={cfMessage()}
         error={cfError()}
         testId="deploy-cf-row"
-        instructions={<>Press <span style={{color: CLOUDFLARE_BRAND_COLOR, "font-weight": "600"}}>"Open Cloudflare"</span> below, click <span style={{color: CLOUDFLARE_BRAND_COLOR, "font-weight": "600"}}>"Create Token"</span>, then use the <span style={{color: CLOUDFLARE_BRAND_COLOR, "font-weight": "600"}}>"Edit Cloudflare Workers"</span> template. Select your account and zones, then create the token.</>}
+        tierOptions={{
+          tiers: CLOUDFLARE_TIERS,
+          getUrl: getCloudflareTokenUrl,
+          docsUrl: SCOPES_DOCS_URL,
+        }}
       />
 
       {/* Cloudflare multi-account dropdown */}

--- a/web-ui/src/lib/token-scopes.ts
+++ b/web-ui/src/lib/token-scopes.ts
@@ -44,11 +44,72 @@ export function getGithubTokenUrl(tier: ScopeTier): string {
   return GITHUB_BASE_URL + GITHUB_SCOPES[tier];
 }
 
-/** Cloudflare API tokens page — users select the "Edit Cloudflare Workers" template. */
-export const CLOUDFLARE_TOKEN_PAGE = 'https://dash.cloudflare.com/profile/api-tokens';
+// ---------------------------------------------------------------------------
+// Cloudflare token scopes (verified key mapping 2026-05-26)
+// ---------------------------------------------------------------------------
+
+export const CLOUDFLARE_TIERS: Record<ScopeTier, TierConfig> = {
+  minimal: {
+    label: 'Minimal',
+    description: 'Deploy Workers, KV, R2, D1, and manage routes.',
+  },
+  recommended: {
+    label: 'Recommended',
+    description: 'Minimal plus DNS records and Cloudflare Access.',
+  },
+  advanced: {
+    label: 'Advanced',
+    description: 'Everything including Pages, AI, Containers, Queues, and more.',
+  },
+};
+
+type CfScope = { key: string; type: string };
+
+const CF_MINIMAL: CfScope[] = [
+  { key: 'workers_scripts', type: 'edit' },
+  { key: 'workers_kv_storage', type: 'edit' },
+  { key: 'workers_r2', type: 'edit' },
+  { key: 'd1', type: 'edit' },
+  { key: 'workers_routes', type: 'edit' },
+  { key: 'account_settings', type: 'read' },
+  { key: 'zone', type: 'read' },
+];
+
+const CF_RECOMMENDED: CfScope[] = [
+  ...CF_MINIMAL,
+  { key: 'dns', type: 'edit' },
+  { key: 'access', type: 'edit' },
+  { key: 'access_acct', type: 'edit' },
+];
+
+const CF_ADVANCED: CfScope[] = [
+  ...CF_RECOMMENDED,
+  { key: 'page', type: 'edit' },
+  { key: 'containers', type: 'edit' },
+  { key: 'account_api_tokens', type: 'edit' },
+  { key: 'queues', type: 'edit' },
+  { key: 'ai', type: 'edit' },
+  { key: 'ai', type: 'read' },
+  { key: 'vectorize', type: 'edit' },
+  { key: 'challenge_widgets', type: 'edit' },
+  { key: 'workers_ci', type: 'edit' },
+  { key: 'workers_observability', type: 'edit' },
+  { key: 'r2_catalog', type: 'edit' },
+  { key: 'cf_agents', type: 'edit' },
+];
+
+const CLOUDFLARE_SCOPES: Record<ScopeTier, CfScope[]> = {
+  minimal: CF_MINIMAL,
+  recommended: CF_RECOMMENDED,
+  advanced: CF_ADVANCED,
+};
+
+const CLOUDFLARE_BASE_URL = 'https://dash.cloudflare.com/profile/api-tokens';
+
+export function getCloudflareTokenUrl(tier: ScopeTier): string {
+  const encoded = encodeURIComponent(JSON.stringify(CLOUDFLARE_SCOPES[tier]));
+  return `${CLOUDFLARE_BASE_URL}?permissionGroupKeys=${encoded}&accountId=%2A&zoneId=all&name=Codeflare`;
+}
 
 /** Documentation page listing all scopes per tier with explanations. */
 export const SCOPES_DOCS_URL = 'https://github.com/nikolanovoselec/codeflare/blob/main/documentation/token-scopes.md';
-
-/** Cloudflare brand color for instruction highlights. */
-export const CLOUDFLARE_BRAND_COLOR = '#f38020';


### PR DESCRIPTION
## Summary

- Restore 3-tier Cloudflare token scope selector (Minimal 7 / Recommended 10 / Advanced 22 scopes) matching the existing GitHub pattern
- All 22 permission group keys verified against the Cloudflare API and dashboard
- Replaces the plain API tokens page link workaround from when Cloudflare broke the old template URL syntax

## Test plan

- [ ] CI passes (token-scopes tests validate URL structure + scope counts per tier)
- [ ] Open Settings > Deploy Keys > Cloudflare - tier selector appears with Recommended pre-selected
- [ ] Click each tier - correct scopes prefilled in Cloudflare dashboard
- [ ] Same tier selector on Onboarding page
- [ ] "See all scopes" link works