### PR TITLE
fix: validate setSessionId payload at DO boundary with Zod (TD5)

### DIFF
--- a/src/__tests__/container/index.test.ts
+++ b/src/__tests__/container/index.test.ts
@@ -1232,6 +1232,47 @@ describe('container DO class / REQ-SESSION-002 (one container per session)', () 
       expect(consoleSpy).not.toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+
+    it('setSessionId stores a valid sessionId and returns success', async () => {
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+      const request = new Request('http://container/_internal/setSessionId', {
+        method: 'PUT',
+        body: JSON.stringify({ sessionId: 'sess-123' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const response = await instance.fetch(request);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ success: true });
+      expect(mockStorage.put).toHaveBeenCalledWith('_sessionId', 'sess-123');
+    });
+
+    it('setSessionId rejects a non-string sessionId with 400 and does not store it', async () => {
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+      const request = new Request('http://container/_internal/setSessionId', {
+        method: 'PUT',
+        body: JSON.stringify({ sessionId: 123 }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const response = await instance.fetch(request);
+      expect(response.status).toBe(400);
+      expect(mockStorage.put).not.toHaveBeenCalledWith('_sessionId', expect.anything());
+    });
+
+    it('setSessionId treats an absent sessionId as a successful no-op', async () => {
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+      const request = new Request('http://container/_internal/setSessionId', {
+        method: 'PUT',
+        body: JSON.stringify({}),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const response = await instance.fetch(request);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ success: true });
+      expect(mockStorage.put).not.toHaveBeenCalledWith('_sessionId', expect.anything());
+    });
   });
 
   describe('validateBucketNameInput (L10)', () => {

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -38,6 +38,7 @@ import {
   type MetricsState,
   type MetricsCallbacks,
 } from './container-metrics';
+import { SetSessionIdBodySchema } from '../lib/container-config-schema';
 
 export { validateBucketNameInput };
 
@@ -516,7 +517,14 @@ export class container extends Container<Env> implements ContainerEnvState {
   /** Handle PUT /_internal/setSessionId (idempotent). */
   private async handleSetSessionId(request: Request): Promise<Response> {
     try {
-      const { sessionId } = await request.json() as { sessionId?: string };
+      const parsed = SetSessionIdBodySchema.safeParse(await request.json());
+      if (!parsed.success) {
+        return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const { sessionId } = parsed.data;
       if (sessionId) {
         await this.ctx.storage.put(SESSION_ID_KEY, sessionId);
         this._sessionId = sessionId;

--- a/src/lib/container-config-schema.ts
+++ b/src/lib/container-config-schema.ts
@@ -32,3 +32,19 @@ export const SetBucketNameBodySchema = z.object({
   /** REQ-MEM-001 AC4: forward the user's IANA timezone to the container. */
   userTimezone: z.string().optional(),
 }).passthrough();
+
+/**
+ * TD5: Zod schema for the /_internal/setSessionId JSON payload.
+ *
+ * Unlike SetBucketNameBodySchema (validated by the Worker-side builder before
+ * sending), setSessionId has no Worker-side sender - sessionId is normally
+ * persisted via setBucketName. The only untrusted entry is the inbound DO
+ * request, so this is validated receiver-side in handleSetSessionId.
+ *
+ * sessionId stays optional: an absent value is a successful no-op, matching the
+ * pre-existing idempotent contract. A non-string value is now rejected (400)
+ * instead of silently coerced.
+ */
+export const SetSessionIdBodySchema = z.object({
+  sessionId: z.string().optional(),
+});


### PR DESCRIPTION
Completes the **TD5** residual flagged when closing #152.

## What
`POST /_internal/setBucketName` is already Zod-validated (CF-006, `SetBucketNameBodySchema`). The other internal Worker->DO endpoint, `PUT /_internal/setSessionId`, still parsed its body with a raw `as { sessionId?: string }` cast - the last untyped surface TD5 was about.

## Change
- Add `SetSessionIdBodySchema` to `src/lib/container-config-schema.ts`.
- `handleSetSessionId` (`src/container/index.ts`) now `safeParse`s the inbound body **receiver-side** (the only untrusted entry - there is no Worker-side sender; sessionId is normally persisted via `setBucketName`).
- Behavioural contract preserved: an **absent** `sessionId` stays a successful idempotent no-op; a **non-string** `sessionId` now returns **400** instead of being silently coerced.

## Tests
`src/__tests__/container/index.test.ts`: valid sessionId stored + 200; non-string -> 400, not stored; absent -> 200 no-op. Existing invalid-JSON -> 500 path unchanged.

## Notes
`GET /_internal/getBucketName` takes no body, so nothing to validate there. This finishes the TD5 surface without reopening #152.

Refs #152.