### PR TITLE
fix: suppress unfixed Debian perl CVE-2026-48959 in Trivy deploy gate

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -565,3 +565,12 @@ CVE-2025-13462
 # (CVE-2026-42499 net/mail consumePhrase DoS, CVE-2025-61725). Fix: Go 1.25.11
 # / 1.26.4; rclone and lazygit upstream have not rebuilt yet.
 CVE-2026-42504
+
+# perl 5.36 in the Debian bookworm base image (libperl5.36, perl, perl-base,
+# perl-modules-5.36; 5.36.0-7+deb12u3): IO::Uncompress::Unzip before 2.220
+# allows CPU exhaustion (DoS) when decompressing a crafted Zip stream. Impact:
+# NONE - perl ships as a base-image/git tooling dependency; the container never
+# feeds attacker-controlled Zip archives through perl's IO::Uncompress. Same
+# base-image-dependency, no-untrusted-input exposure profile as the entries
+# above. No fixed version available in Debian bookworm.
+CVE-2026-48959

--- a/documentation/lanes/security.md
+++ b/documentation/lanes/security.md
@@ -354,6 +354,7 @@ Every entry carries an inline comment recording the affected package, the impact
 - [REQ-SEC-006](../../sdd/spec/security.md#req-sec-006-transparent-kv-encryption-migration) - Transparent KV encryption migration
 - [REQ-SEC-009](../../sdd/spec/security.md#req-sec-009-input-validation-at-system-boundaries) - Input validation at system boundaries
 - [REQ-SEC-010](../../sdd/spec/security.md#req-sec-010-path-traversal-prevention-on-storage-endpoints) - Path traversal prevention on storage endpoints
+- [REQ-SEC-011](../../sdd/spec/security.md#req-sec-011-container-image-scanned-for-cves-before-deploy) - Container image scanned for CVEs before deploy
 - [REQ-SEC-012](../../sdd/spec/security.md#req-sec-012-container-auth-token-per-do-lifecycle) - Container auth token per DO lifecycle
 - [REQ-SEC-014](../../sdd/spec/security.md#req-sec-014-saas-service-token-header-not-trusted-in-saas-mode) - SaaS service-token header not trusted in SaaS mode
 - [REQ-SEC-016](../../sdd/spec/security.md#req-sec-016-concurrent-cache-deduplication-for-auth-config) - Concurrent cache deduplication for auth config

--- a/documentation/lanes/security.md
+++ b/documentation/lanes/security.md
@@ -326,7 +326,15 @@ Browse endpoint validates prefix parameter against directory traversal (`..` rej
 
 ### Container Image Scanning ([REQ-SEC-011](../../sdd/spec/security.md#req-sec-011-container-image-scanned-for-cves-before-deploy))
 
-Trivy scans Docker images for HIGH/CRITICAL vulnerabilities before deployment (in `deploy.yml`).
+Trivy scans Docker images for HIGH/CRITICAL vulnerabilities before deployment (in `deploy.yml`). The scan fails the deploy on any unsuppressed HIGH/CRITICAL finding.
+
+**Suppression policy (`.trivyignore`):** A CVE may be added to the allowlist only when all of:
+
+1. **No untrusted-input path** — the vulnerable code is never reached with attacker-controlled input in the container (typically outbound-only CLI tools, or base-image / git-tooling dependencies never invoked on hostile archives, JSON, XML, or MIME).
+2. **Impact is limited** — DoS only (CPU/memory exhaustion or panic), with no confidentiality or integrity impact in this container's context.
+3. **No remediation is currently applicable** — either no fixed version exists in the installed channel (e.g. Debian bookworm), or a fix exists upstream but the vendored tool or base image has not yet rebuilt against it.
+
+Every entry carries an inline comment recording the affected package, the impact, and which conditions apply. The allowlist is reviewed monthly and entries are removed once a fix reaches the image.
 
 ### Protected R2 Paths
 


### PR DESCRIPTION
## Why

The production Deploy (run 27243472527, commit 703cb7e) failed at **Scan container image for vulnerabilities**. The integration deploy 20 min earlier (run 27242708821, 23:33Z) passed on the *same image*. Difference is scan time, not image: Trivy refreshes its vuln DB at scan time, and **CVE-2026-48959** entered the feed between the two scans.

## What

Trivy flagged 4 HIGH findings, all the same CVE in the Debian bookworm base-image perl packages (`libperl5.36`, `perl`, `perl-base`, `perl-modules-5.36` @ 5.36.0-7+deb12u3) — `IO::Uncompress::Unzip` CPU-exhaustion DoS. **No fixed version exists in Debian bookworm** (blank Fixed Version), so the image cannot be rebuilt out of it.

Adds `CVE-2026-48959` to `.trivyignore` with a justification matching the file's existing per-CVE convention: perl is a base-image/git-tooling dependency, never fed attacker-controlled Zip archives. Suppressing the one CVE clears all 4 rows; the HIGH/CRITICAL gate stays strict for every *fixable* CVE.

## Test plan

- PR Checks (`test`) green on the merge commit.
- On merge to main, production Deploy re-runs via workflow_run and the Trivy scan passes.