### PR TITLE
chore: suppress CVE-2026-48962 to unblock production deploy

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -472,3 +472,12 @@ CVE-2026-39826
 # (stdlib only, same exposure profile as the cpython entries above). No untrusted
 # wheel is installed at runtime. No fixed version available in Debian bookworm.
 CVE-2026-8643
+
+# perl-modules-5.36 / libperl5.36 / perl / perl-base (Debian bookworm):
+# IO::Compress arbitrary code execution via attacker-controlled output glob
+# pattern. Impact: NONE - the container never calls IO::Compress with
+# attacker-controlled glob arguments; perl is invoked only by
+# codeflare-managed entrypoint scripts and system package tooling. Same
+# exposure profile as the Archive::Tar perl entries above (CVE-2026-42496 /
+# CVE-2026-42497 / CVE-2026-9538). No fixed version available in Debian bookworm.
+CVE-2026-48962


### PR DESCRIPTION
## Summary

Unblocks production. The deploy of #443 ([run 26692593338](https://github.com/nikolanovoselec/codeflare/actions/runs/26692593338/job/78671559709)) failed at the Trivy container-scan gate on a single new HIGH CVE that was not yet in `.trivyignore`. This adds the suppression with the same rationale as the existing perl entries.

## The finding

Trivy reported `Total: 4 (HIGH: 4, CRITICAL: 0)`, but it is **one CVE** counted across four perl packages that share the same source:

| CVE | Severity | Packages | Installed | Fixed | Title |
|---|---|---|---|---|---|
| CVE-2026-48962 | HIGH | libperl5.36, perl, perl-base, perl-modules-5.36 | 5.36.0-7+deb12u3 | (none in bookworm) | perl-IO-Compress: arbitrary code execution via attacker-controlled output glob |

It was the only unsuppressed finding (every other detected CVE was already in `.trivyignore`), so it alone failed the gate (`severity: HIGH,CRITICAL`, `exit-code: 1`, `ignore-unfixed: false`).

## Exposure

NONE. The exploit requires calling `IO::Compress` with an attacker-controlled output glob pattern. In this container perl is invoked only by codeflare-managed entrypoint scripts and system package tooling - never on attacker-controlled input. Same exposure profile as the existing Archive::Tar perl suppressions (CVE-2026-42496 / CVE-2026-42497 / CVE-2026-9538). No fixed version is available in Debian bookworm.

## Change

One suppression block appended to `.trivyignore` next to the other perl entries. No code, config, or behaviour change.

## Test plan

- The develop->main PR-boundary review lanes + CI run on this PR.
- On merge, the production deploy re-runs; the Trivy gate should pass (this CVE now suppressed, all others already were).

> develop -> main. Merge is yours.
