### PR TITLE
fix: address session-status review findings (code/spec/docs)

### DIFF
--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -136,6 +136,8 @@ Session PATCH/stop overlap is rare, rate limit off-by-one is minor, `lastAccesse
 
 `collectMetrics` KV read-modify-write can revert session status. Mitigated: session status changes are only observed from the Dashboard, not during active terminal use. Sessions are never interrupted while in Terminal view.
 
+**Update (2026-06-02, [AD70](#ad70-container-exit-writes-kv-stopped-no-read-side-reconciliation)):** the specific Dashboard-side revert this note worried about was the read-side `reconcileStaleStatus` heuristic (a separate later addition), which inferred `stopped` from a stale `metrics.updatedAt` heartbeat and could falsely kick a still-live session. That heuristic was removed in [codeflare#153](https://github.com/nikolanovoselec/codeflare/issues/153); KV `status` is now authoritative and written on every container exit, so the Dashboard renders it verbatim with no reconciliation. The remaining `collectMetrics` RMW concern (overlapping writes to the same record) is unchanged and still last-writer-wins.
+
 **`collectMetrics` density** (formerly [AD17](#ad17-merged-into-ad6)): the function performs activity checking, health probing, and KV status updates in a single `alarm()` callback. Splitting into separate alarms would require coordination logic more complex than the current monolithic approach. The `alarm()` context provides natural atomicity across these tightly coupled operations - same theme as the KV race trade-off above (accept the cheap option until evidence forces change).
 
 ---
@@ -1251,6 +1253,26 @@ Two facts from the SB 2.8.1 source reshape the fix. First, SB's real service wor
 - Risk: the real ~97KB worker interacts with the live vault auth chain, and a prior attempt (`silverbullet-index` branch) stalled on boot timeouts. Mitigated by integration-only rollout and keeping the shim available as a one-line revert until the native path is proven.
 
 **Related REQ:** [REQ-VAULT-008](../../sdd/spec/vault.md#req-vault-008-zero-ui-vault-encryption) (zero-UI vault encryption), [REQ-VAULT-013](../../sdd/spec/vault.md#req-vault-013-silverbullet-subpath-adapter) (SilverBullet subpath adapter), [REQ-VAULT-015](../../sdd/spec/vault.md#req-vault-015-vault-idb-lifecycle-and-listing-filters) (vault IDB lifecycle). Supersedes the shim rationale documented in [vault.md - Service Worker registration noop bypass](../lanes/vault.md#service-worker-registration-noop-bypass). Tracks [codeflare#445](https://github.com/nikolanovoselec/codeflare/issues/445).
+
+---
+
+### AD70: Container exit writes KV `stopped`; no read-side reconciliation
+
+**Category:** Architecture
+
+**Status:** Accepted (2026-06-02)
+
+**Context:** Two user-facing symptoms shared one defect. (1) A live session was falsely flipped to `stopped` and the user bounced to the dashboard; reopening showed "Starting session" then instantly green. (2) A container that exited unexpectedly (crash, deploy-roll, or platform idle-reap) dangled as `running` in KV forever and had to be deleted by hand. Production observability (96h) proved the chain: when a container exits via an unexpected path the SDK (`@cloudflare/containers` v0.3.5) calls `onError()`, **not** `onStop()`; `onError` only logged, `collectMetrics`'s `!running` branch only logged-and-returned, and `onStop` (which does write `stopped`) was never invoked. So KV dangled at `running` and the heartbeat `metrics.updatedAt` froze. A read-side heuristic, `reconcileStaleStatus` (added in [#459](https://github.com/nikolanovoselec/codeflare/pull/459)), then inferred `stopped` from the stale heartbeat age on the dashboard poll - which is exactly what produced the false kick on still-live sessions whose alarm loop had legitimately paused. The June 1→2 incident was a deploy (the user's agent merging a PR to main) that rolled the container → `Container error` with no KV write. Over 96h the SDK `onActivityExpired` fired 0 times (the `sleepAfter='24h'` pin holds), 69/72 clean stops were manual `destroy()`, and 7 `Container error` events each leaked a dangling session.
+
+**Decision:** Make KV `status` the single authoritative source of truth and delete the read-side guess. (a) `onError()` writes `stopped` via the shared `updateKvStatus()` helper, guarded on `!ctx.container.running` so a transient startup error cannot flip a still-starting container. (b) `collectMetrics()`'s `!running` branch writes `stopped` on the next 60s tick as the catch-all for any exit the hooks missed. (c) `reconcileStaleStatus` and its `STALE_RUNNING_MS` constant are removed; all five call sites (`routes/session/{crud,lifecycle}.ts`, `routes/container/lifecycle.ts`) return the raw KV status. `metrics.updatedAt` / `m.u` is **kept** but is display-only (metrics-staleness), never a liveness signal. Safety rests on `updateKvStatus` re-reading sessionId/bucketName from DO storage and the session from KV on every call, and `destroy()` clearing those identifiers first - so a post-destroy write no-ops instead of resurrecting a deleted record (the same invariant as [AD6](#ad6-kv-read-modify-write-races-and-collectmetrics-atomicity)). Whether a session should **survive** a deploy at all (container persistence across Worker versions) is explicitly out of scope.
+
+**Consequences:**
+- Dangling `running` is eliminated: a container that exits for any reason converges to `stopped` within ~60s without manual deletion.
+- The false kick is eliminated at the root: with no heartbeat-age heuristic, a live-but-idle session can never be inferred `stopped` from a paused alarm loop.
+- The dashboard becomes a pure mirror of KV `status`; the frontend `running→stopped` disposal path (REQ-SESSION-010 AC7) stays, but now acts on an authoritative signal rather than a guess.
+- Trade-off: a brief, accurate `stopped` can appear during a failed start before `onStart()` re-asserts `running`. Acceptable - it reflects reality.
+
+**Related REQ:** [REQ-SESSION-010](../../sdd/spec/session-lifecycle.md#req-session-010-session-status-observable-from-dashboard) (session status observable from dashboard, AC8). Tracks [codeflare#153](https://github.com/nikolanovoselec/codeflare/issues/153). Refines [AD6](#ad6-kv-read-modify-write-races-and-collectmetrics-atomicity).
 
 ---
 

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -1269,7 +1269,7 @@ Two facts from the SB 2.8.1 source reshape the fix. First, SB's real service wor
 **Consequences:**
 - Dangling `running` is eliminated: a container that exits for any reason converges to `stopped` within ~60s without manual deletion.
 - The false kick is eliminated at the root: with no heartbeat-age heuristic, a live-but-idle session can never be inferred `stopped` from a paused alarm loop.
-- The dashboard becomes a pure mirror of KV `status`; the frontend `running→stopped` disposal path (REQ-SESSION-010 AC7) stays, but now acts on an authoritative signal rather than a guess.
+- The dashboard becomes a pure mirror of KV `status`; the frontend `running→stopped` disposal path (REQ-SESSION-010 AC7) stays, but now fires on the authoritative KV status written on exit (AC8) rather than a read-side guess.
 - Trade-off: a brief, accurate `stopped` can appear during a failed start before `onStart()` re-asserts `running`. Acceptable - it reflects reality.
 
 **Related REQ:** [REQ-SESSION-010](../../sdd/spec/session-lifecycle.md#req-session-010-session-status-observable-from-dashboard) (session status observable from dashboard, AC8). Tracks [codeflare#153](https://github.com/nikolanovoselec/codeflare/issues/153). Refines [AD6](#ad6-kv-read-modify-write-races-and-collectmetrics-atomicity).

--- a/documentation/lanes/architecture.md
+++ b/documentation/lanes/architecture.md
@@ -83,6 +83,15 @@ The `containerStartedAt` fallback is critical: if a user opens a terminal but ne
 
 `containsUserInput()` in `host/src/session.ts` uses a whitelist approach - only actual keypresses count (printable characters, control keys, arrow keys, function keys, Alt+key, mouse clicks). Terminal protocol responses (CSI, OSC, DCS, APC, focus reports, mouse movement) do not count. `stripTerminalResponses()` removes terminal emulator response sequences (CPR, OSC 10/11/12, DA1) before writing to the PTY. Scenarios: user stops typing → container stops after `sleepAfter` + up to 60s (poll granularity); browser closed → same; user opens terminal but never types → container stops after `sleepAfter` from start time.
 
+**Timestamp taxonomy (four distinct timestamps, often confused):**
+
+| Field | Source / owner | Advances on | Used for |
+| --- | --- | --- | --- |
+| `lastInputAt` | terminal server `/activity` (`host/src/session.ts`) | PTY **keystrokes only** - not output, not WS traffic, not vault/SB activity, not autonomous-agent output | The idle reference for `collectMetrics`. A long agent run with no keystrokes looks "idle". |
+| `lastSeenInputAt` | Container DO in-memory cache of the last non-null `lastInputAt` | New keystroke observed by the poll | Surviving a poll where `/activity` momentarily returns `null`. |
+| `lastActiveAt` | KV session record (written by `updateKvStatus`) | Input-driven status writes + the sleep-timer path | Dashboard "last active" display; persisted across hibernation. |
+| `metrics.updatedAt` (`m.u` in list metadata) | `collectMetrics` heartbeat | **Wall-clock, every tick**, regardless of input | Metrics-staleness display **only**. **Not** a liveness signal - it freezes when the alarm loop is not running (hibernation). A heartbeat-age heuristic over this field previously caused false "stopped" kicks; removed in [codeflare#153](https://github.com/nikolanovoselec/codeflare/issues/153). Liveness comes from the authoritative KV `status`. |
+
 **WebSocket Wake-Loop Prevention:** Three layers prevent browser auto-reconnect from waking a hibernated container in an infinite stop/start cycle:
 1. **DO fetch gate** (`container/index.ts`): The `fetch()` override returns 503 when `!this.ctx.container?.running` for all non-internal routes. This is authoritative (the DO knows container state directly, no KV read needed) and prevents `super.fetch()` from triggering the SDK's `startIfNotRunning`.
 2. **Terminal route guard** (`routes/terminal.ts`): Rejects WebSocket upgrade requests with 503 when `session.status === 'stopped'` in KV. This is defense-in-depth - catches requests before they reach the DO.
@@ -201,13 +210,17 @@ stateDiagram-v2
     running --> stopping : stop
     stopping --> stopped : poll stopped
     running --> stopped : collectMetrics (idle &gt; idleTimeoutPref)
+    running --> stopped : onError / collectMetrics (unexpected exit: crash, deploy-roll, platform reap)
+    error --> stopped : onError writes KV stopped
 ```
+
+**Stop (unexpected exit):** A crash, deploy-roll, or platform idle-reap exits the container without a graceful `stop()`, so the SDK fires `onError()` (**not** `onStop()`). `onError()` writes KV `status: 'stopped'` (guarded on `!ctx.container.running`); if it is skipped, the `collectMetrics()` `!running` branch writes `stopped` on the next 60s tick. Either way KV converges to `stopped` rather than dangling at `running`. See rationale #5 / #17 and [AD70](../decisions/README.md#ad70-container-exit-writes-kv-stopped-no-read-side-reconciliation).
 
 **Stop (idle):** `collectMetrics()` poll -> `idleMs = Date.now() - (lastInputAt ?? containerStartedAt)` -> `idleMs > parseSleepAfterMs(idleTimeoutPref)` -> write KV `status: 'stopped'` (with `lastActiveAt`) -> `this.stop('SIGTERM')` -> `onStop()` clears `collectMetrics` schedule.
 
 **Fast container-stopped detection (frontend):** When the Container DO's "not running" guard returns close code `4503` (`WS_CONTAINER_STOPPED_CODE`), the terminal store stops retrying and marks the connection as disconnected. This is server-authoritative - the container is definitively not running. Non-4503 close codes (1006, 1001, 1011, etc.) trigger automatic reconnection with 1s delay.
 
-**Anti-flapping (KV stopped→running):** When KV batch-status polling detects a `stopped→running` transition for a non-active session, `refreshSessionStatuses()` updates the session status dot but does **not** auto-initialize terminals. This prevents a flapping cycle: stale KV "running" → WS connections → 503 from dead container → disconnected → stale KV "running" restarts cycle. Newly started sessions have a 3-minute startup guard (`session-polling.ts`) during which only `4503` close code can transition them to stopped. The user explicitly clicks the session card to reconnect. Terminal initialization only occurs during: (1) explicit session start by user, (2) `loadSessions()` on initial page load where KV is authoritative.
+**Anti-flapping (KV stopped→running):** When KV batch-status polling detects a `stopped→running` transition for a non-active session, `refreshSessionStatuses()` updates the session status dot but does **not** auto-initialize terminals. This prevents a flapping cycle: stale KV "running" → WS connections → 503 from dead container → disconnected → stale KV "running" restarts cycle. The primary source of a stale KV "running" is now closed at the writer - every container exit persists `stopped` (rationale #5, [AD70](../decisions/README.md#ad70-container-exit-writes-kv-stopped-no-read-side-reconciliation)) - so this guard is defense-in-depth against a transient lag between exit and the catch-all write, not the load-bearing fix it once was when KV could dangle at `running` indefinitely. Newly started sessions have a 3-minute startup guard (`session-polling.ts`) during which only `4503` close code can transition them to stopped. The user explicitly clicks the session card to reconnect. Terminal initialization only occurs during: (1) explicit session start by user, (2) `loadSessions()` on initial page load where KV is authoritative.
 
 **Stop (user-initiated):** Worker sets KV status to `'stopped'` -> calls `container.destroy()` -> `destroy()` clears `SESSION_ID_KEY` + `bucketName` from DO storage to prevent deleted session resurrection -> `super.destroy()` -> `onStop()` bails (no identifiers, so no KV write)
 
@@ -240,8 +253,17 @@ flowchart TD
         D4 --> D5["onStop() bails<br/>(no identifiers, no KV write)"]
     end
 
+    subgraph Crash["Unexpected Exit (crash / deploy-roll / platform reap)"]
+        X1["Container exits<br/>(no graceful stop)"] --> X2["SDK fires onError()<br/>(NOT onStop)"]
+        X2 --> X3{"ctx.container<br/>.running?"}
+        X3 -->|"No (exited)"| X4["onError writes<br/>KV status='stopped'"]
+        X3 -->|"Yes (transient<br/>startup error)"| X5["Skip write<br/>(guard)"]
+        X5 -.-> X6["collectMetrics() 60s<br/>!running branch is the<br/>catch-all -> KV 'stopped'"]
+    end
+
     U3 -.- Key["destroy() clearing identifiers<br/>BEFORE onStop() prevents<br/>session resurrection"]
     D3 -.- Key
+    X4 -.- Auth["KV status is authoritative;<br/>no read-side reconciliation<br/>(AD70)"]
 ```
 
 **Restart (same bucket):** `setBucketName` -> 409 (bucket already set, but stores `sessionId`, `workspaceSyncEnabled`, `tabConfig`, and `fastStartEnabled` in DO storage for KV reconciliation and preference updates) -> `startAndWaitForPorts()` -> `onStart()` re-arms metrics
@@ -324,7 +346,7 @@ Architectural principles and design rationale.
 2. **Newest file wins** - Simple conflict resolution for single-user scenarios.
 3. **Resilient bisync over auto-resync** - `--resilient` + `--recover` handle transient failures without losing deletion tracking. `--resync` is only used for initial baseline establishment (see [AD14](../decisions/README.md#ad14-never-auto---resync-on-bisync-failure)).
 4. **Single-source idle detection via `collectMetrics`** - The DO polls `/activity` inside the container every 60 s and explicitly calls `stop('SIGTERM')` when `idleMs > parseSleepAfterMs(idleTimeoutPref)`. The SDK's own `sleepAfter` timer is pinned to `'24h'` and plays no role in idle decisions (see AD/rationale #11). This replaced both the earlier heartbeat-based approach AND a short-lived input-change-detection design that leaned on the SDK timer - both were fragile when WebSocket reconnects reset the SDK's activity timer. One mechanism, one signal: has the user typed within the configured threshold? Container stops ~threshold + up to 60 s after the last keystroke.
-5. **`onStop()` must set KV status and clear schedules** - SDK hibernation fires `onStop()` which must write `status: 'stopped'` to KV (otherwise other devices see stale 'running' status) and call `deleteSchedules('collectMetrics')` to kill the alarm loop (otherwise zombie alarms fire on a dead container indefinitely).
+5. **Every container exit must write KV `status: 'stopped'` - KV is the single source of truth** - The persisted KV `status` is authoritative; the dashboard renders it verbatim with no read-side staleness reconciliation (the former `reconcileStaleStatus` heartbeat-age heuristic was removed in [codeflare#153](https://github.com/nikolanovoselec/codeflare/issues/153), see rationale #17 / [AD70](../decisions/README.md#ad70-container-exit-writes-kv-stopped-no-read-side-reconciliation)). For that to hold, every exit path must persist `stopped`, written through the shared `updateKvStatus()` helper: (a) graceful hibernation/idle-stop fires `onStop()`, which writes `stopped` and calls `deleteSchedules('collectMetrics')` to kill the alarm loop (otherwise zombie alarms fire on a dead container indefinitely); (b) an **unexpected** exit (crash, deploy-roll, platform reap) fires `onError()` - **not** `onStop()` - which writes `stopped` guarded on `!ctx.container.running` so a transient startup error cannot flip a still-starting container; (c) `collectMetrics()` is the 60s catch-all: its `!ctx.container.running` branch writes `stopped` on the next tick after any exit the hooks missed, then returns without re-arming. Without (b)/(c) an unexpected exit would dangle as `running` in KV forever.
 6. **`destroy()` must clear identifiers before `super.destroy()`** - `onStop()` fires asynchronously after `super.destroy()`. Without clearing identifiers first, `onStop()` resuscitates deleted sessions in KV via read-modify-write.
 7. **Secrets persist with worker state** - `wrangler delete` destroys all secrets.
 8. **Single port architecture** - All services on port 8080 eliminates port conflict bugs.
@@ -336,6 +358,7 @@ Architectural principles and design rationale.
 14. **Never auto-`--resync` on bisync failure** - `--resync` makes both sides identical by copying the newer version of every file, then creates a fresh baseline. This permanently loses any pending deletions - if side A deleted a file and bisync fails before propagating, `--resync` resurrects the file from side B. Use `--resilient` + `--recover` for self-healing: `--resilient` allows bisync to continue past non-critical errors, and `--recover` automatically reconstructs corrupted listing files without losing state. Manual `--resync` is still available via `establish_bisync_baseline()` on container startup (one-way restore runs first, so no data loss).
 15. **Never `docker system prune` in CI deploy workflows** - `docker system prune -af` in the deploy workflow nukes the Docker layer cache on self-hosted runners, causing every subsequent build to pull all layers from scratch. This triggers Docker Hub 429 rate limit errors when base images need re-downloading. Let Docker manage its own cache; only prune manually if disk space is critical.
 16. **Vanishing-file recovery before nuke** - When bisync fails with `lstat: no such file or directory`, the file was listed by rclone then deleted before the copy completed (race condition with agents writing/deleting transient files). The correct response is to parse the error, add the file to a session-scoped exclusion filter (`/tmp/rclone-recovery-filters.txt`), and retry - not escalate to `nuke_corrupted_r2_files`. Non-workspace files are auto-excluded; workspace files (user code) trigger a plain retry on the assumption the file reappeared. Known ephemeral files (`.claude/mcp-*.json`) are statically excluded from all sync operations to prevent the race from occurring. See [Vanishing-file recovery](storage-and-sync.md#vanishing-file-recovery) and [AD43](../decisions/README.md#ad43-parse-and-exclude-vanishing-files-before-escalating-to-nuke).
+17. **Exit-writes-`stopped` over read-side reconciliation** - KV `status` is the single source of truth: every container exit persists `stopped` (rationale #5), so the dashboard renders KV verbatim with no staleness heuristic. The former `reconcileStaleStatus` read-side guess inferred `stopped` from a stale `metrics.updatedAt` heartbeat and falsely kicked live-but-idle sessions whose alarm loop had legitimately paused; it was removed in [codeflare#153](https://github.com/nikolanovoselec/codeflare/issues/153). Writing on exit is both correct (no dangling `running`) and simpler (no clock-skew tuning of a staleness threshold). See [AD70](../decisions/README.md#ad70-container-exit-writes-kv-stopped-no-read-side-reconciliation).
 
 ---
 

--- a/documentation/lanes/architecture.md
+++ b/documentation/lanes/architecture.md
@@ -211,8 +211,9 @@ stateDiagram-v2
     stopping --> stopped : poll stopped
     running --> stopped : collectMetrics (idle &gt; idleTimeoutPref)
     running --> stopped : onError / collectMetrics (unexpected exit: crash, deploy-roll, platform reap)
-    error --> stopped : onError writes KV stopped
 ```
+
+(`error` is a frontend-ephemeral state, never persisted - AC2; it resolves to `stopped` on the next batch-status poll, not via a KV write. The SDK's `onError()` fires on a **running** container's unexpected exit, hence the `running --> stopped` transition above.)
 
 **Stop (unexpected exit):** A crash, deploy-roll, or platform idle-reap exits the container without a graceful `stop()`, so the SDK fires `onError()` (**not** `onStop()`). `onError()` writes KV `status: 'stopped'` (guarded on `!ctx.container.running`); if it is skipped, the `collectMetrics()` `!running` branch writes `stopped` on the next 60s tick. Either way KV converges to `stopped` rather than dangling at `running`. See rationale #5 / #17 and [AD70](../decisions/README.md#ad70-container-exit-writes-kv-stopped-no-read-side-reconciliation).
 

--- a/sdd/spec/session-lifecycle.md
+++ b/sdd/spec/session-lifecycle.md
@@ -341,8 +341,8 @@ Container creation, idle detection, auto-sleep, restart, and destroy.
 ---
 
 <!-- @test: src/__tests__/routes/session-batch-status.test.ts (REQ-SESSION-010 describe -> batch-status uses KV list metadata no kv.get + r/s compression + metrics in metadata + lastActiveAt/lastStartedAt + SESSION_LIST_POLL_INTERVAL_MS constant -> AC1,2,3,5,6; batch-status reports KV status verbatim no staleness reconciliation -> AC8) -->
-<!-- @test: src/__tests__/container-metrics.test.ts (collectMetrics describe -> writes status=stopped to KV when the container is not running -> AC8) -->
-<!-- @test: src/__tests__/container/index.test.ts (onError describe -> updates KV with status stopped on unexpected exit -> AC8) -->
+<!-- @test: src/__tests__/container-metrics.test.ts (collectMetrics describe -> writes status=stopped to KV when the container is not running (dangling-running guard) -> AC8) -->
+<!-- @test: src/__tests__/container/index.test.ts (onStop lifecycle describe -> onError updates KV with status stopped (unexpected exit dangling-running guard) -> AC8) -->
 ### REQ-SESSION-010: Session status observable from dashboard
 
 <!-- @impl: src/routes/session/crud.ts -->

--- a/sdd/spec/session-lifecycle.md
+++ b/sdd/spec/session-lifecycle.md
@@ -343,6 +343,7 @@ Container creation, idle detection, auto-sleep, restart, and destroy.
 <!-- @test: src/__tests__/routes/session-batch-status.test.ts (REQ-SESSION-010 describe -> batch-status uses KV list metadata no kv.get + r/s compression + metrics in metadata + lastActiveAt/lastStartedAt + SESSION_LIST_POLL_INTERVAL_MS constant -> AC1,2,3,5,6; batch-status reports KV status verbatim no staleness reconciliation -> AC8) -->
 <!-- @test: src/__tests__/container-metrics.test.ts (collectMetrics describe -> writes status=stopped to KV when the container is not running (dangling-running guard) -> AC8) -->
 <!-- @test: src/__tests__/container/index.test.ts (onStop lifecycle describe -> onError updates KV with status stopped (unexpected exit dangling-running guard) -> AC8) -->
+<!-- @test: src/__tests__/container/index.test.ts (onStop lifecycle describe -> onStop updates KV with lastActiveAt and sets status to stopped -> AC8) -->
 ### REQ-SESSION-010: Session status observable from dashboard
 
 <!-- @impl: src/routes/session/crud.ts -->
@@ -376,7 +377,7 @@ Container creation, idle detection, auto-sleep, restart, and destroy.
 
 **Dependencies:** [REQ-SESSION-001](#req-session-001-session-creation-with-name-and-agent-type)
 
-**Verification:** [Integration test](../../src/__tests__/routes/session-batch-status.test.ts)
+**Verification:** Batch-status read path - [Integration test](../../src/__tests__/routes/session-batch-status.test.ts); exit-writes-stopped paths (AC8) - [collectMetrics catch-all](../../src/__tests__/container-metrics.test.ts) and [onError / onStop lifecycle](../../src/__tests__/container/index.test.ts). The `@test` anchors above are the authoritative per-AC mapping.
 
 **Status:** Implemented
 

--- a/src/__tests__/container/index.test.ts
+++ b/src/__tests__/container/index.test.ts
@@ -1003,8 +1003,9 @@ describe('container DO class / REQ-SESSION-002 (one container per session)', () 
 
     it('onError updates KV with status stopped (unexpected exit dangling-running guard)', async () => {
       // The SDK calls onError (not onStop) when a container exits unexpectedly
-      // (crash / deploy-roll / platform reap). onError must persist 'stopped'
-      // so the session does not dangle as 'running' in KV forever.
+      // (crash / deploy-roll / platform reap). When the container is no longer
+      // running, onError must persist 'stopped' so the session does not dangle
+      // as 'running' in KV forever.
       const mockKvPut = vi.fn().mockResolvedValue(undefined);
       const mockKvGet = vi.fn().mockResolvedValue({
         id: 'sess123',
@@ -1019,6 +1020,9 @@ describe('container DO class / REQ-SESSION-002 (one container per session)', () 
         return null;
       });
 
+      // Unexpected exit: the runtime has already torn the container down.
+      mockContainerRuntime.running = false;
+
       const instance = new ContainerClass(mockCtx as any, mockEnv);
       await vi.waitFor(() => {
         expect(mockStorage.get).toHaveBeenCalledWith('bucketName');
@@ -1032,6 +1036,38 @@ describe('container DO class / REQ-SESSION-002 (one container per session)', () 
       const putArgs = mockKvPut.mock.calls[0];
       const writtenSession = JSON.parse(putArgs[1]);
       expect(writtenSession.status).toBe('stopped');
+    });
+
+    it('onError does NOT write stopped while the container is still running (startup error guard)', async () => {
+      // A transient error during startup can fire onError while the container
+      // is still coming up. The !running guard must keep a live session from
+      // being flipped to 'stopped'; collectMetrics is the 60s catch-all.
+      const mockKvPut = vi.fn().mockResolvedValue(undefined);
+      const mockKvGet = vi.fn().mockResolvedValue({
+        id: 'sess123',
+        status: 'running',
+        name: 'Test',
+      });
+      mockEnv.KV = { get: mockKvGet, put: mockKvPut };
+
+      mockStorage.get.mockImplementation(async (key: string) => {
+        if (key === 'bucketName') return 'test-bucket';
+        if (key === '_sessionId') return 'sess123';
+        return null;
+      });
+
+      // Container is still running when the error fires.
+      mockContainerRuntime.running = true;
+
+      const instance = new ContainerClass(mockCtx as any, mockEnv);
+      await vi.waitFor(() => {
+        expect(mockStorage.get).toHaveBeenCalledWith('bucketName');
+      });
+
+      await instance.onError(new Error('Transient startup error'));
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(mockKvPut).not.toHaveBeenCalled();
     });
 
     it('onStop does NOT set tombstone', async () => {

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -725,11 +725,21 @@ export class container extends Container<Env> implements ContainerEnvState {
   /** Called when the container encounters an error. */
   override async onError(error: unknown): Promise<void> {
     this.logger.error('Container error', error instanceof Error ? error : new Error(toErrorMessage(error)));
-    // The SDK calls onError (not onStop) on an unexpected container exit, so
-    // write 'stopped' to KV here too - otherwise the session dangles as
-    // 'running' forever. onStart() re-asserts 'running' if the container
-    // restarts; DO methods are serialized so there is no race with onStart.
-    await updateKvStatus(this.ctx, this.env, this._bucketName, 'stopped', 'lastActiveAt');
+    // The SDK (@cloudflare/containers v0.3.5) calls onError - and awaits it -
+    // when its monitor detects the container exited unexpectedly (crash,
+    // deploy-roll, platform reap); it does NOT call onStop on that path, so
+    // without this write the session dangles 'running' forever (codeflare#153).
+    // Guard on !running so a transient startup port-check error (onError can
+    // fire while the container is still coming up) cannot flip a live session
+    // to 'stopped'; the collectMetrics not-running branch is the 60s catch-all
+    // if this is skipped. No cross-await serialization is assumed: updateKvStatus
+    // re-reads sessionId/bucketName from storage and the session from KV on
+    // every call, and destroy() clears those first, so a post-destroy write
+    // no-ops instead of resurrecting the record. onStart() re-asserts 'running'
+    // on the next start.
+    if (!this.ctx.container?.running) {
+      await updateKvStatus(this.ctx, this.env, this._bucketName, 'stopped', 'lastActiveAt');
+    }
   }
 
 }


### PR DESCRIPTION
## Summary

Follow-up to #476 (KV `stopped`-on-exit + reconcile removal). Applies the legitimate code, spec, and documentation findings raised by the review agents on the develop->main PR. Each was verified as a real correctness/staleness gap, not a false positive.

## Changes

**Code** (`src/container/index.ts` `onError`)
- Guard the exit-write on `!ctx.container.running` so a transient startup error cannot flip a still-starting container to `stopped`. `collectMetrics` stays the 60s catch-all.
- Reword the comment: drop the inaccurate "DO methods are serialized" claim; document the real invariant (`updateKvStatus` re-reads identifiers each call, `destroy()` clears them first, the SDK awaits `onError` on unexpected exit).

**Tests** (`src/__tests__/container/index.test.ts`)
- Existing onError-writes-stopped test now sets `running=false` to match the guard.
- New guard-skip test: `running=true` => no KV write.

**Spec** (`sdd/spec/session-lifecycle.md`)
- Fix two `@test` anchors to exact test names (collectMetrics dangling-running guard; `onStop lifecycle` -> onError).

**Docs**
- `architecture.md`: rationale #5 broadened to the full exit-writes-stopped contract; lifecycle state machine + flowchart gain the `onError` unexpected-exit path; anti-flapping note marked defense-in-depth; new four-timestamp taxonomy table; new rationale #17.
- `decisions/README.md`: corrected AD6 mitigation note; added **AD70** (container exit writes KV `stopped`; no read-side reconciliation).

## Requirements

- [REQ-SESSION-010](../blob/develop/sdd/spec/session-lifecycle.md) AC8 - status authoritative from KV, exit writes `stopped`.
- Tracks codeflare#153. Refines AD6; adds AD70.

## Test plan

- CI only (1-vCPU container, no local runs). New + adjusted unit tests cover both guard branches of `onError`.
- Behavioral gate runs on the integration deploy: confirm an unexpected exit converges KV to `stopped` within ~60s, and a live-but-idle session is never falsely kicked.