### PR TITLE
Complete final release traceability

### DIFF
--- a/host/__tests__/release-signing-workflow.test.js
+++ b/host/__tests__/release-signing-workflow.test.js
@@ -98,6 +98,14 @@ describe('REQ-OPS-034/REQ-OPS-035: keyless GitHub release signing', () => {
       steps['Attest release assets'].with['subject-path'],
       'release-assets/codeflare-v*.tar.gz\nrelease-assets/SHA256SUMS\n',
     );
+    const serializedWorkflow = JSON.stringify(workflow);
+    assert.doesNotMatch(serializedWorkflow, /\$\{\{\s*secrets\./);
+    assert.doesNotMatch(serializedWorkflow, /COSIGN_PASSWORD|PRIVATE_KEY|SIGNING_KEY/);
+
+    const stepNames = job.steps.map((step) => step.name);
+    assert.ok(stepNames.indexOf('Sign release assets') < stepNames.indexOf('Attest release assets'));
+    assert.ok(stepNames.indexOf('Attest release assets') < stepNames.indexOf('Upload signed release assets'));
+    assert.equal(steps['Upload signed release assets'].if, undefined);
   });
 
   it('accepts only an existing semantic release reachable from main', () => {

--- a/sdd/spec/agents.md
+++ b/sdd/spec/agents.md
@@ -236,7 +236,7 @@ Multi-agent support, preseed system, and session modes.
 **Acceptance Criteria:**
 
 1. One unreviewed head emits at most five settled follow-ups before latching `GIVEUP`. <!-- @impl: preseed/agents/pi/extensions/review-enforcement.ts::blockDecision --> <!-- @test: src/__tests__/lib/review-enforcement.test.ts (REQ-AGENT-041/REQ-AGENT-119: blocks five times then latches GIVEUP for the same head without acknowledging it) -->
-2. Linked worktrees persist the follow-up count in their resolved Git metadata directory. <!-- @impl: preseed/agents/pi/extensions/review-enforcement.ts::gitMetadataDirectory --> <!-- @test: src/__tests__/lib/review-enforcement.test.ts (REQ-AGENT-041/REQ-AGENT-119: persists settled retry counts in a linked worktree git directory) -->
+2. Linked worktrees preserve the follow-up count across settled checks. <!-- @impl: preseed/agents/pi/extensions/review-enforcement.ts::gitMetadataDirectory --> <!-- @test: src/__tests__/lib/review-enforcement.test.ts (REQ-AGENT-041/REQ-AGENT-119: persists settled retry counts in a linked worktree git directory) -->
 3. A different head starts a fresh follow-up count. <!-- @impl: preseed/agents/pi/extensions/review-enforcement.ts::blockDecision --> <!-- @test: src/__tests__/lib/review-enforcement.test.ts (REQ-AGENT-041/REQ-AGENT-119: blocks five times then latches GIVEUP for the same head without acknowledging it) -->
 
 **Constraints:** Accounting never acknowledges an unreviewed head.

--- a/sdd/spec/operations.md
+++ b/sdd/spec/operations.md
@@ -270,7 +270,7 @@ CI/CD pipeline, testing strategy, deployment workflow, container sizing, and cos
 
 **Dependencies:** [REQ-OPS-003](#req-ops-003-pr-checks-run-lint-test-typecheck-and-security-audit)
 
-**Verification:** Automated workflow-routing test for AC3; manual checks for AC1, AC2, AC4, and AC5.
+**Verification:** Automated workflow-routing tests for AC3 and AC4; manual checks for AC1, AC2, AC5, and AC6.
 
 **Status:** Implemented
 


### PR DESCRIPTION
## Summary

- Correct REQ-OPS-009 verification ownership after its dispatch routes were split into atomic ACs.
- Keep REQ-AGENT-119 behavioral by describing linked-worktree persistence without mandating its Git metadata mechanism.
- Prove release signing has no repository-secret/password input and that signing, attestation, and upload retain fail-closed workflow order.

Relevant requirements: [REQ-AGENT-119](sdd/spec/agents.md#req-agent-119-settled-review-follow-up-accounting), [REQ-OPS-009](sdd/spec/operations.md#req-ops-009-supply-chain-security-monitoring), [REQ-OPS-035](sdd/spec/operations.md#req-ops-035-keyless-signed-release-artifacts).

## Test plan

- [ ] Exact-head PR Checks, CodeQL, and Property-based fuzzing pass
- [ ] Release workflow contract test rejects repository secret/password references
- [ ] Release workflow contract test proves sign → attest → upload ordering and default success gating

Local suites were intentionally not run because repository policy reserves executable verification for GitHub Actions.
