### PR TITLE
Enforce keyless signing boundary

### DIFF
--- a/host/__tests__/release-signing-workflow.test.js
+++ b/host/__tests__/release-signing-workflow.test.js
@@ -46,7 +46,7 @@ fi
 exit 2
 `);
   writeFileSync(join(bin, 'cosign'), `#!/bin/sh
-printf '%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+printf '%s password=%s\\n' "$*" "\${COSIGN_PASSWORD-unset}" >> "$FAKE_COMMAND_LOG"
 while [ "$#" -gt 0 ]; do
   if [ "$1" = '--bundle' ]; then shift; printf 'bundle\\n' > "$1"; exit 0; fi
   shift
@@ -98,10 +98,6 @@ describe('REQ-OPS-034/REQ-OPS-035: keyless GitHub release signing', () => {
       steps['Attest release assets'].with['subject-path'],
       'release-assets/codeflare-v*.tar.gz\nrelease-assets/SHA256SUMS\n',
     );
-    const serializedWorkflow = JSON.stringify(workflow);
-    assert.doesNotMatch(serializedWorkflow, /\$\{\{\s*secrets\./);
-    assert.doesNotMatch(serializedWorkflow, /COSIGN_PASSWORD|PRIVATE_KEY|SIGNING_KEY/);
-
     const stepNames = job.steps.map((step) => step.name);
     assert.ok(stepNames.indexOf('Sign release assets') < stepNames.indexOf('Attest release assets'));
     assert.ok(stepNames.indexOf('Attest release assets') < stepNames.indexOf('Upload signed release assets'));
@@ -136,6 +132,7 @@ describe('REQ-OPS-034/REQ-OPS-035: keyless GitHub release signing', () => {
       RELEASE_TAG: 'v1.2.3',
       RELEASE_COMMIT: '1'.repeat(40),
       FAKE_COMMAND_LOG: commandLog,
+      COSIGN_PASSWORD: 'repository-secret',
     };
     const built = execute(cwd, bin, 'build', env);
     assert.equal(built.status, 0, built.stderr);
@@ -158,7 +155,12 @@ describe('REQ-OPS-034/REQ-OPS-035: keyless GitHub release signing', () => {
     const uploaded = execute(cwd, bin, 'upload', env);
     assert.equal(uploaded.status, 0, uploaded.stderr);
     const commands = readFileSync(commandLog, 'utf8').trim().split('\n');
-    assert.equal(commands.filter((line) => line.startsWith('sign-blob ')).length, 2);
+    const signingCommands = commands.filter((line) => line.startsWith('sign-blob '));
+    assert.equal(signingCommands.length, 2);
+    for (const command of signingCommands) {
+      assert.match(command, / password=unset$/);
+      assert.doesNotMatch(command, /(?:^| )--key(?: |$)/);
+    }
     assert.equal(commands.at(-1), [
       'release upload v1.2.3',
       'release-assets/SHA256SUMS',

--- a/scripts/ci/sign-release.sh
+++ b/scripts/ci/sign-release.sh
@@ -40,7 +40,7 @@ sign_release_assets() {
   local asset
   for asset in "release-assets/codeflare-$RELEASE_TAG.tar.gz" release-assets/SHA256SUMS; do
     test -f "$asset"
-    cosign sign-blob --yes --bundle "$asset.sigstore.json" "$asset"
+    env -u COSIGN_PASSWORD cosign sign-blob --yes --bundle "$asset.sigstore.json" "$asset"
   done
 }
 


### PR DESCRIPTION
## Summary

- Remove serialized-workflow regex checks that could not prove credential-free signing behavior.
- Explicitly remove `COSIGN_PASSWORD` at the executable signing boundary.
- Exercise signing with a poisoned password and verify the signer receives neither that password nor a key argument.

Relevant requirement: [REQ-OPS-035](sdd/spec/operations.md#req-ops-035-keyless-signed-release-artifacts).

## Test plan

- [ ] Exact-head PR Checks, CodeQL, and Property-based fuzzing pass
- [ ] Controlled signer receives `COSIGN_PASSWORD` as unset even when the parent environment supplies it
- [ ] Controlled signer receives no `--key` argument and still creates both Sigstore bundles

Local suites were intentionally not run because repository policy reserves executable verification for GitHub Actions.
