### PR TITLE
chore: add CVE-2026-42497 trivy exception (Archive::Tar hardlink traversal)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -421,6 +421,15 @@ CVE-2025-61727
 # with Archive::Tar 3.08).
 CVE-2026-42496
 
+# perl-modules-5.36 / libperl5.36 (Debian bookworm): Archive::Tar before 3.08
+# extracts hardlinks with attacker-controlled targets, allowing files outside
+# the extraction directory to be linked (hardlink traversal). Impact: NONE -
+# container does not extract untrusted tar archives; perl is invoked only by
+# codeflare-managed entrypoint scripts and system package tooling. Same exposure
+# profile as CVE-2026-42496 above. No fix available in Debian bookworm (requires
+# Perl 5.38+ with Archive::Tar 3.08).
+CVE-2026-42497
+
 # perl-modules-5.36 / libperl5.36 (Debian bookworm): Archive::Tar before 3.10
 # allows memory exhaustion via crafted tar archives. Impact: NONE - container
 # does not extract untrusted tar archives; perl is invoked only by


### PR DESCRIPTION
## Summary
- Adds `CVE-2026-42497` to `.trivyignore`, the only finding blocking the Deploy workflow's Trivy scan on `main`.
- It is the hardlink-traversal sibling of `CVE-2026-42496` (already suppressed): Archive::Tar before 3.08 in `perl-modules-5.36`/`libperl5.36`. Same exposure profile.

## Impact assessment
- **Impact: NONE.** The container never extracts untrusted tar archives; `perl` is invoked only by codeflare-managed entrypoint scripts and system package tooling.
- No fixed version in Debian bookworm (requires Perl 5.38+ with Archive::Tar 3.08).

## Diff
- Single commit: one suppression entry with description + impact rationale in `.trivyignore`.

## Test plan
- [ ] Deploy workflow Trivy scan passes on the merge to `main`.