### PR TITLE
fix: clear happy-dom RCE + 2 highs (Dependabot 53-55) and scope deploy token perms

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
     schedule:
       interval: weekly
 
+  - package-ecosystem: npm
+    directory: /landing
+    target-branch: develop
+    schedule:
+      interval: weekly
+
   # Pi agent preseed (@gotgenes/pi-subagents, context-mode)
   # is intentionally NOT managed by Dependabot. Although it has a real
   # package.json + lockfile, every version here is ALSO pinned as a literal

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ concurrency:
 
 permissions:
   contents: read
-  actions: write  # type=gha buildx cache writes to the Actions cache service
 
 jobs:
   deploy:
@@ -40,6 +39,9 @@ jobs:
        && github.event.workflow_run.conclusion == 'success'
        && github.event.workflow_run.event == 'push'
        && github.event.workflow_run.head_repository.full_name == github.repository)
+    permissions:
+      contents: read
+      actions: write  # type=gha buildx cache writes to the Actions cache service
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     # On workflow_run: only deploy when PR Checks ended green.
     # On workflow_dispatch (manual): always run; the inner production-

--- a/documentation/lanes/ci-cd.md
+++ b/documentation/lanes/ci-cd.md
@@ -17,7 +17,7 @@ Workflows covering deploy, testing, fuzzing, penetration testing, stress testing
 
 ### Dependabot Configuration
 
-Dependabot runs weekly against the `develop` branch for three npm package directories (`/`, `/web-ui`, `/host`), Docker images, and GitHub Actions.
+Dependabot runs weekly against the `develop` branch for four npm package directories (`/`, `/web-ui`, `/host`, `/landing`), Docker images, and GitHub Actions.
 
 **Node Docker image major updates are ignored.** The `docker.io/library/node` and `public.ecr.aws/docker/library/node` images are pinned to suppress semver-major proposals. Dependabot would otherwise propose Node Current (odd, non-LTS) releases such as Node 25. Node major upgrades are handled manually when a new LTS version is released (even major: 22, 24, 26, ...).
 
@@ -79,6 +79,8 @@ The Pi preseed job is data-driven: it diffs **every** dependency in `preseed/age
 | `STRESS_TEST_CONCURRENCY` | `0` (disabled) | `stress-test.yml` | k6 virtual user scaling factor. When >0, scales VU targets proportionally and loosens latency thresholds. | Set per `integration` environment |
 
 ### Deploy Workflow Detail
+
+**Workflow permissions:** top-level is `contents: read` (read-only default); the `deploy` job adds `actions: write` (required only for `type=gha` BuildKit cache writes). Code-scanning least-privilege hardening (#56).
 
 1. Install dependencies (cached via `actions/cache`)
 2. Build frontend, then build landing page (`landing/` → `web-ui/dist/landing/`; order matters — the web-ui build wipes `dist/`), run backend + frontend + landing tests, generate Workers runtime types (`wrangler types`), typecheck both

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -14,7 +14,7 @@
         "motion": "^12.40.0"
       },
       "devDependencies": {
-        "happy-dom": "^17.4.4",
+        "happy-dom": "^20.10.3",
         "vitest": "^4.1.8"
       }
     },
@@ -1708,11 +1708,38 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
@@ -2005,6 +2032,19 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2647,17 +2687,35 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "17.6.3",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-17.6.3.tgz",
-      "integrity": "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==",
+      "version": "20.10.3",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.3.tgz",
+      "integrity": "sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -4729,6 +4787,13 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -5213,16 +5278,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -5257,6 +5312,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xxhash-wasm": {

--- a/landing/package.json
+++ b/landing/package.json
@@ -16,7 +16,7 @@
     "motion": "^12.40.0"
   },
   "devDependencies": {
-    "happy-dom": "^17.4.4",
+    "happy-dom": "^20.10.3",
     "vitest": "^4.1.8"
   },
   "overrides": {

--- a/sdd/spec/constraints.md
+++ b/sdd/spec/constraints.md
@@ -59,6 +59,7 @@ HSTS, CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions
 | Path traversal prevention | `decodeURIComponent` before `..` check; catches `%2E%2E` and double-encoded variants |
 | Supply chain | CodeQL, OSSF Scorecard, `npm audit`, dependency review, Dependabot, Trivy container scanning |
 | Deploy gate | `deploy.yml` `workflow_run` trigger requires `event == 'push'` and `head_repository.full_name == github.repository` so a fork PR cannot trigger a deploy by naming its head branch `main` (defeats Scorecard DangerousWorkflowID pwn-request pattern). |
+| CI token scope | `actions: write` (Actions cache writes for buildx) is scoped to the deploy job only; top-level workflow permissions are `contents: read` (read-only), limiting blast radius on token compromise. |
 | Penetration testing | Weekly automated external pentest (auth gate, headers, TLS, injection, info disclosure) |
 | Secret scanning | GitHub secret scanning with push protection enabled |
 | Credential masking | `maskSecret()` shows only last 4 chars in all API responses |


### PR DESCRIPTION
## Summary

Security pass: clears all three open Dependabot alerts and the one fixable high code-scanning alert.

- **happy-dom `^17.4.4` → `^20.10.3`** (`landing/package.json` + lockfile) — clears the critical VM-context-escape **RCE** (GHSA-37j7-fg3j-429f) plus two highs: export-name code injection (GHSA-6q6h-j7hj-3r64) and target-origin cookie leak (GHSA-w4gp-fjgq-3q4g). Covers Dependabot **#53/#54/#55** and code-scanning **#31** (the Scorecard aggregate of the same three).
- **`/landing` added to `.github/dependabot.yml`** — root cause: landing was never in Dependabot's npm update list, so happy-dom rotted three majors behind until a critical landed. Now monitored weekly.
- **`deploy.yml` token permissions** — moved `actions: write` (needed only for the buildx gha cache) from the top level to the `deploy` job; top level is now `contents: read`. Clears code-scanning **#56** TokenPermissions.

## Not in this PR (deliberate)

- **code-scanning #63** (`DangerousWorkflow`, `deploy.yml:92`): the `workflow_run` checkout of `head_sha` is already guarded (`workflow_run.event == 'push'` + `head_repository == repo`), which defeats the fork pwn-request vector. Accepted risk — dismiss in the security UI rather than break the post-merge deploy design.
- **~8 medium `PinnedDependencies`** (Dockerfile `apt` / action digest pinning): hardening backlog, not security-blocking.

## Test plan

- [ ] PR Checks green on the merge head — **verifies the happy-dom 17→20 major bump against the landing vitest suite** (happy-dom is the landing test DOM environment; this is the one behavioral risk in the bump)
- [ ] After merge to main: Dependabot #53/#54/#55 + code-scanning #31 auto-resolve
- [ ] deploy.yml still deploys (the `deploy` job retains `actions: write` for the buildx cache)