### PR TITLE
fix: align packaged Oxlint smoke version

### DIFF
--- a/host/__tests__/coding-agent-selection.test.js
+++ b/host/__tests__/coding-agent-selection.test.js
@@ -126,15 +126,15 @@ describe('REQ-OPS-038: deployment coding-agent selection', () => {
     const version = verifyOxlintRuntime({
       run: (path, args) => {
         calls.push([path, args]);
-        return 'Version: 1.77.0\n';
+        return 'Version: 1.79.0\n';
       },
     });
-    assert.equal(version, 'Version: 1.77.0');
+    assert.equal(version, 'Version: 1.79.0');
     assert.deepEqual(calls, [['/usr/local/bin/oxlint', ['--version']]]);
-    for (const reported of ['Version: 1.78.0\n', 'Version: 1.77.0-beta.1\n', 'Version: 1.77.0.1\n']) {
+    for (const reported of ['Version: 1.80.0\n', 'Version: 1.79.0-beta.1\n', 'Version: 1.79.0.1\n']) {
       assert.throws(
         () => verifyOxlintRuntime({ run: () => reported }),
-        /must report exact version 1\.77\.0/,
+        /must report exact version 1\.79\.0/,
       );
     }
   });

--- a/scripts/ci/smoke-openvscode-sidebar-image.mjs
+++ b/scripts/ci/smoke-openvscode-sidebar-image.mjs
@@ -100,7 +100,7 @@ export async function verifySelectedAgentLaunchers(
 
 export function verifyOxlintRuntime({
   path = '/usr/local/bin/oxlint',
-  expectedVersion = '1.77.0',
+  expectedVersion = '1.79.0',
   run = execFileSync,
 } = {}) {
   const output = run(path, ['--version'], { encoding: 'utf8', timeout: 10_000 }).trim();


### PR DESCRIPTION
## Summary

- update packaged-image Oxlint smoke expectation from 1.77.0 to the installed exact pin 1.79.0
- update behavioral coverage to reject nearby and prerelease values around 1.79.0
- keep all recovery work on the unified integration branch

## Failure addressed

Integration deployment run [32955479426](https://github.com/nikolanovoselec/codeflare/actions/runs/32955479426) built the image successfully, then failed packaged smoke because the image reported the correct `Version: 1.79.0` while the smoke helper still expected `1.77.0`.

## Validation

- bounded syntax preflight passed for both changed JavaScript files
- authoritative behavioral and packaged-image verification remains CI-owned