### PR TITLE
docs: annotate deploy.yml workflow_run checkout (Scorecard #63 mitigation)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,17 @@ jobs:
           echo "::error::Production deploys are only allowed from main. Got branch: ${{ github.ref }}"
           exit 1
 
+      # Scorecard DangerousWorkflowID (code-scanning alert #63) flags this
+      # workflow_run + head_sha checkout as a pwn-request vector. It is
+      # MITIGATED, not exploitable, and is deliberately left OPEN (not
+      # dismissed) so any future weakening of the guards re-surfaces the alert:
+      # the job `if:` above requires workflow_run.event == 'push' AND
+      # head_repository.full_name == github.repository, so only a post-merge
+      # push originating from THIS repo ever reaches here — head_sha is then
+      # always already-merged, maintainer-trusted code. Fork PRs fire the
+      # pull_request event (not push) and are filtered out before checkout.
+      # Scorecard scores the pattern 0 unconditionally because it cannot read
+      # the job `if:` guards. See the rationale at lines 54-64 (prior alert #34).
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # On workflow_run: pin to the SHA whose PR Checks just ended


### PR DESCRIPTION
## Summary

Adds an inline comment at the `actions/checkout` step in `deploy.yml` (the line flagged by OSSF Scorecard code-scanning alert **#63**, `DangerousWorkflowID`, critical) documenting why the `workflow_run` + `head_sha` checkout is mitigated and not exploitable.

The alert is **left open, not dismissed** — by design, so that any future weakening of the job `if:` guards re-surfaces it.

## Why it's mitigated (not a fix to behavior — comment only)

The checkout is gated by the `deploy` job `if:` which requires:
- `workflow_run.event == 'push'` — fork PRs fire `pull_request`, never `push`
- `head_repository.full_name == github.repository` — only pushes from this repo, never a fork

So the checked-out `head_sha` is always already-merged, maintainer-trusted code. Scorecard scores the pattern 0 unconditionally because its static analyzer cannot read the `if:` guards. This pattern was already audited once (prior alert #34, rationale at deploy.yml:54-64).

No workflow behavior changes — this is a comment-only addition.