### PR TITLE
fix: align Claude platform package locks

### DIFF
--- a/host/__tests__/dockerfile-dependency-integrity.test.js
+++ b/host/__tests__/dockerfile-dependency-integrity.test.js
@@ -70,6 +70,30 @@ describe('REQ-OPS-033: build dependencies have committed integrity', () => {
     assertCompleteIntegrityTree(npmToolsLock);
   });
 
+  it('locks every Claude platform package at the exact CLI release', () => {
+    const version = npmToolsPackage.dependencies['@anthropic-ai/claude-code'];
+    const platforms = [
+      'darwin-arm64',
+      'darwin-x64',
+      'linux-arm64',
+      'linux-arm64-musl',
+      'linux-x64',
+      'linux-x64-musl',
+      'win32-arm64',
+      'win32-x64',
+    ];
+    for (const platform of platforms) {
+      const name = `@anthropic-ai/claude-code-${platform}`;
+      const metadata = npmToolsLock.packages[`node_modules/${name}`];
+      assert.equal(metadata.version, version, `${name} must match the exact Claude CLI release`);
+      assert.equal(
+        metadata.resolved,
+        `https://registry.npmjs.org/${name}/-/claude-code-${platform}-${version}.tgz`,
+      );
+      assert.match(metadata.integrity, /^sha512-/);
+    }
+  });
+
   it('Codex platform license exceptions match exact Apache-2.0 lock metadata', () => {
     const platforms = [
       'darwin-arm64',

--- a/preseed/npm-tools/package-lock.json
+++ b/preseed/npm-tools/package-lock.json
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.224",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.224.tgz",
-      "integrity": "sha512-a16Zlqhr1CXO5vsfsw7FcvLbG2nqBAXWmvMmyXtNW+f9pAJm91GMJE9wK79cIyO9InZRLN06wYWyPcp1cx/nNg==",
+      "version": "2.1.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.233.tgz",
+      "integrity": "sha512-G7Te22sph7qywNyfIcQq7Li7bbQp8zBHZV4mDBBP5ZXswkGDJSip8MSNU2OlHsoVgcLtTzNlm0U25wys/r0jag==",
       "cpu": [
         "arm64"
       ],
@@ -85,9 +85,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.224",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.224.tgz",
-      "integrity": "sha512-VT4M5HIrfiqzkyuoUo/+R6QW05UhGOqWLdjHAr7Atu5pio6ZZl3hSyEPCT8nceApYB4v3BhwJjY7sSMO1BxbFA==",
+      "version": "2.1.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.233.tgz",
+      "integrity": "sha512-XmMTZ3U4hhAUMvOQ794tmkz0/Mga39ecBB7vf+CdSm4HirdzOaGAvW18l7tWhcPRXH3M7Tx1bDefhyRdlSEc5g==",
       "cpu": [
         "arm64"
       ],
@@ -98,9 +98,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.224",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.224.tgz",
-      "integrity": "sha512-X9irQAhHb727EuvOo+Mi06wmNxHqdR7Fww17AaHSvuMGFBHkfsxLJSUTcPPhDDhQwoyr2lViplQxWA+noD51HQ==",
+      "version": "2.1.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.233.tgz",
+      "integrity": "sha512-ubMVvBBlsks5NE0EmucELB2h/XZ64L86JgmMBUWShLgDAkrrzCh1zIf5qX1+SPskXAnMfKBFTMNeaT6UruxRkQ==",
       "cpu": [
         "x64"
       ],
@@ -111,9 +111,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.224",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.224.tgz",
-      "integrity": "sha512-4dbht7QaZnRSVKRHcA8Fp3HfvWiZs43+wx4CjBGVuklh8QINc00lkBlNTnKyGi7E/d2/pS+g9RoWqC4wur2lqg==",
+      "version": "2.1.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.233.tgz",
+      "integrity": "sha512-KlgySdzFyoGmBLr6ReSBHclRwAzEuRLBmmYSHq2j9BLlXTy1kt0mhJoEffYkw1Hs5dasSK9sGEVgNt6wJ/PMmA==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
## Summary
- align all four stale Linux Claude Code platform lock entries with the exact 2.1.233 CLI release
- use exact registry-published tarball URLs and SHA-512 integrity metadata
- add a lockstep contract covering all eight Claude platform packages

## Failure addressed
Integration deployment run [32947620860](https://github.com/nikolanovoselec/codeflare/actions/runs/32947620860) failed during the container's `npm ci` because the CLI required 2.1.233 while four Linux packages remained locked at 2.1.224.

## Validation
- manifest root and lock root dependencies remain identical
- all eight Claude platform entries resolve to 2.1.233 with registry integrity
- bounded syntax preflight passed for the changed host contract
- authoritative behavioral and image verification remains CI-owned