### PR TITLE
fix: align image smoke version

### DIFF
--- a/host/__tests__/coding-agent-selection.test.js
+++ b/host/__tests__/coding-agent-selection.test.js
@@ -157,15 +157,15 @@ describe('REQ-OPS-038: deployment coding-agent selection', () => {
     const version = verifyOxlintRuntime({
       run: (path, args) => {
         calls.push([path, args]);
-        return 'Version: 1.79.0\n';
+        return 'Version: 1.80.0\n';
       },
     });
-    assert.equal(version, 'Version: 1.79.0');
+    assert.equal(version, 'Version: 1.80.0');
     assert.deepEqual(calls, [['/usr/local/bin/oxlint', ['--version']]]);
-    for (const reported of ['Version: 1.80.0\n', 'Version: 1.79.0-beta.1\n', 'Version: 1.79.0.1\n']) {
+    for (const reported of ['Version: 1.81.0\n', 'Version: 1.80.0-beta.1\n', 'Version: 1.80.0.1\n']) {
       assert.throws(
         () => verifyOxlintRuntime({ run: () => reported }),
-        /must report exact version 1\.79\.0/,
+        /must report exact version 1\.80\.0/,
       );
     }
   });

--- a/scripts/ci/smoke-openvscode-sidebar-image.mjs
+++ b/scripts/ci/smoke-openvscode-sidebar-image.mjs
@@ -100,7 +100,7 @@ export async function verifySelectedAgentLaunchers(
 
 export function verifyOxlintRuntime({
   path = '/usr/local/bin/oxlint',
-  expectedVersion = '1.79.0',
+  expectedVersion = '1.80.0',
   run = execFileSync,
 } = {}) {
   const output = run(path, ['--version'], { encoding: 'utf8', timeout: 10_000 }).trim();


### PR DESCRIPTION
## Summary
- align packaged-image runtime smoke with the reviewed Oxlint 1.80.0 pin
- update exact-version positive and rejection coverage

## Evidence
- Integration deploy run `33704345619` built the image successfully, then failed because smoke expected 1.79.0 while runtime reported 1.80.0
- package manifest, lockfile, and integrity sentinel already agree on 1.80.0

## Test plan
- [ ] PR Checks pass
- [ ] Integration image smoke passes during redeployment